### PR TITLE
Remove writing-daml from reference

### DIFF
--- a/docs/index/index.rst
+++ b/docs/index/index.rst
@@ -105,7 +105,6 @@ Daml Documentation
    :hidden:
    :caption: Reference
 
-   writing-daml
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
    Examples <https://daml.com/examples>


### PR DESCRIPTION
This content is already in "Write smart contracts with daml" section in Create Daml Apps