### PR TITLE
fix scaladoc links

### DIFF
--- a/LATEST
+++ b/LATEST
@@ -1,5 +1,5 @@
 {
   "daml": "2.2.0-snapshot.20220412.9721.0.b7c4bdab",
-  "canton": "2.1.0",
+  "canton": "2.1.1",
   "prefix": "2.1.1"
 }

--- a/docs/setup-sphinx-source-tree.sh
+++ b/docs/setup-sphinx-source-tree.sh
@@ -9,6 +9,8 @@ CANTON_RELEASE_TAG=$2
 DOWNLOAD_DIR=$3
 SPHINX_DIR=$4
 
+prefix=$(jq -r '.prefix' $DIR/../LATEST)
+
 mkdir -p $SPHINX_DIR/source/canton
 tar xf $DOWNLOAD_DIR/sphinx-source-tree-$RELEASE_TAG.tar.gz -C $SPHINX_DIR --strip-components=1
 tar xf $DOWNLOAD_DIR/canton-docs-$CANTON_RELEASE_TAG.tar.gz -C $SPHINX_DIR/source/canton
@@ -19,7 +21,7 @@ cp $SPHINX_DIR/source/canton/exts/canton_enterprise_only.py $SPHINX_DIR/configs/
 find $SPHINX_DIR/source/canton -type f -print0 | while IFS= read -r -d '' file
 do
     sed -i 's|include:: /substitution.hrst|include:: /canton/substitution.hrst|g ; s|image:: /images|image:: /canton/images|g' $file
-    sed -i "s|__VERSION__|$RELEASE_TAG|g" $file
+    sed -i "s|__VERSION__|$prefix|g" $file
 done
 sed -i '/^  concepts$/d' $SPHINX_DIR/source/canton/tutorials/tutorials.rst
 
@@ -30,8 +32,6 @@ declare -A sphinx_targets=( [html]=html [pdf]=latex )
 
 sed -i "s/'sphinx.ext.extlinks',$/'sphinx.ext.extlinks','canton_enterprise_only','sphinx.ext.todo',/g" $SPHINX_DIR/configs/html/conf.py
 sed -i "s/'sphinx.ext.extlinks'$/'sphinx.ext.extlinks','canton_enterprise_only','sphinx.ext.todo'/g" $SPHINX_DIR/configs/pdf/conf.py
-
-prefix=$(jq -r '.prefix' $DIR/../LATEST)
 
 # We rename the PDF so need to update the link.
 sed -i "s/DigitalAssetSDK\\.pdf/DamlEnterprise$prefix.pdf/" $SPHINX_DIR/theme/da_theme/layout.html


### PR DESCRIPTION
Bumps Canton for 2.1.1 release, and fixes the Scaladoc links as in https://docs.daml.com/2.1.1/canton/usermanual/static_conf.html#configuration-reference linking to https://docs.daml.com/2.2.0-snapshot.20220412.9721.0.b7c4bdab/canton/scaladoc/com/digitalasset/canton/config/index.html (wrong version number, using the daml version instead of the docs version).