### PR TITLE
remove mopinion from 2.5.2

### DIFF
--- a/docs/2.5.2/LATEST
+++ b/docs/2.5.2/LATEST
@@ -1,5 +1,5 @@
 {
-  "daml": "2.5.2",
+  "daml": "2.5.2-snapshot.20230130.11089.0.1aa59a08",
   "canton": "2.5.2",
   "daml_finance": "1.0.4",
   "prefix": "2.5.2"


### PR DESCRIPTION
This is a special snapshot I have created to include [this PR](https://github.com/digital-asset/daml/pull/16188), which itself is a backport of @da-katmurp's [PR](https://github.com/digital-asset/daml/pull/16077).

This is demonstrating that we can update a published daml version, including the one currently displayed on root, after the release of that version (as long as we manually create corresponding snapshots).