### PR TITLE
Removing the Operational Processes links

### DIFF
--- a/docs/index/deploy-daml/intro/index.rst
+++ b/docs/index/deploy-daml/intro/index.rst
@@ -14,6 +14,6 @@ Intro
    Canton Demos 3 </canton/tutorials/use_daml_sdk>
    Canton Demos 4 </canton/tutorials/composability>
    Compatibility Matrix and Supported Dependencies </canton/usermanual/versioning>
-   Choosing Open-source or Enterprise Edition </canton/usermanual/downloading>
+   Choosing Open-Source or Enterprise Edition </canton/usermanual/downloading>
 
 ..

--- a/docs/index/operate-a-daml-ledger/advanced-operations/index.rst
+++ b/docs/index/operate-a-daml-ledger/advanced-operations/index.rst
@@ -7,11 +7,8 @@ Advanced Ledger Operations
 .. toctree::
    :titlesonly:
 
-   Run Time Changes to Domain Configuration <https://docs.daml.com/canton/usermanual/operational_processes.html#dynamic-domain-parameters>
-   Manually Initializing a Node <https://docs.daml.com/canton/usermanual/identity_management.html#manually-initializing-a-node>
-   The Same Party On Two Nodes <https://docs.daml.com/canton/usermanual/identity_management.html#party-on-two-nodes>
-   Import Existing Contracts <https://docs.daml.com/canton/usermanual/operational_processes.html#importing-existing-contracts>
-   /canton/usermanual/pruning
-   Recover From a Lost Domain <https://docs.daml.com/canton/usermanual/operational_processes.html#recovering-from-a-lost-domain>
-   Api Configuration </canton/usermanual/apis>
-   Sequencer Connections </canton/usermanual/connectivity>
+    Manage Domains </canton/usermanual/manage_domains>
+    Manage Domain Entities </canton/usermanual/manage_domain_entities>
+    Pruning </canton/usermanual/pruning>
+    Api Configuration </canton/usermanual/apis>
+    Sequencer Connections </canton/usermanual/connectivity>

--- a/docs/index/operate-a-daml-ledger/common-tasks/index.rst
+++ b/docs/index/operate-a-daml-ledger/common-tasks/index.rst
@@ -10,8 +10,6 @@ Common Operational Tasks
    Add a Party <https://docs.daml.com/canton/usermanual/identity_management.html#adding-a-new-party-to-a-participant>
    Repair the Topology Information </canton/usermanual/repairing>
    Manage DARs and Packages </canton/usermanual/packagemanagement>
-   /canton/usermanual/manage_domains
-   /canton/usermanual/manage_domain_entities
    Upgrade To a New Release </canton/usermanual/upgrading>
    Configure Auth0 Middleware (With Example Configuration) </tools/trigger-service/auth0_example>
    Move the Namespace Secret Key to Offline Stoarge (In Cryptographic Key Management) </canton/usermanual/security>


### PR DESCRIPTION
The Operational Processes page has been split; this updates the TOC to reflect that.

[CHANGELOG_BEGIN]
[CHANGELOG_END]