### PR TITLE
Mandatory config options in trigger service docs

### DIFF
--- a/docs/2.6.0/docs/tools/trigger-service/index.rst
+++ b/docs/2.6.0/docs/tools/trigger-service/index.rst
@@ -33,15 +33,15 @@ alongside a few annotations with regards to the meaning of the configuration key
 .. code-block:: none
 
     {
-      // Mandatory. Paths to the DAR files containing the code executed by the trigger.
+      // Paths to the DAR files containing the code executed by the trigger.
       dar-paths = [
         "./my-app.dar"
       ]
 
-      // Mandatory. Host address that the Trigger Service listens on. Defaults to 127.0.0.1.
+      // Host address that the Trigger Service listens on. Defaults to 127.0.0.1.
       address = "127.0.0.1"
 
-      // Mandatory. Trigger Service port number. Defaults to 8088.
+      // Trigger Service port number. Defaults to 8088.
       // A port number of 0 will let the system pick an ephemeral port.
       port = 8088
       // Optional. If using 0 as the port number, consider specifying the path to a `port-file` where the chosen port will be saved in textual format.

--- a/docs/2.7.0/docs/tools/trigger-service/index.rst
+++ b/docs/2.7.0/docs/tools/trigger-service/index.rst
@@ -33,15 +33,15 @@ alongside a few annotations with regards to the meaning of the configuration key
 .. code-block:: none
 
     {
-      // Mandatory. Paths to the DAR files containing the code executed by the trigger.
+      // Paths to the DAR files containing the code executed by the trigger.
       dar-paths = [
         "./my-app.dar"
       ]
 
-      // Mandatory. Host address that the Trigger Service listens on. Defaults to 127.0.0.1.
+      // Host address that the Trigger Service listens on. Defaults to 127.0.0.1.
       address = "127.0.0.1"
 
-      // Mandatory. Trigger Service port number. Defaults to 8088.
+      // Trigger Service port number. Defaults to 8088.
       // A port number of 0 will let the system pick an ephemeral port.
       port = 8088
       // Optional. If using 0 as the port number, consider specifying the path to a `port-file` where the chosen port will be saved in textual format.


### PR DESCRIPTION
I found during testing related to support ticket [00003571](https://digitalasset1.lightning.force.com/lightning/r/Case/5004x00000LbSWXAA3/view), that the only necessary configuration option to define in the configuration file for the trigger service is the ledger-api section.

Created originally in the daml repo: https://github.com/digital-asset/daml/pull/15635

CHANGELOG_BEGIN
CHANGELOG_END