### PR TITLE
enable toc ref

### DIFF
--- a/docs/index/operate-a-daml-ledger/administration-introduction/index.rst
+++ b/docs/index/operate-a-daml-ledger/administration-introduction/index.rst
@@ -1,6 +1,8 @@
 .. Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
+.. _ledger-administration-introduction:
+
 Ledger Administration Introduction
 ##################################
 


### PR DESCRIPTION
In [daml#15449] we want to link to a TOC page, which doesn't exist there. So we resort to the same trick as for canton <-> daml links: introduce a phony reference on the daml side and reify it here.

[daml#15449]: https://github.com/digital-asset/daml/pull/15449