### PR TITLE
2.2.0-rc1

### DIFF
--- a/LATEST
+++ b/LATEST
@@ -1,5 +1,5 @@
 {
-  "daml": "2.2.0-snapshot.20220412.9721.0.b7c4bdab",
-  "canton": "2.1.1",
-  "prefix": "2.1.1"
+  "daml": "2.3.0-snapshot.20220505.9861.0.5d8ebd7a",
+  "canton": "2.2.0-rc1",
+  "prefix": "2.2.0"
 }

--- a/docs/index/index_html.rst
+++ b/docs/index/index_html.rst
@@ -41,12 +41,12 @@ Daml Documentation
    :maxdepth: 2
    :hidden:
    :caption: Platform operations
-   
+
    Introduction <canton/about>
    Tutorials <canton/tutorials/tutorials>
    User Manual <canton/usermanual/usermanual>
    Architecture-In-Depth <canton/architecture/architecture>
-   
+
 .. toctree::
    :titlesonly:
    :maxdepth: 2
@@ -71,6 +71,7 @@ Daml Documentation
    concepts/identity-and-package-management
    concepts/time
    concepts/local-ledger
+   concepts/test-evidence
    support/overview
    support/releases
 

--- a/docs/index/index_pdf.rst
+++ b/docs/index/index_pdf.rst
@@ -68,6 +68,7 @@ Reference
    concepts/identity-and-package-management
    concepts/time
    concepts/local-ledger
+   concepts/test-evidence
    support/overview
    support/releases
 


### PR DESCRIPTION
Stefano has explicitly requested we include digital-asset/daml#13801 in the 2.2.0 docs; using [5d8ebd7a] is the simplest way to achieve that.

Compared to the RC commit ([4c8e027d]), [5d8ebd7a] contains just three changes to the documentation:

- digital-asset/daml#13545: 2.2.0-rc1 is the first release to include security evidence artifacts, so it makes sense to include this.
- digital-asset/daml#13801: Explicit request.
- digital-asset/daml#13787: Fixes an RST syntax typo.

[4c8e027d]: https://github.com/digital-asset/daml/commit/4c8e027d8d50d408a2c501b774040ea7abe6a9fa
[5d8ebd7a]: https://github.com/digital-asset/daml/commit/5d8ebd7a08761ac4a8bc848eb0ff8e6871492b4a