### PR TITLE
Revert "remove links to deleted examples page (#209)"

### DIFF
--- a/docs/2.3.10/docs/index/index_html.rst
+++ b/docs/2.3.10/docs/index/index_html.rst
@@ -66,6 +66,7 @@ Daml Documentation
 
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
+   Examples <https://daml.com/examples>
    concepts/ledger-model/index
    concepts/identity-and-package-management
    concepts/time

--- a/docs/2.3.10/docs/index/index_pdf.rst
+++ b/docs/2.3.10/docs/index/index_pdf.rst
@@ -63,6 +63,7 @@ Reference
 
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
+   Examples <https://daml.com/examples>
    concepts/ledger-model/index
    concepts/identity-and-package-management
    concepts/time

--- a/docs/2.3.8/docs/index/index_html.rst
+++ b/docs/2.3.8/docs/index/index_html.rst
@@ -66,6 +66,7 @@ Daml Documentation
 
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
+   Examples <https://daml.com/examples>
    concepts/ledger-model/index
    concepts/identity-and-package-management
    concepts/time

--- a/docs/2.3.8/docs/index/index_pdf.rst
+++ b/docs/2.3.8/docs/index/index_pdf.rst
@@ -63,6 +63,7 @@ Reference
 
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
+   Examples <https://daml.com/examples>
    concepts/ledger-model/index
    concepts/identity-and-package-management
    concepts/time

--- a/docs/2.3.9/docs/index/index_html.rst
+++ b/docs/2.3.9/docs/index/index_html.rst
@@ -66,6 +66,7 @@ Daml Documentation
 
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
+   Examples <https://daml.com/examples>
    concepts/ledger-model/index
    concepts/identity-and-package-management
    concepts/time

--- a/docs/2.3.9/docs/index/index_pdf.rst
+++ b/docs/2.3.9/docs/index/index_pdf.rst
@@ -63,6 +63,7 @@ Reference
 
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
+   Examples <https://daml.com/examples>
    concepts/ledger-model/index
    concepts/identity-and-package-management
    concepts/time

--- a/docs/2.4.3/docs/index/_toc.yml
+++ b/docs/2.4.3/docs/index/_toc.yml
@@ -851,6 +851,8 @@ subtrees:
     title: "Cheat Sheet"
   - file: concepts/glossary
     title: "Glossary of concepts"
+  - url: https://daml.com/examples
+    title: "Examples"
   - file: index/advanced-architecture
     title: "Advanced Architecture"
     entries:

--- a/docs/2.4.3/docs/index/index.rst
+++ b/docs/2.4.3/docs/index/index.rst
@@ -109,6 +109,7 @@ Daml Documentation
    writing-daml
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
+   Examples <https://daml.com/examples>
    daml/stdlib/index
    daml/reference/index
    canton/usermanual/FAQ

--- a/docs/2.4.3/docs/index/index_html.rst
+++ b/docs/2.4.3/docs/index/index_html.rst
@@ -66,6 +66,7 @@ Daml Documentation
 
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
+   Examples <https://daml.com/examples>
    concepts/ledger-model/index
    concepts/identity-and-package-management
    concepts/time

--- a/docs/2.4.3/docs/index/index_pdf.rst
+++ b/docs/2.4.3/docs/index/index_pdf.rst
@@ -63,6 +63,7 @@ Reference
 
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
+   Examples <https://daml.com/examples>
    concepts/ledger-model/index
    concepts/identity-and-package-management
    concepts/time

--- a/docs/2.5.1/docs/index/_toc.yml
+++ b/docs/2.5.1/docs/index/_toc.yml
@@ -873,6 +873,8 @@ subtrees:
     title: "Cheat Sheet"
   - file: concepts/glossary
     title: "Glossary of concepts"
+  - url: https://daml.com/examples
+    title: "Examples"
   - file: index/advanced-architecture
     title: "Canton Advanced Architecture"
     entries:

--- a/docs/2.5.1/docs/index/index.rst
+++ b/docs/2.5.1/docs/index/index.rst
@@ -109,6 +109,7 @@ Daml Documentation
    writing-daml
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
+   Examples <https://daml.com/examples>
    daml/stdlib/index
    daml/reference/index
    canton/usermanual/FAQ

--- a/docs/2.5.2/docs/index/_toc.yml
+++ b/docs/2.5.2/docs/index/_toc.yml
@@ -873,6 +873,8 @@ subtrees:
     title: "Cheat Sheet"
   - file: concepts/glossary
     title: "Glossary of concepts"
+  - url: https://daml.com/examples
+    title: "Examples"
   - file: index/advanced-architecture
     title: "Canton Advanced Architecture"
     entries:

--- a/docs/2.5.2/docs/index/index.rst
+++ b/docs/2.5.2/docs/index/index.rst
@@ -109,6 +109,7 @@ Daml Documentation
    writing-daml
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
+   Examples <https://daml.com/examples>
    daml/stdlib/index
    daml/reference/index
    canton/usermanual/FAQ

--- a/docs/2.5.3/docs/index/_toc.yml
+++ b/docs/2.5.3/docs/index/_toc.yml
@@ -873,6 +873,8 @@ subtrees:
     title: "Cheat Sheet"
   - file: concepts/glossary
     title: "Glossary of concepts"
+  - url: https://daml.com/examples
+    title: "Examples"
   - file: index/advanced-architecture
     title: "Canton Advanced Architecture"
     entries:

--- a/docs/2.5.3/docs/index/index.rst
+++ b/docs/2.5.3/docs/index/index.rst
@@ -109,6 +109,7 @@ Daml Documentation
    writing-daml
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
+   Examples <https://daml.com/examples>
    daml/stdlib/index
    daml/reference/index
    canton/usermanual/FAQ

--- a/docs/2.5.5/docs/index/_toc.yml
+++ b/docs/2.5.5/docs/index/_toc.yml
@@ -873,6 +873,8 @@ subtrees:
     title: "Cheat Sheet"
   - file: concepts/glossary
     title: "Glossary of concepts"
+  - url: https://daml.com/examples
+    title: "Examples"
   - file: index/advanced-architecture
     title: "Canton Advanced Architecture"
     entries:

--- a/docs/2.5.5/docs/index/index.rst
+++ b/docs/2.5.5/docs/index/index.rst
@@ -109,6 +109,7 @@ Daml Documentation
    writing-daml
    Cheat Sheet <https://docs.daml.com/cheat-sheet>
    concepts/glossary
+   Examples <https://daml.com/examples>
    daml/stdlib/index
    daml/reference/index
    canton/usermanual/FAQ

--- a/docs/2.6.0/docs/app-dev/bindings-java/quickstart.rst
+++ b/docs/2.6.0/docs/app-dev/bindings-java/quickstart.rst
@@ -639,6 +639,7 @@ Great - you've completed the quickstart guide!
 
 Some steps you could take next include:
 
+- Explore `examples <https://daml.com/examples>`_ for guidance and inspiration.
 - :doc:`Learn Daml </daml/intro/0_Intro>`.
 - :doc:`Language reference </daml/reference/index>`.
 - Learn more about :doc:`application development </app-dev/app-arch>`.

--- a/docs/2.7.0/docs/app-dev/bindings-java/quickstart.rst
+++ b/docs/2.7.0/docs/app-dev/bindings-java/quickstart.rst
@@ -639,6 +639,7 @@ Great - you've completed the quickstart guide!
 
 Some steps you could take next include:
 
+- Explore `examples <https://daml.com/examples>`_ for guidance and inspiration.
 - :doc:`Learn Daml </daml/intro/0_Intro>`.
 - :doc:`Language reference </daml/reference/index>`.
 - Learn more about :doc:`application development </app-dev/app-arch>`.


### PR DESCRIPTION
This reverts commit 5bb797397999fa184c4687720b1d97023409e10f.

The link is no longer dead.