### PR TITLE
fix workdir path in snapshot release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,13 +223,13 @@ jobs:
                         '{daml: $daml, canton: $canton, prefix: $daml, daml_finance: $finance}' \
                         > LATEST
 
+                     bin/clean
                      bin/download
                      bin/build
                      upload=$(mktemp -d)
-                     tar xf docs/workdir/target/html-docs-$version.tar.gz -C $upload --strip-components=1
+                     tar xf workdir/target/html-docs-$version.tar.gz -C $upload --strip-components=1
                      aws s3 cp $upload s3://docs-daml-com/$version --recursive --acl public-read --region us-east-1
                      aws cloudfront create-invalidation --distribution-id E1U753I56ERH55 --paths "/$version/*"
-                     rm -rf docs/workdir
                      echo "-> Done."
                  fi
                  echo


### PR DESCRIPTION
Turns out, beyond the credentials issue, there was actually also a small bug introduced by #104, in that I forgot to update the path for the workdir folder in the cron code.

This should fix that.