### PR TITLE
Requires is now enabled by default

### DIFF
--- a/docs/2.6.0/docs/daml/reference/interfaces.rst
+++ b/docs/2.6.0/docs/daml/reference/interfaces.rst
@@ -359,11 +359,6 @@ Interface Functions
 Required Interfaces
 *******************
 
-.. warning::
-  This feature is under active development and not officially supported in
-  production environments.
-  Required interfaces are only available when targeting Daml-LF 1.dev.
-
 .. literalinclude:: ../code-snippets-dev/Interfaces.daml
    :language: daml
    :start-after: -- INTERFACE_REQUIRES_BEGIN

--- a/docs/2.7.0/docs/daml/reference/interfaces.rst
+++ b/docs/2.7.0/docs/daml/reference/interfaces.rst
@@ -359,11 +359,6 @@ Interface Functions
 Required Interfaces
 *******************
 
-.. warning::
-  This feature is under active development and not officially supported in
-  production environments.
-  Required interfaces are only available when targeting Daml-LF 1.dev.
-
 .. literalinclude:: ../code-snippets-dev/Interfaces.daml
    :language: daml
    :start-after: -- INTERFACE_REQUIRES_BEGIN


### PR DESCRIPTION
Requires is now enabled by default so the warning for 1.dev does not apply any more.