### PR TITLE
Updated LATEST to rc1 snapshots.

### DIFF
--- a/LATEST
+++ b/LATEST
@@ -1,6 +1,6 @@
 {
-  "daml": "2.5.0-snapshot.20221129.11056.0.4a554ac2",
-  "canton": "20221129",
+  "daml": "2.5.0-snapshot.20221201.11065.0.caac1d10",
+  "canton": "2.5.0-rc1",
   "daml_finance": "1.0.1",
   "prefix": "2.5.0"
 }

--- a/docs/index/index.rst
+++ b/docs/index/index.rst
@@ -111,6 +111,7 @@ Daml Documentation
    concepts/glossary
    Examples <https://daml.com/examples>
    daml/stdlib/index
+   daml/reference/index
    canton/usermanual/FAQ
    canton/reference/error_codes
    canton/reference/admin_apis


### PR DESCRIPTION
```
deps use 2.5.0-rc1
2.5.0-snapshot.20221201.11065.0.caac1d10 2.5.0-rc1 caac1d10109749e9ef9dbcdd09150818311fcd9f
```

See [LATEST in assembly](https://github.com/DACH-NY/assembly/blob/main/LATEST), which points to canton version `2.5.0-rc1`  and daml snapshot `2.5.0-snapshot.20221201.11065.0.caac1d10`.
