### PR TITLE
removing duplicate link to writing daml menu

### DIFF
--- a/docs/index/index.rst
+++ b/docs/index/index.rst
@@ -105,7 +105,6 @@ Daml Documentation
    :hidden:
    :caption: Reference
 
-   writing-daml
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
    Examples <https://daml.com/examples>


### PR DESCRIPTION
Removing an actual duplicate menu item from the Reference section.