### PR TITLE
Update Daml Finance to 1.1.4

### DIFF
--- a/docs/2.6.0/_toc.yml
+++ b/docs/2.6.0/_toc.yml
@@ -536,332 +536,332 @@ subtrees:
       entries:
       - file: daml-finance/reference/glossary
         title: "Glossary"
-      - file: daml-finance/reference/code-documentation/daml-finance-rst/index
+      - file: daml-finance/reference/code-documentation/index
         title: "Daml Finance"
         subtrees:
         - hidden: False
           titlesonly: True
           maxdepth: 3
           entries:
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Builders
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Core-Builders
             title: "ContingentClaims.Core.Builders"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Claim
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Core-Claim
             title: "ContingentClaims.Core.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Internal-Claim
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Core-Internal-Claim
             title: "ContingentClaims.Core.Internal.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Observation
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Core-Observation
             title: "ContingentClaims.Core.Observation"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Util-Recursion
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Core-Util-Recursion
             title: "ContingentClaims.Core.Util.Recursion"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Lifecycle-Lifecycle
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Lifecycle-Lifecycle
             title: "ContingentClaims.Lifecycle.Lifecycle"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Lifecycle-Util
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Lifecycle-Util
             title: "ContingentClaims.Lifecycle.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Valuation-MathML
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Valuation-MathML
             title: "ContingentClaims.Valuation.MathML"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Valuation-Stochastic
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Valuation-Stochastic
             title: "ContingentClaims.Valuation.Stochastic"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Account-Account
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Account-Account
             title: "Daml.Finance.Account.Account"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Lifecycle-Rule
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Claims-Lifecycle-Rule
             title: "Daml.Finance.Claims.Lifecycle.Rule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Claims-Util
             title: "Daml.Finance.Claims.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Util-Builders
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Claims-Util-Builders
             title: "Daml.Finance.Claims.Util.Builders"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Util-Lifecycle
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Claims-Util-Lifecycle
             title: "Daml.Finance.Claims.Util.Lifecycle"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Numeric-Observation
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Data-Numeric-Observation
             title: "Daml.Finance.Data.Numeric.Observation"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Reference-HolidayCalendar
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Data-Reference-HolidayCalendar
             title: "Daml.Finance.Data.Reference.HolidayCalendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-DateClock
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Data-Time-DateClock
             title: "Daml.Finance.Data.Time.DateClock"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-DateClock-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Data-Time-DateClock-Types
             title: "Daml.Finance.Data.Time.DateClock.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-DateClockUpdate
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Data-Time-DateClockUpdate
             title: "Daml.Finance.Data.Time.DateClockUpdate"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-LedgerTime
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Data-Time-LedgerTime
             title: "Daml.Finance.Data.Time.LedgerTime"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-Fungible
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Holding-Fungible
             title: "Daml.Finance.Holding.Fungible"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-NonFungible
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Holding-NonFungible
             title: "Daml.Finance.Holding.NonFungible"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-NonTransferable
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Holding-NonTransferable
             title: "Daml.Finance.Holding.NonTransferable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Holding-Util
             title: "Daml.Finance.Holding.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FixedRate-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-FixedRate-Factory
             title: "Daml.Finance.Instrument.Bond.FixedRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FixedRate-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-FixedRate-Instrument
             title: "Daml.Finance.Instrument.Bond.FixedRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FloatingRate-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-FloatingRate-Factory
             title: "Daml.Finance.Instrument.Bond.FloatingRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FloatingRate-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-FloatingRate-Instrument
             title: "Daml.Finance.Instrument.Bond.FloatingRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-InflationLinked-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-InflationLinked-Factory
             title: "Daml.Finance.Instrument.Bond.InflationLinked.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-InflationLinked-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-InflationLinked-Instrument
             title: "Daml.Finance.Instrument.Bond.InflationLinked.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-Util
             title: "Daml.Finance.Instrument.Bond.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-ZeroCoupon-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-ZeroCoupon-Factory
             title: "Daml.Finance.Instrument.Bond.ZeroCoupon.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-ZeroCoupon-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-ZeroCoupon-Instrument
             title: "Daml.Finance.Instrument.Bond.ZeroCoupon.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Equity-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Equity-Factory
             title: "Daml.Finance.Instrument.Equity.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Equity-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Equity-Instrument
             title: "Daml.Finance.Instrument.Equity.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-Election
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Generic-Election
             title: "Daml.Finance.Instrument.Generic.Election"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Generic-Factory
             title: "Daml.Finance.Instrument.Generic.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Generic-Instrument
             title: "Daml.Finance.Instrument.Generic.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-Lifecycle-Rule
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Generic-Lifecycle-Rule
             title: "Daml.Finance.Instrument.Generic.Lifecycle.Rule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-European-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Option-European-Factory
             title: "Daml.Finance.Instrument.Option.European.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-European-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Option-European-Instrument
             title: "Daml.Finance.Instrument.Option.European.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Option-Util
             title: "Daml.Finance.Instrument.Option.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Asset-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Asset-Factory
             title: "Daml.Finance.Instrument.Swap.Asset.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Asset-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Asset-Instrument
             title: "Daml.Finance.Instrument.Swap.Asset.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-CreditDefault-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-CreditDefault-Factory
             title: "Daml.Finance.Instrument.Swap.CreditDefault.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-CreditDefault-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-CreditDefault-Instrument
             title: "Daml.Finance.Instrument.Swap.CreditDefault.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Currency-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Currency-Factory
             title: "Daml.Finance.Instrument.Swap.Currency.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Currency-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Currency-Instrument
             title: "Daml.Finance.Instrument.Swap.Currency.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-ForeignExchange-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-ForeignExchange-Factory
             title: "Daml.Finance.Instrument.Swap.ForeignExchange.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-ForeignExchange-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-ForeignExchange-Instrument
             title: "Daml.Finance.Instrument.Swap.ForeignExchange.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Fpml-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Fpml-Factory
             title: "Daml.Finance.Instrument.Swap.Fpml.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Fpml-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Fpml-Instrument
             title: "Daml.Finance.Instrument.Swap.Fpml.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Fpml-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Fpml-Util
             title: "Daml.Finance.Instrument.Swap.Fpml.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-InterestRate-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-InterestRate-Factory
             title: "Daml.Finance.Instrument.Swap.InterestRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-InterestRate-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-InterestRate-Instrument
             title: "Daml.Finance.Instrument.Swap.InterestRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Util
             title: "Daml.Finance.Instrument.Swap.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Token-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Token-Factory
             title: "Daml.Finance.Instrument.Token.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Token-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Token-Instrument
             title: "Daml.Finance.Instrument.Token.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-Account
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Account-Account
             title: "Daml.Finance.Interface.Account.Account"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Account-Factory
             title: "Daml.Finance.Interface.Account.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Account-Util
             title: "Daml.Finance.Interface.Account.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-Claim
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Claims-Claim
             title: "Daml.Finance.Interface.Claims.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-Dynamic-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Claims-Dynamic-Instrument
             title: "Daml.Finance.Interface.Claims.Dynamic.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Claims-Types
             title: "Daml.Finance.Interface.Claims.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Numeric-Observation
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Data-Numeric-Observation
             title: "Daml.Finance.Interface.Data.Numeric.Observation"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Numeric-Observation-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Data-Numeric-Observation-Factory
             title: "Daml.Finance.Interface.Data.Numeric.Observation.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Reference-HolidayCalendar
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Data-Reference-HolidayCalendar
             title: "Daml.Finance.Interface.Data.Reference.HolidayCalendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Reference-HolidayCalendar-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Data-Reference-HolidayCalendar-Factory
             title: "Daml.Finance.Interface.Data.Reference.HolidayCalendar.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Reference-Time
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Data-Reference-Time
             title: "Daml.Finance.Interface.Data.Reference.Time"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Base
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Holding-Base
             title: "Daml.Finance.Interface.Holding.Base"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Holding-Factory
             title: "Daml.Finance.Interface.Holding.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Fungible
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Holding-Fungible
             title: "Daml.Finance.Interface.Holding.Fungible"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Transferable
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Holding-Transferable
             title: "Daml.Finance.Interface.Holding.Transferable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Holding-Util
             title: "Daml.Finance.Interface.Holding.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Base-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Base-Instrument
             title: "Daml.Finance.Interface.Instrument.Base.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FixedRate-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-FixedRate-Factory
             title: "Daml.Finance.Interface.Instrument.Bond.FixedRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FixedRate-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-FixedRate-Instrument
             title: "Daml.Finance.Interface.Instrument.Bond.FixedRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FixedRate-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-FixedRate-Types
             title: "Daml.Finance.Interface.Instrument.Bond.FixedRate.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Factory
             title: "Daml.Finance.Interface.Instrument.Bond.FloatingRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Instrument
             title: "Daml.Finance.Interface.Instrument.Bond.FloatingRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Types
             title: "Daml.Finance.Interface.Instrument.Bond.FloatingRate.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Factory
             title: "Daml.Finance.Interface.Instrument.Bond.InflationLinked.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Instrument
             title: "Daml.Finance.Interface.Instrument.Bond.InflationLinked.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Types
             title: "Daml.Finance.Interface.Instrument.Bond.InflationLinked.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Factory
             title: "Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Instrument
             title: "Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Types
             title: "Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Equity-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Equity-Factory
             title: "Daml.Finance.Interface.Instrument.Equity.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Equity-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Equity-Instrument
             title: "Daml.Finance.Interface.Instrument.Equity.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-Election
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Generic-Election
             title: "Daml.Finance.Interface.Instrument.Generic.Election"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-Election-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Generic-Election-Factory
             title: "Daml.Finance.Interface.Instrument.Generic.Election.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Generic-Factory
             title: "Daml.Finance.Interface.Instrument.Generic.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Generic-Instrument
             title: "Daml.Finance.Interface.Instrument.Generic.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-European-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Option-European-Factory
             title: "Daml.Finance.Interface.Instrument.Option.European.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-European-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Option-European-Instrument
             title: "Daml.Finance.Interface.Instrument.Option.European.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-European-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Option-European-Types
             title: "Daml.Finance.Interface.Instrument.Option.European.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Asset-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Asset-Factory
             title: "Daml.Finance.Interface.Instrument.Swap.Asset.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Asset-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Asset-Instrument
             title: "Daml.Finance.Interface.Instrument.Swap.Asset.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Asset-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Asset-Types
             title: "Daml.Finance.Interface.Instrument.Swap.Asset.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Factory
             title: "Daml.Finance.Interface.Instrument.Swap.CreditDefault.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Instrument
             title: "Daml.Finance.Interface.Instrument.Swap.CreditDefault.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Types
             title: "Daml.Finance.Interface.Instrument.Swap.CreditDefault.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Currency-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Currency-Factory
             title: "Daml.Finance.Interface.Instrument.Swap.Currency.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Currency-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Currency-Instrument
             title: "Daml.Finance.Interface.Instrument.Swap.Currency.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Currency-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Currency-Types
             title: "Daml.Finance.Interface.Instrument.Swap.Currency.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Factory
             title: "Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Instrument
             title: "Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Types
             title: "Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Fpml-Factory
             title: "Daml.Finance.Interface.Instrument.Swap.Fpml.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-FpmlTypes
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Fpml-FpmlTypes
             title: "Daml.Finance.Interface.Instrument.Swap.Fpml.FpmlTypes"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Fpml-Instrument
             title: "Daml.Finance.Interface.Instrument.Swap.Fpml.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Fpml-Types
             title: "Daml.Finance.Interface.Instrument.Swap.Fpml.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-InterestRate-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-InterestRate-Factory
             title: "Daml.Finance.Interface.Instrument.Swap.InterestRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-InterestRate-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-InterestRate-Instrument
             title: "Daml.Finance.Interface.Instrument.Swap.InterestRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-InterestRate-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-InterestRate-Types
             title: "Daml.Finance.Interface.Instrument.Swap.InterestRate.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Token-Factory
             title: "Daml.Finance.Interface.Instrument.Token.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Token-Instrument
             title: "Daml.Finance.Interface.Instrument.Token.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Token-Types
             title: "Daml.Finance.Interface.Instrument.Token.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Effect
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Effect
             title: "Daml.Finance.Interface.Lifecycle.Effect"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Event
             title: "Daml.Finance.Interface.Lifecycle.Event"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event-Distribution
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Event-Distribution
             title: "Daml.Finance.Interface.Lifecycle.Event.Distribution"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event-Replacement
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Event-Replacement
             title: "Daml.Finance.Interface.Lifecycle.Event.Replacement"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event-Time
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Event-Time
             title: "Daml.Finance.Interface.Lifecycle.Event.Time"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Observable-NumericObservable
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Observable-NumericObservable
             title: "Daml.Finance.Interface.Lifecycle.Observable.NumericObservable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Observable-TimeObservable
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Observable-TimeObservable
             title: "Daml.Finance.Interface.Lifecycle.Observable.TimeObservable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Rule-Claim
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Rule-Claim
             title: "Daml.Finance.Interface.Lifecycle.Rule.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Rule-Lifecycle
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Rule-Lifecycle
             title: "Daml.Finance.Interface.Lifecycle.Rule.Lifecycle"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Batch
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Settlement-Batch
             title: "Daml.Finance.Interface.Settlement.Batch"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Settlement-Factory
             title: "Daml.Finance.Interface.Settlement.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Instruction
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Settlement-Instruction
             title: "Daml.Finance.Interface.Settlement.Instruction"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-RouteProvider
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Settlement-RouteProvider
             title: "Daml.Finance.Interface.Settlement.RouteProvider"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Settlement-Types
             title: "Daml.Finance.Interface.Settlement.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Common-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Types-Common-Types
             title: "Daml.Finance.Interface.Types.Common.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-Calendar
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Types-Date-Calendar
             title: "Daml.Finance.Interface.Types.Date.Calendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-Classes
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Types-Date-Classes
             title: "Daml.Finance.Interface.Types.Date.Classes"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-DayCount
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Types-Date-DayCount
             title: "Daml.Finance.Interface.Types.Date.DayCount"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-RollConvention
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Types-Date-RollConvention
             title: "Daml.Finance.Interface.Types.Date.RollConvention"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-Schedule
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Types-Date-Schedule
             title: "Daml.Finance.Interface.Types.Date.Schedule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-Common
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Util-Common
             title: "Daml.Finance.Interface.Util.Common"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-Disclosure
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Util-Disclosure
             title: "Daml.Finance.Interface.Util.Disclosure"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Effect
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-Effect
             title: "Daml.Finance.Lifecycle.Effect"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-ElectionEffect
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-ElectionEffect
             title: "Daml.Finance.Lifecycle.ElectionEffect"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Event-Distribution
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-Event-Distribution
             title: "Daml.Finance.Lifecycle.Event.Distribution"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Event-Replacement
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-Event-Replacement
             title: "Daml.Finance.Lifecycle.Event.Replacement"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Claim
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-Rule-Claim
             title: "Daml.Finance.Lifecycle.Rule.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Distribution
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-Rule-Distribution
             title: "Daml.Finance.Lifecycle.Rule.Distribution"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Replacement
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-Rule-Replacement
             title: "Daml.Finance.Lifecycle.Rule.Replacement"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-Rule-Util
             title: "Daml.Finance.Lifecycle.Rule.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Batch
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Settlement-Batch
             title: "Daml.Finance.Settlement.Batch"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Settlement-Factory
             title: "Daml.Finance.Settlement.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Hierarchy
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Settlement-Hierarchy
             title: "Daml.Finance.Settlement.Hierarchy"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Instruction
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Settlement-Instruction
             title: "Daml.Finance.Settlement.Instruction"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-RouteProvider-IntermediatedStatic
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Settlement-RouteProvider-IntermediatedStatic
             title: "Daml.Finance.Settlement.RouteProvider.IntermediatedStatic"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-RouteProvider-SingleCustodian
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Settlement-RouteProvider-SingleCustodian
             title: "Daml.Finance.Settlement.RouteProvider.SingleCustodian"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Common
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Util-Common
             title: "Daml.Finance.Util.Common"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-Calendar
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Util-Date-Calendar
             title: "Daml.Finance.Util.Date.Calendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-DayCount
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Util-Date-DayCount
             title: "Daml.Finance.Util.Date.DayCount"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-RollConvention
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Util-Date-RollConvention
             title: "Daml.Finance.Util.Date.RollConvention"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-Schedule
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Util-Date-Schedule
             title: "Daml.Finance.Util.Date.Schedule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Disclosure
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Util-Disclosure
             title: "Daml.Finance.Util.Disclosure"
 
 - caption: "Deploy Daml"

--- a/docs/2.6.0/versions.json
+++ b/docs/2.6.0/versions.json
@@ -1,5 +1,5 @@
 {
   "daml": "2.6.0-snapshot.20230222.11475.0.ec147a82",
   "canton": "20230222",
-  "daml_finance": "1.1.3"
+  "daml_finance": "1.1.4"
 }

--- a/docs/2.7.0/_toc.yml
+++ b/docs/2.7.0/_toc.yml
@@ -536,332 +536,332 @@ subtrees:
       entries:
       - file: daml-finance/reference/glossary
         title: "Glossary"
-      - file: daml-finance/reference/code-documentation/daml-finance-rst/index
+      - file: daml-finance/reference/code-documentation/index
         title: "Daml Finance"
         subtrees:
         - hidden: False
           titlesonly: True
           maxdepth: 3
           entries:
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Builders
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Core-Builders
             title: "ContingentClaims.Core.Builders"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Claim
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Core-Claim
             title: "ContingentClaims.Core.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Internal-Claim
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Core-Internal-Claim
             title: "ContingentClaims.Core.Internal.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Observation
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Core-Observation
             title: "ContingentClaims.Core.Observation"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Util-Recursion
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Core-Util-Recursion
             title: "ContingentClaims.Core.Util.Recursion"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Lifecycle-Lifecycle
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Lifecycle-Lifecycle
             title: "ContingentClaims.Lifecycle.Lifecycle"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Lifecycle-Util
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Lifecycle-Util
             title: "ContingentClaims.Lifecycle.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Valuation-MathML
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Valuation-MathML
             title: "ContingentClaims.Valuation.MathML"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Valuation-Stochastic
+          - file: daml-finance/reference/code-documentation/ContingentClaims-Valuation-Stochastic
             title: "ContingentClaims.Valuation.Stochastic"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Account-Account
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Account-Account
             title: "Daml.Finance.Account.Account"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Lifecycle-Rule
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Claims-Lifecycle-Rule
             title: "Daml.Finance.Claims.Lifecycle.Rule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Claims-Util
             title: "Daml.Finance.Claims.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Util-Builders
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Claims-Util-Builders
             title: "Daml.Finance.Claims.Util.Builders"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Util-Lifecycle
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Claims-Util-Lifecycle
             title: "Daml.Finance.Claims.Util.Lifecycle"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Numeric-Observation
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Data-Numeric-Observation
             title: "Daml.Finance.Data.Numeric.Observation"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Reference-HolidayCalendar
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Data-Reference-HolidayCalendar
             title: "Daml.Finance.Data.Reference.HolidayCalendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-DateClock
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Data-Time-DateClock
             title: "Daml.Finance.Data.Time.DateClock"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-DateClock-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Data-Time-DateClock-Types
             title: "Daml.Finance.Data.Time.DateClock.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-DateClockUpdate
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Data-Time-DateClockUpdate
             title: "Daml.Finance.Data.Time.DateClockUpdate"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-LedgerTime
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Data-Time-LedgerTime
             title: "Daml.Finance.Data.Time.LedgerTime"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-Fungible
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Holding-Fungible
             title: "Daml.Finance.Holding.Fungible"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-NonFungible
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Holding-NonFungible
             title: "Daml.Finance.Holding.NonFungible"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-NonTransferable
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Holding-NonTransferable
             title: "Daml.Finance.Holding.NonTransferable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Holding-Util
             title: "Daml.Finance.Holding.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FixedRate-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-FixedRate-Factory
             title: "Daml.Finance.Instrument.Bond.FixedRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FixedRate-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-FixedRate-Instrument
             title: "Daml.Finance.Instrument.Bond.FixedRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FloatingRate-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-FloatingRate-Factory
             title: "Daml.Finance.Instrument.Bond.FloatingRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FloatingRate-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-FloatingRate-Instrument
             title: "Daml.Finance.Instrument.Bond.FloatingRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-InflationLinked-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-InflationLinked-Factory
             title: "Daml.Finance.Instrument.Bond.InflationLinked.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-InflationLinked-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-InflationLinked-Instrument
             title: "Daml.Finance.Instrument.Bond.InflationLinked.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-Util
             title: "Daml.Finance.Instrument.Bond.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-ZeroCoupon-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-ZeroCoupon-Factory
             title: "Daml.Finance.Instrument.Bond.ZeroCoupon.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-ZeroCoupon-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Bond-ZeroCoupon-Instrument
             title: "Daml.Finance.Instrument.Bond.ZeroCoupon.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Equity-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Equity-Factory
             title: "Daml.Finance.Instrument.Equity.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Equity-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Equity-Instrument
             title: "Daml.Finance.Instrument.Equity.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-Election
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Generic-Election
             title: "Daml.Finance.Instrument.Generic.Election"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Generic-Factory
             title: "Daml.Finance.Instrument.Generic.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Generic-Instrument
             title: "Daml.Finance.Instrument.Generic.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-Lifecycle-Rule
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Generic-Lifecycle-Rule
             title: "Daml.Finance.Instrument.Generic.Lifecycle.Rule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-European-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Option-European-Factory
             title: "Daml.Finance.Instrument.Option.European.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-European-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Option-European-Instrument
             title: "Daml.Finance.Instrument.Option.European.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Option-Util
             title: "Daml.Finance.Instrument.Option.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Asset-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Asset-Factory
             title: "Daml.Finance.Instrument.Swap.Asset.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Asset-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Asset-Instrument
             title: "Daml.Finance.Instrument.Swap.Asset.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-CreditDefault-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-CreditDefault-Factory
             title: "Daml.Finance.Instrument.Swap.CreditDefault.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-CreditDefault-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-CreditDefault-Instrument
             title: "Daml.Finance.Instrument.Swap.CreditDefault.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Currency-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Currency-Factory
             title: "Daml.Finance.Instrument.Swap.Currency.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Currency-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Currency-Instrument
             title: "Daml.Finance.Instrument.Swap.Currency.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-ForeignExchange-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-ForeignExchange-Factory
             title: "Daml.Finance.Instrument.Swap.ForeignExchange.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-ForeignExchange-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-ForeignExchange-Instrument
             title: "Daml.Finance.Instrument.Swap.ForeignExchange.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Fpml-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Fpml-Factory
             title: "Daml.Finance.Instrument.Swap.Fpml.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Fpml-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Fpml-Instrument
             title: "Daml.Finance.Instrument.Swap.Fpml.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Fpml-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Fpml-Util
             title: "Daml.Finance.Instrument.Swap.Fpml.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-InterestRate-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-InterestRate-Factory
             title: "Daml.Finance.Instrument.Swap.InterestRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-InterestRate-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-InterestRate-Instrument
             title: "Daml.Finance.Instrument.Swap.InterestRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Swap-Util
             title: "Daml.Finance.Instrument.Swap.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Token-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Token-Factory
             title: "Daml.Finance.Instrument.Token.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Token-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Instrument-Token-Instrument
             title: "Daml.Finance.Instrument.Token.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-Account
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Account-Account
             title: "Daml.Finance.Interface.Account.Account"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Account-Factory
             title: "Daml.Finance.Interface.Account.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Account-Util
             title: "Daml.Finance.Interface.Account.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-Claim
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Claims-Claim
             title: "Daml.Finance.Interface.Claims.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-Dynamic-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Claims-Dynamic-Instrument
             title: "Daml.Finance.Interface.Claims.Dynamic.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Claims-Types
             title: "Daml.Finance.Interface.Claims.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Numeric-Observation
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Data-Numeric-Observation
             title: "Daml.Finance.Interface.Data.Numeric.Observation"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Numeric-Observation-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Data-Numeric-Observation-Factory
             title: "Daml.Finance.Interface.Data.Numeric.Observation.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Reference-HolidayCalendar
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Data-Reference-HolidayCalendar
             title: "Daml.Finance.Interface.Data.Reference.HolidayCalendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Reference-HolidayCalendar-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Data-Reference-HolidayCalendar-Factory
             title: "Daml.Finance.Interface.Data.Reference.HolidayCalendar.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Reference-Time
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Data-Reference-Time
             title: "Daml.Finance.Interface.Data.Reference.Time"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Base
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Holding-Base
             title: "Daml.Finance.Interface.Holding.Base"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Holding-Factory
             title: "Daml.Finance.Interface.Holding.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Fungible
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Holding-Fungible
             title: "Daml.Finance.Interface.Holding.Fungible"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Transferable
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Holding-Transferable
             title: "Daml.Finance.Interface.Holding.Transferable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Holding-Util
             title: "Daml.Finance.Interface.Holding.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Base-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Base-Instrument
             title: "Daml.Finance.Interface.Instrument.Base.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FixedRate-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-FixedRate-Factory
             title: "Daml.Finance.Interface.Instrument.Bond.FixedRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FixedRate-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-FixedRate-Instrument
             title: "Daml.Finance.Interface.Instrument.Bond.FixedRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FixedRate-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-FixedRate-Types
             title: "Daml.Finance.Interface.Instrument.Bond.FixedRate.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Factory
             title: "Daml.Finance.Interface.Instrument.Bond.FloatingRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Instrument
             title: "Daml.Finance.Interface.Instrument.Bond.FloatingRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Types
             title: "Daml.Finance.Interface.Instrument.Bond.FloatingRate.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Factory
             title: "Daml.Finance.Interface.Instrument.Bond.InflationLinked.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Instrument
             title: "Daml.Finance.Interface.Instrument.Bond.InflationLinked.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Types
             title: "Daml.Finance.Interface.Instrument.Bond.InflationLinked.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Factory
             title: "Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Instrument
             title: "Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Types
             title: "Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Equity-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Equity-Factory
             title: "Daml.Finance.Interface.Instrument.Equity.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Equity-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Equity-Instrument
             title: "Daml.Finance.Interface.Instrument.Equity.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-Election
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Generic-Election
             title: "Daml.Finance.Interface.Instrument.Generic.Election"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-Election-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Generic-Election-Factory
             title: "Daml.Finance.Interface.Instrument.Generic.Election.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Generic-Factory
             title: "Daml.Finance.Interface.Instrument.Generic.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Generic-Instrument
             title: "Daml.Finance.Interface.Instrument.Generic.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-European-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Option-European-Factory
             title: "Daml.Finance.Interface.Instrument.Option.European.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-European-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Option-European-Instrument
             title: "Daml.Finance.Interface.Instrument.Option.European.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-European-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Option-European-Types
             title: "Daml.Finance.Interface.Instrument.Option.European.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Asset-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Asset-Factory
             title: "Daml.Finance.Interface.Instrument.Swap.Asset.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Asset-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Asset-Instrument
             title: "Daml.Finance.Interface.Instrument.Swap.Asset.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Asset-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Asset-Types
             title: "Daml.Finance.Interface.Instrument.Swap.Asset.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Factory
             title: "Daml.Finance.Interface.Instrument.Swap.CreditDefault.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Instrument
             title: "Daml.Finance.Interface.Instrument.Swap.CreditDefault.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Types
             title: "Daml.Finance.Interface.Instrument.Swap.CreditDefault.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Currency-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Currency-Factory
             title: "Daml.Finance.Interface.Instrument.Swap.Currency.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Currency-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Currency-Instrument
             title: "Daml.Finance.Interface.Instrument.Swap.Currency.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Currency-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Currency-Types
             title: "Daml.Finance.Interface.Instrument.Swap.Currency.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Factory
             title: "Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Instrument
             title: "Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Types
             title: "Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Fpml-Factory
             title: "Daml.Finance.Interface.Instrument.Swap.Fpml.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-FpmlTypes
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Fpml-FpmlTypes
             title: "Daml.Finance.Interface.Instrument.Swap.Fpml.FpmlTypes"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Fpml-Instrument
             title: "Daml.Finance.Interface.Instrument.Swap.Fpml.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-Fpml-Types
             title: "Daml.Finance.Interface.Instrument.Swap.Fpml.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-InterestRate-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-InterestRate-Factory
             title: "Daml.Finance.Interface.Instrument.Swap.InterestRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-InterestRate-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-InterestRate-Instrument
             title: "Daml.Finance.Interface.Instrument.Swap.InterestRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-InterestRate-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Swap-InterestRate-Types
             title: "Daml.Finance.Interface.Instrument.Swap.InterestRate.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Token-Factory
             title: "Daml.Finance.Interface.Instrument.Token.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-Instrument
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Token-Instrument
             title: "Daml.Finance.Interface.Instrument.Token.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Instrument-Token-Types
             title: "Daml.Finance.Interface.Instrument.Token.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Effect
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Effect
             title: "Daml.Finance.Interface.Lifecycle.Effect"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Event
             title: "Daml.Finance.Interface.Lifecycle.Event"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event-Distribution
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Event-Distribution
             title: "Daml.Finance.Interface.Lifecycle.Event.Distribution"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event-Replacement
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Event-Replacement
             title: "Daml.Finance.Interface.Lifecycle.Event.Replacement"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event-Time
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Event-Time
             title: "Daml.Finance.Interface.Lifecycle.Event.Time"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Observable-NumericObservable
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Observable-NumericObservable
             title: "Daml.Finance.Interface.Lifecycle.Observable.NumericObservable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Observable-TimeObservable
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Observable-TimeObservable
             title: "Daml.Finance.Interface.Lifecycle.Observable.TimeObservable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Rule-Claim
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Rule-Claim
             title: "Daml.Finance.Interface.Lifecycle.Rule.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Rule-Lifecycle
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Lifecycle-Rule-Lifecycle
             title: "Daml.Finance.Interface.Lifecycle.Rule.Lifecycle"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Batch
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Settlement-Batch
             title: "Daml.Finance.Interface.Settlement.Batch"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Settlement-Factory
             title: "Daml.Finance.Interface.Settlement.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Instruction
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Settlement-Instruction
             title: "Daml.Finance.Interface.Settlement.Instruction"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-RouteProvider
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Settlement-RouteProvider
             title: "Daml.Finance.Interface.Settlement.RouteProvider"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Settlement-Types
             title: "Daml.Finance.Interface.Settlement.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Common-Types
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Types-Common-Types
             title: "Daml.Finance.Interface.Types.Common.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-Calendar
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Types-Date-Calendar
             title: "Daml.Finance.Interface.Types.Date.Calendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-Classes
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Types-Date-Classes
             title: "Daml.Finance.Interface.Types.Date.Classes"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-DayCount
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Types-Date-DayCount
             title: "Daml.Finance.Interface.Types.Date.DayCount"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-RollConvention
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Types-Date-RollConvention
             title: "Daml.Finance.Interface.Types.Date.RollConvention"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-Schedule
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Types-Date-Schedule
             title: "Daml.Finance.Interface.Types.Date.Schedule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-Common
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Util-Common
             title: "Daml.Finance.Interface.Util.Common"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-Disclosure
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Interface-Util-Disclosure
             title: "Daml.Finance.Interface.Util.Disclosure"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Effect
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-Effect
             title: "Daml.Finance.Lifecycle.Effect"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-ElectionEffect
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-ElectionEffect
             title: "Daml.Finance.Lifecycle.ElectionEffect"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Event-Distribution
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-Event-Distribution
             title: "Daml.Finance.Lifecycle.Event.Distribution"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Event-Replacement
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-Event-Replacement
             title: "Daml.Finance.Lifecycle.Event.Replacement"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Claim
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-Rule-Claim
             title: "Daml.Finance.Lifecycle.Rule.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Distribution
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-Rule-Distribution
             title: "Daml.Finance.Lifecycle.Rule.Distribution"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Replacement
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-Rule-Replacement
             title: "Daml.Finance.Lifecycle.Rule.Replacement"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Util
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Lifecycle-Rule-Util
             title: "Daml.Finance.Lifecycle.Rule.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Batch
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Settlement-Batch
             title: "Daml.Finance.Settlement.Batch"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Factory
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Settlement-Factory
             title: "Daml.Finance.Settlement.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Hierarchy
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Settlement-Hierarchy
             title: "Daml.Finance.Settlement.Hierarchy"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Instruction
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Settlement-Instruction
             title: "Daml.Finance.Settlement.Instruction"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-RouteProvider-IntermediatedStatic
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Settlement-RouteProvider-IntermediatedStatic
             title: "Daml.Finance.Settlement.RouteProvider.IntermediatedStatic"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-RouteProvider-SingleCustodian
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Settlement-RouteProvider-SingleCustodian
             title: "Daml.Finance.Settlement.RouteProvider.SingleCustodian"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Common
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Util-Common
             title: "Daml.Finance.Util.Common"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-Calendar
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Util-Date-Calendar
             title: "Daml.Finance.Util.Date.Calendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-DayCount
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Util-Date-DayCount
             title: "Daml.Finance.Util.Date.DayCount"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-RollConvention
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Util-Date-RollConvention
             title: "Daml.Finance.Util.Date.RollConvention"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-Schedule
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Util-Date-Schedule
             title: "Daml.Finance.Util.Date.Schedule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Disclosure
+          - file: daml-finance/reference/code-documentation/Daml-Finance-Util-Disclosure
             title: "Daml.Finance.Util.Disclosure"
 
 - caption: "Deploy Daml"

--- a/docs/2.7.0/versions.json
+++ b/docs/2.7.0/versions.json
@@ -1,5 +1,5 @@
 {
   "daml": "2.7.0-snapshot.20230228.11494.0.510b7e1f",
   "canton": "20230227",
-  "daml_finance": "1.1.3"
+  "daml_finance": "1.1.4"
 }


### PR DESCRIPTION
This finalises the migration of the Daml Finance docs to this repo: the `1.1.4` assembly package includes only the code snippets and auto-generated documentation