### PR TITLE
Upgrade to daml finance assembly 0.1.7

### DIFF
--- a/LATEST
+++ b/LATEST
@@ -1,6 +1,6 @@
 {
   "daml": "2.5.0-snapshot.20221017.10775.0.61e85b19",
   "canton": "20221018",
-  "daml_finance": "0.1.6",
+  "daml_finance": "0.1.7",
   "prefix": "2.5.0"
 }

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ To view the PDF docs or the exact HTML files that we publish to
 locally:
 
 ```
-mkdir docs_output
 ./build.sh
 ```
 


### PR DESCRIPTION
- Upgrade Daml Finance version to 0.1.7
- Remove redundant instruction from "How to build locally"