### PR TITLE
Restoring the Write Smart Contracts With Daml structure

### DIFF
--- a/docs/index/create-daml-apps/intro/index.rst
+++ b/docs/index/create-daml-apps/intro/index.rst
@@ -1,0 +1,25 @@
+.. Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+  
+Write Smart Contracts With Daml
+###############################
+
+  
+.. toctree::
+   :titlesonly:
+   
+   Introduction </daml/intro/0_Intro>
+   Basic Contracts </daml/intro/1_Token>
+   Test Templates With Daml Script </daml/intro/2_DamlScript>
+   Data Types </daml/intro/3_Data>
+   Transform Data Using Choices </daml/intro/4_Transformations>
+   Add Constraints to a Contract </daml/intro/5_Restrictions>
+   Parties and Authority </daml/intro/6_Parties>
+   Composing Choices </daml/intro/7_Composing>
+   Exception Handling </daml/intro/8_Exceptions>
+   Work With Dependencies </daml/intro/9_Dependencies>
+   Functional Programming 101 </daml/intro/10_Functional101>
+   Introduction </daml/intro/11_StdLib>
+   Testing </daml/intro/12_Testing>
+   Good Design Patterns </daml/patterns>

--- a/docs/index/create-daml-apps/standard-library/index.rst
+++ b/docs/index/create-daml-apps/standard-library/index.rst
@@ -8,6 +8,4 @@ Daml Standard Library
    :titlesonly:
    :maxdepth: 2
 
-   Introduction </daml/intro/11_StdLib>
-   Testing </daml/intro/12_Testing>
    Good Design Patterns </daml/patterns>

--- a/docs/index/index.rst
+++ b/docs/index/index.rst
@@ -45,6 +45,7 @@ Daml Documentation
    :hidden:
    :caption: Create Daml Apps
 
+   Write Smart Contracts With Daml </index/create-daml-apps/intro/index>
    Daml Standard Library </index/create-daml-apps/standard-library/index>
    Integrate Daml with Off-Ledger Services </index/create-daml-apps/off-ledger/index>
    Developer Tools </index/create-daml-apps/developer-tools/index>


### PR DESCRIPTION
And adding a place for the new introduction page when it is approved.

[CHANGELOG_BEGIN]
[CHANGELOG_END}