### PR TITLE
Fixes small details in common metrics

### DIFF
--- a/docs/2.6.0/docs/ops/common-metrics.rst
+++ b/docs/2.6.0/docs/ops/common-metrics.rst
@@ -100,10 +100,10 @@ These metrics have the following common labels attached:
     fully qualified hostname of the HTTP endpoint (e.g. ``example.com``)
 
 - **path**:
-    path of the HTTP endpoint (e.g. ``/parties/create``)
+    path of the HTTP endpoint (e.g. ``/v1/parties/create``)
 
 - **service**:
-    Daml service's name (``json-api`` for the HTTP JSON API Service)
+    Daml service's name (``json_api`` for the HTTP JSON API Service)
 
 daml_http_requests_duration_seconds
 ===================================

--- a/docs/2.7.0/docs/ops/common-metrics.rst
+++ b/docs/2.7.0/docs/ops/common-metrics.rst
@@ -100,10 +100,10 @@ These metrics have the following common labels attached:
     fully qualified hostname of the HTTP endpoint (e.g. ``example.com``)
 
 - **path**:
-    path of the HTTP endpoint (e.g. ``/parties/create``)
+    path of the HTTP endpoint (e.g. ``/v1/parties/create``)
 
 - **service**:
-    Daml service's name (``json-api`` for the HTTP JSON API Service)
+    Daml service's name (``json_api`` for the HTTP JSON API Service)
 
 daml_http_requests_duration_seconds
 ===================================


### PR DESCRIPTION
* values in `service` label uses `_`, not `-`
* the paths usually start with a version segment