### PR TITLE
Spell check everything else

### DIFF
--- a/docs/2.5.5/docs/canton/architecture/requirements/requirements.rst
+++ b/docs/2.5.5/docs/canton/architecture/requirements/requirements.rst
@@ -1,7 +1,7 @@
 ..
      Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates
 ..
-    
+
 ..
      Proprietary code. All rights reserved.
 
@@ -178,7 +178,7 @@ and design limitations :ref:`later in the section
   of the validity requirement on the shared ledger can be violated for
   contracts with no honestly represented signatories, even if I am an observer on the contract.
 
-  .. 
+  ..
      **Exception 2**: The aspects :ref:`key uniqueness <contract-key-uniqueness>` and :ref:`key assertion validity <contract-key-assertion-validity>`
      of the validity requirement on the shared ledger can be violated for
      keys with no honestly represented maintainers, even if I am a non-maintainer stakeholder of contracts with that key.
@@ -333,7 +333,7 @@ and design limitations :ref:`later in the section
 
   .. _seek-support-for-notifications-hlreq:
 
-* **Seek support for notifications**. I want to be able to receive 
+* **Seek support for notifications**. I want to be able to receive
   notifications (about ledger changes and about the decisions on
   my change requests) only from a particular known offset, so that I can
   synchronize my application state with the set of active contracts on
@@ -381,7 +381,7 @@ therefore the Daml compiler will not emit an error or warning if a resource limi
   **Definition:** The maximum number of levels (except for the top-level) in a transaction tree.
 
   **Example:** The following transaction has a depth of 2:
-  
+
   .. image:: ./images/action-structure-paint-offer.svg
      :align: left
      :width: 70%
@@ -446,12 +446,12 @@ section <requirements-exceptions>`.
   action (according to the ledger privacy model) may learn the following:
 
   * How deeply lies the action within a ledger commit.
-    
+
   * How many sibling actions each parent action has.
-    
+
   * The transaction identifiers (but not the transactions' contents)
     that have created the contracts used by the action.
-  
+
   **Design limitation 2**: Domain entities operated by trusted third
   parties may learn the hierarchical structure and stakeholders of all
   actions of the ledger (but none of the contents of the contracts,
@@ -894,7 +894,7 @@ section <requirements-exceptions>`.
   .. todo::
     #. `Large transaction support <https://github.com/DACH-NY/canton/issues/210>`_.
 
-.. _resilience-to-erronous-behavior-hlreq:
+.. _resilience-to-erroneous-behavior-hlreq:
 
 * **Resilience to erroneous behavior**. I want that the system
   to be resilient against erroneous behavior of users and participants
@@ -903,7 +903,7 @@ section <requirements-exceptions>`.
   This item is scheduled on the roadmap.
 
   .. todo::
-    #. `Resilience to errorenous behaviour <https://github.com/DACH-NY/canton/issues/211>`_.
+    #. `Resilience to erroneous behaviour <https://github.com/DACH-NY/canton/issues/211>`_.
 
 .. _resilience-to-faulty-domain-behavior-hlreq:
 

--- a/docs/2.6.4/docs/app-dev/custom-views/index.rst
+++ b/docs/2.6.4/docs/app-dev/custom-views/index.rst
@@ -292,7 +292,7 @@ Configuration
 *************
 
 The Custom Views library uses the `Lightbend config library <https://github.com/lightbend/config>`_ for configuration.
-The library is packaged with a ``reference.conf`` file which specifies default settings. The next sections describe the default confguration settings.
+The library is packaged with a ``reference.conf`` file which specifies default settings. The next sections describe the default configuration settings.
 You can override the configuration by using an ``application.conf`` file, see `using the Lightbend config library <https://github.com/lightbend/config#using-the-library>`_ for more details.
 
 Database migration with Flyway

--- a/docs/2.6.4/docs/canton/architecture/requirements/requirements.rst
+++ b/docs/2.6.4/docs/canton/architecture/requirements/requirements.rst
@@ -1,7 +1,7 @@
 ..
      Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates
 ..
-    
+
 ..
      Proprietary code. All rights reserved.
 
@@ -178,7 +178,7 @@ and design limitations :ref:`later in the section
   of the validity requirement on the shared ledger can be violated for
   contracts with no honestly represented signatories, even if I am an observer on the contract.
 
-  .. 
+  ..
      **Exception 2**: The aspects :ref:`key uniqueness <contract-key-uniqueness>` and :ref:`key assertion validity <contract-key-assertion-validity>`
      of the validity requirement on the shared ledger can be violated for
      keys with no honestly represented maintainers, even if I am a non-maintainer stakeholder of contracts with that key.
@@ -333,7 +333,7 @@ and design limitations :ref:`later in the section
 
   .. _seek-support-for-notifications-hlreq:
 
-* **Seek support for notifications**. I want to be able to receive 
+* **Seek support for notifications**. I want to be able to receive
   notifications (about ledger changes and about the decisions on
   my change requests) only from a particular known offset, so that I can
   synchronize my application state with the set of active contracts on
@@ -381,7 +381,7 @@ therefore the Daml compiler will not emit an error or warning if a resource limi
   **Definition:** The maximum number of levels (except for the top-level) in a transaction tree.
 
   **Example:** The following transaction has a depth of 2:
-  
+
   .. image:: ./images/action-structure-paint-offer.svg
      :align: left
      :width: 70%
@@ -446,12 +446,12 @@ section <requirements-exceptions>`.
   action (according to the ledger privacy model) may learn the following:
 
   * How deeply lies the action within a ledger commit.
-    
+
   * How many sibling actions each parent action has.
-    
+
   * The transaction identifiers (but not the transactions' contents)
     that have created the contracts used by the action.
-  
+
   **Design limitation 2**: Domain entities operated by trusted third
   parties may learn the hierarchical structure and stakeholders of all
   actions of the ledger (but none of the contents of the contracts,
@@ -894,7 +894,7 @@ section <requirements-exceptions>`.
   .. todo::
     #. `Large transaction support <https://github.com/DACH-NY/canton/issues/210>`_.
 
-.. _resilience-to-erronous-behavior-hlreq:
+.. _resilience-to-erroneous-behavior-hlreq:
 
 * **Resilience to erroneous behavior**. I want that the system
   to be resilient against erroneous behavior of users and participants
@@ -903,7 +903,7 @@ section <requirements-exceptions>`.
   This item is scheduled on the roadmap.
 
   .. todo::
-    #. `Resilience to errorenous behaviour <https://github.com/DACH-NY/canton/issues/211>`_.
+    #. `Resilience to erroneous behaviour <https://github.com/DACH-NY/canton/issues/211>`_.
 
 .. _resilience-to-faulty-domain-behavior-hlreq:
 

--- a/docs/2.6.4/docs/concepts/glossary.rst
+++ b/docs/2.6.4/docs/concepts/glossary.rst
@@ -11,21 +11,21 @@ Key Concepts
 Daml
 ====
 
-Daml is a platform for building and running sophisticated, multi-party applications. At its core, it contains a smart contract `language <#daml-language>`__ and `tooling <#developer-tools>`__ 
-that defines the schema, semantics, and execution of transactions between parties. Daml includes `Canton <#canton-ledger>`__, a privacy-enabled distributed ledger that is enhanced when deployed 
+Daml is a platform for building and running sophisticated, multi-party applications. At its core, it contains a smart contract `language <#daml-language>`__ and `tooling <#developer-tools>`__
+that defines the schema, semantics, and execution of transactions between parties. Daml includes `Canton <#canton-ledger>`__, a privacy-enabled distributed ledger that is enhanced when deployed
 with complementary blockchains.
 
 Daml Language
 =============
 
-The Daml language is a purpose-built language for rapid development of composable multi-party applications. It is a modern, ergonomically designed functional language that carefully avoids many 
+The Daml language is a purpose-built language for rapid development of composable multi-party applications. It is a modern, ergonomically designed functional language that carefully avoids many
 of the pitfalls that hinder multi-party application development in other languages.
 
 Daml Ledger
 ===========
 
 A Daml ledger is a distributed ledger system running `Daml smart contracts <#contract>`__ according to the :doc:`Daml ledger model </concepts/ledger-model/index>` and exposes the Daml Ledger APIs.
-All current implementations of Daml ledgers consist of a Daml driver that utilises an underlying Synchronization Technology to either implement the Daml ledger directly, or to run the Canton protocol.
+All current implementations of Daml ledgers consist of a Daml driver that utilizes an underlying Synchronization Technology to either implement the Daml ledger directly, or to run the Canton protocol.
 
 Canton Ledger
 -------------
@@ -35,7 +35,7 @@ A Canton ledger is a privacy-enabled Daml ledger implemented using the Canton ap
 Canton Protocol
 ===============
 
-The Canton protocol is the technology which synchronizes `participant nodes <#participant-node>`__ across any Daml-enabled blockchain or database.  The Canton protocol not only makes Daml 
+The Canton protocol is the technology which synchronizes `participant nodes <#participant-node>`__ across any Daml-enabled blockchain or database.  The Canton protocol not only makes Daml
 applications portable between different underlying `synchronization technologies <#synchronization-technology>`__, but also allows applications to transact with each other across them.
 
 .. Synchronization technology.  Not 'Environment', 'Infrastructure layer', 'Messaging layer', 'Topology layer', 'Underlying <enter-any-previous-term>'
@@ -43,13 +43,13 @@ applications portable between different underlying `synchronization technologies
 Synchronization Technology
 ==========================
 
-The syncronization technology is the database or blockchain that Daml uses for synchronization, messaging, and topology. Daml runs on a range of synchronization technologies, from centralized 
+The synchronization technology is the database or blockchain that Daml uses for synchronization, messaging, and topology. Daml runs on a range of synchronization technologies, from centralized
 databases to fully distributed deployments, and users can employ the technology that best suits their technical and operational needs.
 
 Daml Drivers
 ============
 
-Daml drivers enable a `ledger <#daml-ledger>`__ to be implemented on top of different `synchronization technologies <#synchronization-technology>`__; a database or distributed ledger technology. 
+Daml drivers enable a `ledger <#daml-ledger>`__ to be implemented on top of different `synchronization technologies <#synchronization-technology>`__; a database or distributed ledger technology.
 
 Daml Language Concepts
 **********************
@@ -349,7 +349,7 @@ There's a lot of information available about application development, starting w
 Ledger API
 ==========
 
-The **Ledger API** is an API that's exposed by any `ledger <#daml-ledger>`__ on a participant node. Users access and manipulate the ledger state through the leger API.
+The **Ledger API** is an API that's exposed by any `ledger <#daml-ledger>`__ on a participant node. Users access and manipulate the ledger state through the Ledger API.
 An alternative name for the Ledger API is the **gRPC Ledger API** if disambiguation from other technologies is needed.
 See :doc:`/app-dev/ledger-api` page.
 It includes the following :doc:`services </app-dev/services>`.
@@ -438,13 +438,13 @@ A **command** is an instruction to add a transaction to the `ledger <#daml-ledge
 Participant Node
 ================
 
-The participant node is a server that provides users a consistent programmatic access to a ledger through the `Ledger API <#ledger-api>`__. The participant nodes handles transaction signing and 
+The participant node is a server that provides users a consistent programmatic access to a ledger through the `Ledger API <#ledger-api>`__. The participant nodes handles transaction signing and
 validation, such that users don't have to deal with cryptographic primitives but can trust the participant node that the data they are observing has been properly verified to be correct.
 
 Sub-transaction Privacy
 =======================
 
-Sub-transaction privacy is where participants to a transaction only `learn about the subset of the transaction <https://docs.daml.com/concepts/ledger-model/ledger-privacy.html>`__ they are 
+Sub-transaction privacy is where participants to a transaction only `learn about the subset of the transaction <https://docs.daml.com/concepts/ledger-model/ledger-privacy.html>`__ they are
 directly involved in, but not about any other part of the transaction. This applies to both the content of the transaction as well as other involved participants.
 
 Daml-LF
@@ -461,7 +461,7 @@ As a user, you don't need to interact with Daml-LF directly. But internally, it'
 Composability
 =============
 
-Composability is the ability of a participant to extend an existing system with new Daml applications or new topologies unilaterally without requiring cooperation from anyone except the 
+Composability is the ability of a participant to extend an existing system with new Daml applications or new topologies unilaterally without requiring cooperation from anyone except the
 directly involved participants who wish to be part of the new application functionality.
 
 .. _trust-domain:
@@ -481,10 +481,10 @@ Canton Concepts
 Domain
 ======
 
-The domain provides total ordered, guaranteed delivery multi-cast to the participants. This means that participant nodes communicate with each other by sending end-to-end encrypted messages 
-through the domain. 
+The domain provides total ordered, guaranteed delivery multi-cast to the participants. This means that participant nodes communicate with each other by sending end-to-end encrypted messages
+through the domain.
 
-The `sequencer service <#sequencer>`__ of the domain orders these messages without knowing about the content and ensures that every participant receives the messages in the same order. 
+The `sequencer service <#sequencer>`__ of the domain orders these messages without knowing about the content and ensures that every participant receives the messages in the same order.
 
 The other services of the domain are the `mediator <#mediator>`__ and the `domain identity manager <#domain-identity-manager>`__.
 
@@ -496,36 +496,36 @@ Every participant node manages its own private contract store (PCS) which contai
 Virtual Global Ledger
 =====================
 
-While every participant has their own private contract store (PCS), the `Canton protocol <#canton-protocol>`__ guarantees that the contracts which are stored in the PCS are well-authorized 
-and that any change to the store is justified, authorized and valid. The result is that every participant only possesses a small part of the *virtual global ledger*. All the local 
-stores together make up that *virtual global ledger* and they are thus synchronized. The Canton protocol guarantees that the virtual ledger provides integrity, privacy, 
+While every participant has their own private contract store (PCS), the `Canton protocol <#canton-protocol>`__ guarantees that the contracts which are stored in the PCS are well-authorized
+and that any change to the store is justified, authorized and valid. The result is that every participant only possesses a small part of the *virtual global ledger*. All the local
+stores together make up that *virtual global ledger* and they are thus synchronized. The Canton protocol guarantees that the virtual ledger provides integrity, privacy,
 transparency and auditability. The ledger is logically global, even though physically, it runs on segregated and isolated domains that are not aware of each other.
 
 Mediator
 ========
 
-The mediator is a service provided by the `domain <#domain>`__ and used by the `Canton protocol <#canton-protocol>`__. The mediator acts as commit coordinator, collecting individual transaction verdicts issued by validating 
+The mediator is a service provided by the `domain <#domain>`__ and used by the `Canton protocol <#canton-protocol>`__. The mediator acts as commit coordinator, collecting individual transaction verdicts issued by validating
 participants and aggregates them into a single result. The mediator does not learn about the content of the transaction, they only learn about the involved participants.
 
 Sequencer
 =========
 
-The sequencer is a service provided by the `domain <#domain>`__, used by the `Canton protocol <#canton-protocol>`__. The sequencer forwards encrypted addressed messages from participants and ensures that every member receives 
+The sequencer is a service provided by the `domain <#domain>`__, used by the `Canton protocol <#canton-protocol>`__. The sequencer forwards encrypted addressed messages from participants and ensures that every member receives
 the messages in the same order. Think about registered and sealed mail delivered according to the postal datestamp.
 
 Domain Identity Manager
 =======================
 
-The Domain Identity Manager is a service provided by the `domain <#domain>`__, used by the `Canton protocol <#canton-protocol>`__. Participants join a new domain by registering with the domain identity manager. The domain 
+The Domain Identity Manager is a service provided by the `domain <#domain>`__, used by the `Canton protocol <#canton-protocol>`__. Participants join a new domain by registering with the domain identity manager. The domain
 identity manager establishes a consistent identity state among all participants. The domain identity manager only forwards identity updates. It can not invent them.
 
 
 Consensus
 =========
 
-The Canton protocol does not use PBFT or any similar consensus algorithm. There is no proof of work or proof of stake involved. Instead, Canton uses a variant of a stakeholder based 
-two-phase commit protocol. As such, only stakeholders of a transaction are involved in it and need to process it, providing efficiency, privacy and horizontal scalability. Canton based 
-ledgers are resilient to malicious participants as long as there is at least a single honest participant. A domain integration itself might be using the consensus mechanism of the underlying 
+The Canton protocol does not use PBFT or any similar consensus algorithm. There is no proof of work or proof of stake involved. Instead, Canton uses a variant of a stakeholder based
+two-phase commit protocol. As such, only stakeholders of a transaction are involved in it and need to process it, providing efficiency, privacy and horizontal scalability. Canton based
+ledgers are resilient to malicious participants as long as there is at least a single honest participant. A domain integration itself might be using the consensus mechanism of the underlying
 platform, but participant nodes will not be involved in that process.
 
 .. Transaction

--- a/docs/2.6.4/docs/concepts/time.rst
+++ b/docs/2.6.4/docs/concepts/time.rst
@@ -36,7 +36,7 @@ and it is assigned by the backing storage mechanism when the transaction is pers
 
 The record time should be an intuitive representation of "real time",
 but the Daml abstract ledger model does not prescribe exactly how to assign the record time.
-Each persistance technology might use a different way of representing time in a distributed setting.
+Each persistence technology might use a different way of representing time in a distributed setting.
 
 
 .. _time_guarantees:
@@ -109,7 +109,7 @@ The algorithm is not part of the definition of time in Daml, and may change in t
    or if the transaction uses a very fine-grained control flow based on time.
 
 #. At this point, the ledger time may lie in the future (e.g., if a large value for ``min_ledger_time_rel`` was given).
-   The participant waits until ``lt_TX - transaction_latency`` before it submits the transaction to the ledger - 
+   The participant waits until ``lt_TX - transaction_latency`` before it submits the transaction to the ledger -
    the intention is that the transaction is recorded at ``lt_TX == rt_TX``.
 
 Use the parameters ``min_ledger_time_rel`` and ``min_ledger_time_abs`` if you expect that

--- a/docs/2.6.4/docs/daml-finance/concepts/asset-model.rst
+++ b/docs/2.6.4/docs/daml-finance/concepts/asset-model.rst
@@ -250,7 +250,7 @@ Entity, a Securities Depository, and an Investor.
 
 The Issuing Entity acts as ``issuer`` of the :ref:`Equity Instrument
 <type-daml-finance-instrument-equity-instrument-instrument-90430>`. The Securities Depository acts
-as ``depository`` of the instrument, thus preventing the Issuing Entity from single-handledly
+as ``depository`` of the instrument, thus preventing the Issuing Entity from single-handedly
 modifying details of the instrument (such as the share's nominal value).
 
 The Institutional Investor holds units of shares against the Securities Depository, through

--- a/docs/2.6.4/docs/daml-finance/concepts/contingent-claims.rst
+++ b/docs/2.6.4/docs/daml-finance/concepts/contingent-claims.rst
@@ -171,7 +171,7 @@ Concerning Type Parameters
 
 The curious reader may have noticed that the signature we gave for ``data Claim`` is not quite what
 is in the library, where we have ``data Claim t x a o``. In our examples, we have specialised this
-to ``type Claim' t x a o = Claim Date Decimal a a``. Parametrising these variables allows us to
+to ``type Claim' t x a o = Claim Date Decimal a a``. Parameterising these variables allows us to
 reason about ``Asset``\ s and ``Observation``\ s that appear in\ ``Claim``\ s as function-like
 objects. The main use of this is to create claims with ‘placeholders’ for actual parameters, that
 can later be ‘filled in’ by mapping over them (``mapParams``).

--- a/docs/2.6.4/docs/daml-finance/concepts/lifecycling.rst
+++ b/docs/2.6.4/docs/daml-finance/concepts/lifecycling.rst
@@ -7,7 +7,7 @@ Lifecycling
 :ref:`Lifecycling <lifecycling>` refers to the evolution of financial instruments over their
 lifetime. This includes processing of contractual events, like interest payments or coupon
 cashflows, as well as discretionary events, like dividends and other corporate actions. The library
-provides a standard mechanism for processing such events accross different instruments.
+provides a standard mechanism for processing such events across different instruments.
 
 The interfaces for lifecycling are defined in the ``Daml.Finance.Interface.Lifecycle`` package, and
 several default implementations are provided in the ``Daml.Finance.Lifecycle`` package.
@@ -76,7 +76,7 @@ We will now explain each step in the process in detail.
 Creating the event
 ==================
 
-The issuer first creates a new instance of the ``ACME`` instrument, assiging a new version. Note
+The issuer first creates a new instance of the ``ACME`` instrument, assigning a new version. Note
 that the logic to create the new version of an instrument can also be encoded in the lifecycle rule.
 The new version is then automatically produced when processing the event as described in the next
 step.

--- a/docs/2.6.4/docs/daml-finance/overview/intro.rst
+++ b/docs/2.6.4/docs/daml-finance/overview/intro.rst
@@ -45,7 +45,7 @@ Daml Finance optimizes for the following aspects:
 * Extensibility
 
    Various extension points allow customization and extension of the library as required. If an
-   existing implementation does not fulfil the requirements it is straightforward to provide a
+   existing implementation does not fulfill the requirements it is straightforward to provide a
    custom extension.
 
 Scope

--- a/docs/2.6.4/docs/daml-finance/packages/implementations/daml-finance-data.rst
+++ b/docs/2.6.4/docs/daml-finance/packages/implementations/daml-finance-data.rst
@@ -12,7 +12,7 @@ This package implements templates containing reference data. It includes the fol
 - :ref:`Reference.HolidayCalendar <module-daml-finance-data-reference-holidaycalendar-10773>`:
   A holiday calendar of an entity (typically an exchange or a currency)
 - :ref:`Time.DateClock.Types <module-daml-finance-data-time-dateclock-types-48777>`:
-  A date type which can be converted to time, and time-related utility funtions
+  A date type which can be converted to time, and time-related utility functions
 - :ref:`Time.DateClock <module-daml-finance-data-time-dateclock-65212>`:
   A contract specifying what is the current local date. It is used to inject date information in
   lifecycle processing rules

--- a/docs/2.6.4/docs/daml-finance/tutorials/getting-started/intro.rst
+++ b/docs/2.6.4/docs/daml-finance/tutorials/getting-started/intro.rst
@@ -35,7 +35,7 @@ Reference App
 *************
 
 In addition to Daml Finance, there is also a separate ``Daml Finance Reference App``. It showcases
-several of the Daml Finance capabilites in a web-based graphical user interface.
+several of the Daml Finance capabilities in a web-based graphical user interface.
 
 If you are interested in trying out the app locally, you can clone the
 corresponding repo and follow the installation instructions on the

--- a/docs/2.6.4/docs/daml-finance/tutorials/getting-started/settlement.rst
+++ b/docs/2.6.4/docs/daml-finance/tutorials/getting-started/settlement.rst
@@ -56,7 +56,7 @@ We first give a quick outline of the settlement process:
 +--------------------+-----------------------------------------------------------------------------+
 | 4. Settle the      | A :ref:`Batch <type-daml-finance-interface-settlement-batch-batch-97497>`   |
 |    batch           | contract is used to settle all instructions atomically according to the     |
-|                    | specified preferences (e.g. by transfering all allocated holdings to the    |
+|                    | specified preferences (e.g. by transferring all allocated holdings to the    |
 |                    | corresponding receiving accounts).                                          |
 |                    |                                                                             |
 |                    | This batch contract is created in step 2, together with the settlement      |

--- a/docs/2.6.4/docs/daml-finance/tutorials/getting-started/settlement.rst
+++ b/docs/2.6.4/docs/daml-finance/tutorials/getting-started/settlement.rst
@@ -56,7 +56,7 @@ We first give a quick outline of the settlement process:
 +--------------------+-----------------------------------------------------------------------------+
 | 4. Settle the      | A :ref:`Batch <type-daml-finance-interface-settlement-batch-batch-97497>`   |
 |    batch           | contract is used to settle all instructions atomically according to the     |
-|                    | specified preferences (e.g. by transferring all allocated holdings to the    |
+|                    | specified preferences (e.g. by transferring all allocated holdings to the   |
 |                    | corresponding receiving accounts).                                          |
 |                    |                                                                             |
 |                    | This batch contract is created in step 2, together with the settlement      |

--- a/docs/2.6.4/docs/daml-finance/tutorials/getting-started/transfer.rst
+++ b/docs/2.6.4/docs/daml-finance/tutorials/getting-started/transfer.rst
@@ -218,7 +218,7 @@ In order to fully understand these instructions, we need to keep in mind the int
 used by our holding implementation.
 
 .. image:: ../../images/interface_hierarchy.png
-  :alt: A diagram of t he interface heirarchy. From left to right, Disclosure, Holding,
+  :alt: A diagram of t he interface hierarchy. From left to right, Disclosure, Holding,
         Transferable, and Fungible are each linked by arrows pointing left. Below is an arrow, also
         pointing left, labelled Implements.
 

--- a/docs/2.6.4/docs/daml-finance/tutorials/instrument-modeling/bond-extension.rst
+++ b/docs/2.6.4/docs/daml-finance/tutorials/instrument-modeling/bond-extension.rst
@@ -162,7 +162,7 @@ Frequently Asked Questions
 How do I transfer or trade a bond?
 ==================================
 
-When you have created a holding on a bond instrument this can be transfered to another party.
+When you have created a holding on a bond instrument this can be transferred to another party.
 This is described in the :doc:`Getting Started: Transfer <../getting-started/transfer>` tutorial.
 
 In order to trade a bond (transfer it in exchange for cash) you can also initiate a delivery versus

--- a/docs/2.6.4/docs/daml-finance/tutorials/instrument-modeling/contingent-claims-on-ledger-vs-on-the-fly.rst
+++ b/docs/2.6.4/docs/daml-finance/tutorials/instrument-modeling/contingent-claims-on-ledger-vs-on-the-fly.rst
@@ -43,7 +43,7 @@ On the other hand, if you need to quickly create a one-off instrument, the on le
 you to create the claims directly from a script, without first having to define a dedicated
 template. Also, if the :doc:`Contingent Claims <../../concepts/contingent-claims>` representation
 is actively used by both counterparties of the trade it could be useful to have it on ledger from a
-transparancy point of view. Similarly, if you need to explicitly keep the
+transparency point of view. Similarly, if you need to explicitly keep the
 :doc:`Contingent Claims <../../concepts/contingent-claims>` representations of older versions of
 the instrument on the ledger, for example for auditing reasons, that would be achieved out of the
 box.

--- a/docs/2.6.4/docs/daml-finance/tutorials/instrument-modeling/equity-extension.rst
+++ b/docs/2.6.4/docs/daml-finance/tutorials/instrument-modeling/equity-extension.rst
@@ -262,7 +262,7 @@ Frequently Asked Questions
 How do I transfer or trade an Equity?
 =====================================
 
-When you have created a holding on an Equity instrument this can be transfered to another party.
+When you have created a holding on an Equity instrument this can be transferred to another party.
 This is described in the :doc:`Getting Started: Transfer <../getting-started/transfer>` tutorial.
 
 In order to trade an Equity (transfer it in exchange for cash) you can also initiate a delivery

--- a/docs/2.6.4/docs/daml-finance/tutorials/instrument-modeling/generic-extension.rst
+++ b/docs/2.6.4/docs/daml-finance/tutorials/instrument-modeling/generic-extension.rst
@@ -64,7 +64,7 @@ function, which is included in :doc:`Contingent Claims <../../concepts/contingen
 How To Trade and Transfer a Generic Instrument
 **********************************************
 
-When you have created a holding on the above instrument it can be transfered to another party. This
+When you have created a holding on the above instrument it can be transferred to another party. This
 is described in :doc:`Getting Started: Transfer <../getting-started/transfer>`.
 
 In order to trade the instrument (transfer it in exchange for cash) you can also initiate a delivery

--- a/docs/2.6.4/docs/daml-finance/tutorials/instrument-modeling/option-extension.rst
+++ b/docs/2.6.4/docs/daml-finance/tutorials/instrument-modeling/option-extension.rst
@@ -61,7 +61,7 @@ Frequently Asked Questions
 How do I transfer or trade an option?
 =====================================
 
-When you have created a holding on an option instrument this can be transfered to another party.
+When you have created a holding on an option instrument this can be transferred to another party.
 This is described in the :doc:`Getting Started: Transfer <../getting-started/transfer>` tutorial.
 
 In order to trade an option (transfer it in exchange for cash) you can also initiate a delivery

--- a/docs/2.6.4/docs/daml-script/index.rst
+++ b/docs/2.6.4/docs/daml-script/index.rst
@@ -240,7 +240,7 @@ the result of parsing the input file as its argument. For example, we
 can initialize our ledger using the ``initialize`` function defined
 above.
 
-Using the previosuly created ``-ledger-parties.json`` file, we can
+Using the previously created ``-ledger-parties.json`` file, we can
 initialize our ledger as follows:
 
 ``daml script --dar .daml/dist/script-example-0.0.1.dar --script-name ScriptExample:initialize --ledger-host localhost --ledger-port 6865 --input-file ledger-parties.json``
@@ -402,7 +402,7 @@ Run Daml Script Against the HTTP JSON API
 
 In some cases, you only have access to the
 :doc:`HTTP JSON API </json-api/index>` but not to the gRPC of a ledger, e.g., on
-`Daml Hub <https://hub.daml.com>`_. For this usecase, Daml
+`Daml Hub <https://hub.daml.com>`_. For this use case, Daml
 script can be run against the JSON API. Note that if you do have
 access to the gRPC Ledger API, running Daml script against the JSON API does
 not have any advantages.

--- a/docs/2.6.4/docs/daml/considerations.rst
+++ b/docs/2.6.4/docs/daml/considerations.rst
@@ -42,7 +42,7 @@ Most components of Daml store state, so deployment techniques that follow statel
 The diagram below shows the components often used in a Daml deployment. High availability is achieved via either active-active (HTTP JSON API Service, sequencer) or active-passive (participant node, mediator) clustering. Node scaling is achieved via horizontal scaling with participant nodes requiring sharding across participants.
 
 .. image:: ./create-apps-intro.png
-   :alt: Common components of a Daml deployment. Starting at top left: The application is connected to the participant node and the HTTP JSON API service. The trigger service is connected to the HTTP JSON API service, the participant node, and OAuth 2.0 Auth Middleware. The participant node is additionally connected directly to the HTTP JSON API service and the sequencer; the sequencer is further connected to the mediator, topology manager, and Postgres HA for Synchronoization layer.
+   :alt: Common components of a Daml deployment. Starting at top left: The application is connected to the participant node and the HTTP JSON API service. The trigger service is connected to the HTTP JSON API service, the participant node, and OAuth 2.0 Auth Middleware. The participant node is additionally connected directly to the HTTP JSON API service and the sequencer; the sequencer is further connected to the mediator, topology manager, and Postgres HA for Synchronization layer.
 
 Next Steps
 **********

--- a/docs/2.6.4/docs/daml/intro/13_Interfaces.rst
+++ b/docs/2.6.4/docs/daml/intro/13_Interfaces.rst
@@ -179,7 +179,7 @@ For instance, both ``Cash`` and ``NFT`` are ``Asset``\s, which means that
 contracts of either template have an owner who can propose to transfer the
 contract to a third party. Thus, you can use Daml Script (see
 :ref:`testing-using-script`) to test that the same contract can be created by
-``Alice`` and successively transfered to ``Bob`` and then ``Charlie``, who then
+``Alice`` and successively transferred to ``Bob`` and then ``Charlie``, who then
 proposes to transfer to ``Dominic``, who rejects the proposal, and finally to
 ``Emily`` before withdrawing the proposal, so in the end the contract remains in
 ``Charlie``'s ownership. This procedure is tested on the ``Cash`` and ``NFT``

--- a/docs/2.6.4/docs/daml/intro/8_Exceptions.rst
+++ b/docs/2.6.4/docs/daml/intro/8_Exceptions.rst
@@ -17,7 +17,7 @@ also has two major downsides. First, it can
 be invasive for operations where aborting the transaction is often the
 desired behavior, e.g., changing division to return ``Either`` or an
 ``Option`` to handle division by zero would be a very invasive change
-and many callsites might not want to handle the error case explicitly.
+and many call sites might not want to handle the error case explicitly.
 Second, and more importantly, this approach does not allow rolling
 back ledger actions that have happened before the point where failure is
 detected; if a contract

--- a/docs/2.6.4/docs/daml/patterns/initaccept.rst
+++ b/docs/2.6.4/docs/daml/patterns/initaccept.rst
@@ -47,7 +47,7 @@ Result Contract
     :end-before: -- END_COIN_ISSUE_AGREEMENT
 
 .. figure:: images/initiateaccept.png
-   :alt: The Intiate and Accept Pattern, showing how the CoinIssueProposal contract (an initiate contract), when accepted, returns the CoinIssueAgreement result contract.
+   :alt: The Initiate and Accept Pattern, showing how the CoinIssueProposal contract (an initiate contract), when accepted, returns the CoinIssueAgreement result contract.
 
    Initiate and Accept pattern diagram
 

--- a/docs/2.6.4/docs/daml/reference/data-types.rst
+++ b/docs/2.6.4/docs/daml/reference/data-types.rst
@@ -62,7 +62,7 @@ Table of built-in primitive types
      - models differences between time values
      - ``seconds 1``, ``seconds (-2)``
      - ``RelTime`` values have microsecond precision with allowed range from `-9,223,372,036,854,775,808ms` to `9,223,372,036,854,775,807ms`
-       There are no literals for ``RelTime``. Instead they are created using one of ``days``, ``hours``, ``minutes``, ``seconds``, ``miliseconds`` and ``microseconds``  (to get these functions, import ``DA.Time``).
+       There are no literals for ``RelTime``. Instead they are created using one of ``days``, ``hours``, ``minutes``, ``seconds``, ``milliseconds`` and ``microseconds``  (to get these functions, import ``DA.Time``).
 
 Escaping Characters
 ===================

--- a/docs/2.6.4/docs/daml/reference/interfaces.rst
+++ b/docs/2.6.4/docs/daml/reference/interfaces.rst
@@ -19,7 +19,7 @@ Configuration
 
 In order to use this new feature, your Daml project needs to
 explicitly target Daml-LF version ``1.15`` or higher which is
-specificed by adding the following line to the project's ``daml.yaml``
+specified by adding the following line to the project's ``daml.yaml``
 file:
 
 .. code-block:: yaml

--- a/docs/2.6.4/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/understanding-ha.rst
+++ b/docs/2.6.4/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/understanding-ha.rst
@@ -5,9 +5,9 @@ High Availability From a Business Perspective
 #############################################
 
 .. IMPORTANT::
-    
-    This section contains information for those unfamiliar with HA and how it is fundamental to operational efficiency. We look at how business goals drive the configuration and operational aspects of the HA deployment. 
-    
+
+    This section contains information for those unfamiliar with HA and how it is fundamental to operational efficiency. We look at how business goals drive the configuration and operational aspects of the HA deployment.
+
     **Those familiar with these principles may skip this page.**
 
 **Definition**
@@ -22,12 +22,12 @@ High Availability From a Business Perspective
     1. Elimination of `single points of failure <https://en.wikipedia.org/wiki/Single_point_of_failure>`_. This means adding or building redundancy into the system so that failure of a component does not mean failure of the entire system.
     2. Reliable crossover. In `redundant systems <https://en.wikipedia.org/wiki/Redundancy_(engineering)>`_, the crossover point itself tends to become a single point of failure. Reliable systems must provide for reliable crossover.
     3. Detection of failures as they occur. If the two principles above are observed, then a user may never see a failure - but the maintenance activity must."
-    
+
 Daml solution design honors these principles by:
 
 1. Eliminating single points of failure through redundant components.
-2. Executing reliable crossover through networking best practices, in conjunction with the Canton transaction consensus protocol, to eliminate partially processed requests. 
-3. Ensuring automated failover when a single failure is detected. 
+2. Executing reliable crossover through networking best practices, in conjunction with the Canton transaction consensus protocol, to eliminate partially processed requests.
+3. Ensuring automated failover when a single failure is detected.
 
 **Useful External Resources**
 
@@ -40,24 +40,24 @@ Daml solution design honors these principles by:
 Availability
 ************
 
-Availability defines whether a system is able to fulfill its intended function over a period of time, i.e. the system works as intended 99.5% or 99.999% of the time. 
+Availability defines whether a system is able to fulfill its intended function over a period of time, i.e. the system works as intended 99.5% or 99.999% of the time.
 
-The inverse is the percentage of time it is expected to fail, such as 0.5% or 0.001%. 
+The inverse is the percentage of time it is expected to fail, such as 0.5% or 0.001%.
 
 Time-based availability
 =======================
 
-Availability is usually measured in whole system uptime percentage, rather than the uptime percentages of separate components. 
+Availability is usually measured in whole system uptime percentage, rather than the uptime percentages of separate components.
 
 A refinement of this metric is *unplanned downtime*, i.e. the amount of time that the system is unexpectedly unavailable. This is because well-published maintenance activities have no business impact whereas unplanned downtime can cause lost revenue, reputational harm, customers switching to a competitor, etc.
 
-The general formula is: 
+The general formula is:
 
     :math:`availability = uptime / (uptime + downtime)`
 
-This formula calculates how many minutes of downtime are allowed in a given period. For example, a system with an availability target of 99.99% can be down for up to 52.56 minutes in an entire year and stay within its availability level. 
+This formula calculates how many minutes of downtime are allowed in a given period. For example, a system with an availability target of 99.99% can be down for up to 52.56 minutes in an entire year and stay within its availability level.
 
-The table below shows estimated downtimes for a number of given availability levels. 
+The table below shows estimated downtimes for a number of given availability levels.
 
 ..  .. list-table:: Availability calculator table
     :widths: 14 14 14 14 14 14 16
@@ -66,9 +66,9 @@ The table below shows estimated downtimes for a number of given availability lev
     - * Availability level
       * Downtime per year
       * Downtime per quarter
-      * Downtime per month 
-      * Downtime per week 
-      * Downtime per day 
+      * Downtime per month
+      * Downtime per week
+      * Downtime per day
       * Downtime per hour
     - * 90%
       * 36.52 days
@@ -154,23 +154,23 @@ The table below shows estimated downtimes for a number of given availability lev
 
 Data like this helps a business define an error budget or "the maximum amount of time that a technical system can fail without contractual consequences.”[#f2]_ which may also be a KPI for SREs.
 
-For example, over a 30 day (43,200 minutes) time-window, with an availability target of 99.9%, the system must not be down for more than 43.2 minutes. This 43.2 minute figure is a concrete target to plan around, and is often referred to as the error budget. If you exceed 43.2 minutes of downtime over 30 days, you fail to meet your availability goal. 
+For example, over a 30 day (43,200 minutes) time-window, with an availability target of 99.9%, the system must not be down for more than 43.2 minutes. This 43.2 minute figure is a concrete target to plan around, and is often referred to as the error budget. If you exceed 43.2 minutes of downtime over 30 days, you fail to meet your availability goal.
 
 Aggregate request availability
 ==============================
 
-In contrast to time-based availabilty, the fine-grained aggregate request availability metric considers the number of failed requests i.e. x% of total failed requests.
+In contrast to time-based availability, the fine-grained aggregate request availability metric considers the number of failed requests i.e. x% of total failed requests.
 
-This metric is most useful for services that may be partially available or whose load varies over the course of a day or week rather than remaining constant, or to monitor specific, business-critical endpoints. 
+This metric is most useful for services that may be partially available or whose load varies over the course of a day or week rather than remaining constant, or to monitor specific, business-critical endpoints.
 
-The general formula is: 
+The general formula is:
 
     :math:`availability = successfulRequests / totalRequests`
 
 Although not all requests have equal business value, this metric is often calculated over all requests made to the system. For example, a system that serves 2.5M requests per day, with a daily availability target of 99.99%, can serve up to 250 errors and still hit the target.
 
 .. NOTE::
-    If a failing request retries and succeeds, it is not considered failed since the end-user sees no failure. 
+    If a failing request retries and succeeds, it is not considered failed since the end-user sees no failure.
 
 Resiliency
 **********
@@ -189,22 +189,22 @@ Other Common Metrics / RTO and RPO
 
 **Recovery Time Objective** (RTO) is the maximum acceptable delay between the interruption of service and restoration of service. This value determines an acceptable duration over which the service is impaired. It is a slice of the error budget but for a single instance of downtime.
 
-**Recovery Point Objective** (RPO) is the maximum acceptable amount of time since the last data recovery point. This determines the acceptable data loss between the latest recovery point and a service interruption. 
+**Recovery Point Objective** (RPO) is the maximum acceptable amount of time since the last data recovery point. This determines the acceptable data loss between the latest recovery point and a service interruption.
 
-Financial systems often require support for an RPO of zero. 
+Financial systems often require support for an RPO of zero.
 
 HA Cost Trade-Offs
 ******************
 
-High availability can be costly and thus require trade-offs. 
+High availability can be costly and thus require trade-offs.
 
-To illustrate, extreme events that are highly improbable and costly to guard against - such as an asteroid strike that wipes out a continent's data centers - may not need consideration. This highlights the trade-off between the cost of avoiding an outage, the probability of a single failure (single component redundancy), and the probability of multiple simultaneous failures (multiple component, integrated redundancy). 
+To illustrate, extreme events that are highly improbable and costly to guard against - such as an asteroid strike that wipes out a continent's data centers - may not need consideration. This highlights the trade-off between the cost of avoiding an outage, the probability of a single failure (single component redundancy), and the probability of multiple simultaneous failures (multiple component, integrated redundancy).
 
 We can analyze the trade-offs by deriving the cost of loss of availability using unplanned downtime as follows:
 
     :math:`cost = errorBudget * revenueLostPerMinuteOfDowntime`
 
-where the revenue lost per minute of downtime is a projected or measured statistic. 
+where the revenue lost per minute of downtime is a projected or measured statistic.
 
 Use this formula in different configurations to compare increasing cost against availability to determine an appropriate trade-off for your business goals.
 

--- a/docs/2.6.4/docs/getting-started/path-variables.rst
+++ b/docs/2.6.4/docs/getting-started/path-variables.rst
@@ -14,7 +14,7 @@ Set the JAVA_HOME Variable
 1. Search for Advanced System Settings (open ``Search``, type "advanced system settings" and hit ``Enter``).
 2. Find the ``Advanced`` tab and click ``Environment Variables``.
 3. Click ``New`` in the ``System variables`` section (if you want to set ``JAVA_HOME`` system wide) or in the ``User variables`` section (if you want to set ``JAVA_HOME`` for a single user). This will open a modal window for ``Variable name``.
-4. In the ``Variable name`` window type ``JAVA_HOME``, and for the ``Variable value`` set the path to the JDK installation. 
+4. In the ``Variable name`` window type ``JAVA_HOME``, and for the ``Variable value`` set the path to the JDK installation.
 5. Click OK in the ``Variable name`` window.
 6. Click OK in the tab and click Apply to apply the changes.
 
@@ -31,14 +31,14 @@ First, determine whether you are running Bash or zsh. Open a Terminal and run::
         echo $SHELL
 
 This should return either ``/bin/bash``, in which case you are running Bash, or
-``/bin/zsh``, in which case you are running zsh. 
+``/bin/zsh``, in which case you are running zsh.
 
 If you get any other output, you have a non-standard setup. If you're not sure
 how to set up environment variables in your setup, ask on the
 `Daml forum <https://discuss.daml.com>`_ and we will be happy to help.
 
 Open a terminal and run the following commands. Copy/paste one line at a time if possible. None of these should produce any
-output on success. 
+output on success.
 
 To set the variables in **bash**::
 
@@ -51,7 +51,7 @@ To set the variables in **zsh**::
         echo 'export PATH="$HOME/.daml/bin:$PATH"' >> ~/.zprofile
 
 For both shells, the above will update the configuration for future, newly
-opened terminals, but will not affect any exsting one. 
+opened terminals, but will not affect any existing one.
 
 To test the
 configuration of ``JAVA_HOME`` (on either shell), open a new terminal and run::

--- a/docs/2.6.4/docs/tools/assistant.rst
+++ b/docs/2.6.4/docs/tools/assistant.rst
@@ -256,7 +256,7 @@ Run Commands Outside of the Project Directory
 *********************************************
 
 In some cases, it can be convenient to run a command in a project
-without having to change directories. For that usecase, you can set
+without having to change directories. For that use case, you can set
 the ``DAML_PROJECT`` environment variable to the path to the project:
 
 .. code-block:: sh

--- a/docs/2.6.4/docs/triggers/index.rst
+++ b/docs/2.6.4/docs/triggers/index.rst
@@ -61,7 +61,7 @@ Our example for this tutorial builds upon the Getting Started Guide,
 specifically picking up right after the :doc:`/getting-started/first-feature`
 section.
 
-We assume that our requirements are to build a chatbot that reponds to every
+We assume that our requirements are to build a chatbot that responds to every
 message with:
 
   "Please, tell me more about that."
@@ -325,7 +325,7 @@ Command Deduplication
 =====================
 
 Daml Triggers react to many things, and it's usually important to make sure
-that the same command is not sent mutiple times.
+that the same command is not sent multiple times.
 
 For example, in our ``autoReply`` chatbot above, the rule will be triggered not
 only when we receive a message, but also when we send one, as well as when we

--- a/docs/2.7.0/docs/app-dev/custom-views/index.rst
+++ b/docs/2.7.0/docs/app-dev/custom-views/index.rst
@@ -292,7 +292,7 @@ Configuration
 *************
 
 The Custom Views library uses the `Lightbend config library <https://github.com/lightbend/config>`_ for configuration.
-The library is packaged with a ``reference.conf`` file which specifies default settings. The next sections describe the default confguration settings.
+The library is packaged with a ``reference.conf`` file which specifies default settings. The next sections describe the default configuration settings.
 You can override the configuration by using an ``application.conf`` file, see `using the Lightbend config library <https://github.com/lightbend/config#using-the-library>`_ for more details.
 
 Database migration with Flyway

--- a/docs/2.7.0/docs/canton/architecture/requirements/requirements.rst
+++ b/docs/2.7.0/docs/canton/architecture/requirements/requirements.rst
@@ -1,7 +1,7 @@
 ..
      Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates
 ..
-    
+
 ..
      Proprietary code. All rights reserved.
 
@@ -178,7 +178,7 @@ and design limitations :ref:`later in the section
   of the validity requirement on the shared ledger can be violated for
   contracts with no honestly represented signatories, even if I am an observer on the contract.
 
-  .. 
+  ..
      **Exception 2**: The aspects :ref:`key uniqueness <contract-key-uniqueness>` and :ref:`key assertion validity <contract-key-assertion-validity>`
      of the validity requirement on the shared ledger can be violated for
      keys with no honestly represented maintainers, even if I am a non-maintainer stakeholder of contracts with that key.
@@ -333,7 +333,7 @@ and design limitations :ref:`later in the section
 
   .. _seek-support-for-notifications-hlreq:
 
-* **Seek support for notifications**. I want to be able to receive 
+* **Seek support for notifications**. I want to be able to receive
   notifications (about ledger changes and about the decisions on
   my change requests) only from a particular known offset, so that I can
   synchronize my application state with the set of active contracts on
@@ -381,7 +381,7 @@ therefore the Daml compiler will not emit an error or warning if a resource limi
   **Definition:** The maximum number of levels (except for the top-level) in a transaction tree.
 
   **Example:** The following transaction has a depth of 2:
-  
+
   .. image:: ./images/action-structure-paint-offer.svg
      :align: left
      :width: 70%
@@ -446,12 +446,12 @@ section <requirements-exceptions>`.
   action (according to the ledger privacy model) may learn the following:
 
   * How deeply lies the action within a ledger commit.
-    
+
   * How many sibling actions each parent action has.
-    
+
   * The transaction identifiers (but not the transactions' contents)
     that have created the contracts used by the action.
-  
+
   **Design limitation 2**: Domain entities operated by trusted third
   parties may learn the hierarchical structure and stakeholders of all
   actions of the ledger (but none of the contents of the contracts,
@@ -894,7 +894,7 @@ section <requirements-exceptions>`.
   .. todo::
     #. `Large transaction support <https://github.com/DACH-NY/canton/issues/210>`_.
 
-.. _resilience-to-erronous-behavior-hlreq:
+.. _resilience-to-erroneous-behavior-hlreq:
 
 * **Resilience to erroneous behavior**. I want that the system
   to be resilient against erroneous behavior of users and participants
@@ -903,7 +903,7 @@ section <requirements-exceptions>`.
   This item is scheduled on the roadmap.
 
   .. todo::
-    #. `Resilience to errorenous behaviour <https://github.com/DACH-NY/canton/issues/211>`_.
+    #. `Resilience to erroneous behaviour <https://github.com/DACH-NY/canton/issues/211>`_.
 
 .. _resilience-to-faulty-domain-behavior-hlreq:
 

--- a/docs/2.7.0/docs/concepts/glossary.rst
+++ b/docs/2.7.0/docs/concepts/glossary.rst
@@ -11,21 +11,21 @@ Key Concepts
 Daml
 ====
 
-Daml is a platform for building and running sophisticated, multi-party applications. At its core, it contains a smart contract `language <#daml-language>`__ and `tooling <#developer-tools>`__ 
-that defines the schema, semantics, and execution of transactions between parties. Daml includes `Canton <#canton-ledger>`__, a privacy-enabled distributed ledger that is enhanced when deployed 
+Daml is a platform for building and running sophisticated, multi-party applications. At its core, it contains a smart contract `language <#daml-language>`__ and `tooling <#developer-tools>`__
+that defines the schema, semantics, and execution of transactions between parties. Daml includes `Canton <#canton-ledger>`__, a privacy-enabled distributed ledger that is enhanced when deployed
 with complementary blockchains.
 
 Daml Language
 =============
 
-The Daml language is a purpose-built language for rapid development of composable multi-party applications. It is a modern, ergonomically designed functional language that carefully avoids many 
+The Daml language is a purpose-built language for rapid development of composable multi-party applications. It is a modern, ergonomically designed functional language that carefully avoids many
 of the pitfalls that hinder multi-party application development in other languages.
 
 Daml Ledger
 ===========
 
 A Daml ledger is a distributed ledger system running `Daml smart contracts <#contract>`__ according to the :doc:`Daml ledger model </concepts/ledger-model/index>` and exposes the Daml Ledger APIs.
-All current implementations of Daml ledgers consist of a Daml driver that utilises an underlying Synchronization Technology to either implement the Daml ledger directly, or to run the Canton protocol.
+All current implementations of Daml ledgers consist of a Daml driver that utilizes an underlying Synchronization Technology to either implement the Daml ledger directly, or to run the Canton protocol.
 
 Canton Ledger
 -------------
@@ -35,7 +35,7 @@ A Canton ledger is a privacy-enabled Daml ledger implemented using the Canton ap
 Canton Protocol
 ===============
 
-The Canton protocol is the technology which synchronizes `participant nodes <#participant-node>`__ across any Daml-enabled blockchain or database.  The Canton protocol not only makes Daml 
+The Canton protocol is the technology which synchronizes `participant nodes <#participant-node>`__ across any Daml-enabled blockchain or database.  The Canton protocol not only makes Daml
 applications portable between different underlying `synchronization technologies <#synchronization-technology>`__, but also allows applications to transact with each other across them.
 
 .. Synchronization technology.  Not 'Environment', 'Infrastructure layer', 'Messaging layer', 'Topology layer', 'Underlying <enter-any-previous-term>'
@@ -43,13 +43,13 @@ applications portable between different underlying `synchronization technologies
 Synchronization Technology
 ==========================
 
-The syncronization technology is the database or blockchain that Daml uses for synchronization, messaging, and topology. Daml runs on a range of synchronization technologies, from centralized 
+The synchronization technology is the database or blockchain that Daml uses for synchronization, messaging, and topology. Daml runs on a range of synchronization technologies, from centralized
 databases to fully distributed deployments, and users can employ the technology that best suits their technical and operational needs.
 
 Daml Drivers
 ============
 
-Daml drivers enable a `ledger <#daml-ledger>`__ to be implemented on top of different `synchronization technologies <#synchronization-technology>`__; a database or distributed ledger technology. 
+Daml drivers enable a `ledger <#daml-ledger>`__ to be implemented on top of different `synchronization technologies <#synchronization-technology>`__; a database or distributed ledger technology.
 
 Daml Language Concepts
 **********************
@@ -349,7 +349,7 @@ There's a lot of information available about application development, starting w
 Ledger API
 ==========
 
-The **Ledger API** is an API that's exposed by any `ledger <#daml-ledger>`__ on a participant node. Users access and manipulate the ledger state through the leger API.
+The **Ledger API** is an API that's exposed by any `ledger <#daml-ledger>`__ on a participant node. Users access and manipulate the ledger state through the Ledger API.
 An alternative name for the Ledger API is the **gRPC Ledger API** if disambiguation from other technologies is needed.
 See :doc:`/app-dev/ledger-api` page.
 It includes the following :doc:`services </app-dev/services>`.
@@ -438,13 +438,13 @@ A **command** is an instruction to add a transaction to the `ledger <#daml-ledge
 Participant Node
 ================
 
-The participant node is a server that provides users a consistent programmatic access to a ledger through the `Ledger API <#ledger-api>`__. The participant nodes handles transaction signing and 
+The participant node is a server that provides users a consistent programmatic access to a ledger through the `Ledger API <#ledger-api>`__. The participant nodes handles transaction signing and
 validation, such that users don't have to deal with cryptographic primitives but can trust the participant node that the data they are observing has been properly verified to be correct.
 
 Sub-transaction Privacy
 =======================
 
-Sub-transaction privacy is where participants to a transaction only `learn about the subset of the transaction <https://docs.daml.com/concepts/ledger-model/ledger-privacy.html>`__ they are 
+Sub-transaction privacy is where participants to a transaction only `learn about the subset of the transaction <https://docs.daml.com/concepts/ledger-model/ledger-privacy.html>`__ they are
 directly involved in, but not about any other part of the transaction. This applies to both the content of the transaction as well as other involved participants.
 
 Daml-LF
@@ -461,7 +461,7 @@ As a user, you don't need to interact with Daml-LF directly. But internally, it'
 Composability
 =============
 
-Composability is the ability of a participant to extend an existing system with new Daml applications or new topologies unilaterally without requiring cooperation from anyone except the 
+Composability is the ability of a participant to extend an existing system with new Daml applications or new topologies unilaterally without requiring cooperation from anyone except the
 directly involved participants who wish to be part of the new application functionality.
 
 .. _trust-domain:
@@ -481,10 +481,10 @@ Canton Concepts
 Domain
 ======
 
-The domain provides total ordered, guaranteed delivery multi-cast to the participants. This means that participant nodes communicate with each other by sending end-to-end encrypted messages 
-through the domain. 
+The domain provides total ordered, guaranteed delivery multi-cast to the participants. This means that participant nodes communicate with each other by sending end-to-end encrypted messages
+through the domain.
 
-The `sequencer service <#sequencer>`__ of the domain orders these messages without knowing about the content and ensures that every participant receives the messages in the same order. 
+The `sequencer service <#sequencer>`__ of the domain orders these messages without knowing about the content and ensures that every participant receives the messages in the same order.
 
 The other services of the domain are the `mediator <#mediator>`__ and the `domain identity manager <#domain-identity-manager>`__.
 
@@ -496,36 +496,36 @@ Every participant node manages its own private contract store (PCS) which contai
 Virtual Global Ledger
 =====================
 
-While every participant has their own private contract store (PCS), the `Canton protocol <#canton-protocol>`__ guarantees that the contracts which are stored in the PCS are well-authorized 
-and that any change to the store is justified, authorized and valid. The result is that every participant only possesses a small part of the *virtual global ledger*. All the local 
-stores together make up that *virtual global ledger* and they are thus synchronized. The Canton protocol guarantees that the virtual ledger provides integrity, privacy, 
+While every participant has their own private contract store (PCS), the `Canton protocol <#canton-protocol>`__ guarantees that the contracts which are stored in the PCS are well-authorized
+and that any change to the store is justified, authorized and valid. The result is that every participant only possesses a small part of the *virtual global ledger*. All the local
+stores together make up that *virtual global ledger* and they are thus synchronized. The Canton protocol guarantees that the virtual ledger provides integrity, privacy,
 transparency and auditability. The ledger is logically global, even though physically, it runs on segregated and isolated domains that are not aware of each other.
 
 Mediator
 ========
 
-The mediator is a service provided by the `domain <#domain>`__ and used by the `Canton protocol <#canton-protocol>`__. The mediator acts as commit coordinator, collecting individual transaction verdicts issued by validating 
+The mediator is a service provided by the `domain <#domain>`__ and used by the `Canton protocol <#canton-protocol>`__. The mediator acts as commit coordinator, collecting individual transaction verdicts issued by validating
 participants and aggregates them into a single result. The mediator does not learn about the content of the transaction, they only learn about the involved participants.
 
 Sequencer
 =========
 
-The sequencer is a service provided by the `domain <#domain>`__, used by the `Canton protocol <#canton-protocol>`__. The sequencer forwards encrypted addressed messages from participants and ensures that every member receives 
+The sequencer is a service provided by the `domain <#domain>`__, used by the `Canton protocol <#canton-protocol>`__. The sequencer forwards encrypted addressed messages from participants and ensures that every member receives
 the messages in the same order. Think about registered and sealed mail delivered according to the postal datestamp.
 
 Domain Identity Manager
 =======================
 
-The Domain Identity Manager is a service provided by the `domain <#domain>`__, used by the `Canton protocol <#canton-protocol>`__. Participants join a new domain by registering with the domain identity manager. The domain 
+The Domain Identity Manager is a service provided by the `domain <#domain>`__, used by the `Canton protocol <#canton-protocol>`__. Participants join a new domain by registering with the domain identity manager. The domain
 identity manager establishes a consistent identity state among all participants. The domain identity manager only forwards identity updates. It can not invent them.
 
 
 Consensus
 =========
 
-The Canton protocol does not use PBFT or any similar consensus algorithm. There is no proof of work or proof of stake involved. Instead, Canton uses a variant of a stakeholder based 
-two-phase commit protocol. As such, only stakeholders of a transaction are involved in it and need to process it, providing efficiency, privacy and horizontal scalability. Canton based 
-ledgers are resilient to malicious participants as long as there is at least a single honest participant. A domain integration itself might be using the consensus mechanism of the underlying 
+The Canton protocol does not use PBFT or any similar consensus algorithm. There is no proof of work or proof of stake involved. Instead, Canton uses a variant of a stakeholder based
+two-phase commit protocol. As such, only stakeholders of a transaction are involved in it and need to process it, providing efficiency, privacy and horizontal scalability. Canton based
+ledgers are resilient to malicious participants as long as there is at least a single honest participant. A domain integration itself might be using the consensus mechanism of the underlying
 platform, but participant nodes will not be involved in that process.
 
 .. Transaction

--- a/docs/2.7.0/docs/concepts/time.rst
+++ b/docs/2.7.0/docs/concepts/time.rst
@@ -36,7 +36,7 @@ and it is assigned by the backing storage mechanism when the transaction is pers
 
 The record time should be an intuitive representation of "real time",
 but the Daml abstract ledger model does not prescribe exactly how to assign the record time.
-Each persistance technology might use a different way of representing time in a distributed setting.
+Each persistence technology might use a different way of representing time in a distributed setting.
 
 
 .. _time_guarantees:
@@ -109,7 +109,7 @@ The algorithm is not part of the definition of time in Daml, and may change in t
    or if the transaction uses a very fine-grained control flow based on time.
 
 #. At this point, the ledger time may lie in the future (e.g., if a large value for ``min_ledger_time_rel`` was given).
-   The participant waits until ``lt_TX - transaction_latency`` before it submits the transaction to the ledger - 
+   The participant waits until ``lt_TX - transaction_latency`` before it submits the transaction to the ledger -
    the intention is that the transaction is recorded at ``lt_TX == rt_TX``.
 
 Use the parameters ``min_ledger_time_rel`` and ``min_ledger_time_abs`` if you expect that

--- a/docs/2.7.0/docs/daml-finance/concepts/asset-model.rst
+++ b/docs/2.7.0/docs/daml-finance/concepts/asset-model.rst
@@ -250,7 +250,7 @@ Entity, a Securities Depository, and an Investor.
 
 The Issuing Entity acts as ``issuer`` of the :ref:`Equity Instrument
 <type-daml-finance-instrument-equity-instrument-instrument-90430>`. The Securities Depository acts
-as ``depository`` of the instrument, thus preventing the Issuing Entity from single-handledly
+as ``depository`` of the instrument, thus preventing the Issuing Entity from single-handedly
 modifying details of the instrument (such as the share's nominal value).
 
 The Institutional Investor holds units of shares against the Securities Depository, through

--- a/docs/2.7.0/docs/daml-finance/concepts/contingent-claims.rst
+++ b/docs/2.7.0/docs/daml-finance/concepts/contingent-claims.rst
@@ -171,7 +171,7 @@ Concerning Type Parameters
 
 The curious reader may have noticed that the signature we gave for ``data Claim`` is not quite what
 is in the library, where we have ``data Claim t x a o``. In our examples, we have specialised this
-to ``type Claim' t x a o = Claim Date Decimal a a``. Parametrising these variables allows us to
+to ``type Claim' t x a o = Claim Date Decimal a a``. Parameterising these variables allows us to
 reason about ``Asset``\ s and ``Observation``\ s that appear in\ ``Claim``\ s as function-like
 objects. The main use of this is to create claims with ‘placeholders’ for actual parameters, that
 can later be ‘filled in’ by mapping over them (``mapParams``).

--- a/docs/2.7.0/docs/daml-finance/concepts/lifecycling.rst
+++ b/docs/2.7.0/docs/daml-finance/concepts/lifecycling.rst
@@ -7,7 +7,7 @@ Lifecycling
 :ref:`Lifecycling <lifecycling>` refers to the evolution of financial instruments over their
 lifetime. This includes processing of contractual events, like interest payments or coupon
 cashflows, as well as discretionary events, like dividends and other corporate actions. The library
-provides a standard mechanism for processing such events accross different instruments.
+provides a standard mechanism for processing such events across different instruments.
 
 The interfaces for lifecycling are defined in the ``Daml.Finance.Interface.Lifecycle`` package, and
 several default implementations are provided in the ``Daml.Finance.Lifecycle`` package.
@@ -76,7 +76,7 @@ We will now explain each step in the process in detail.
 Creating the event
 ==================
 
-The issuer first creates a new instance of the ``ACME`` instrument, assiging a new version. Note
+The issuer first creates a new instance of the ``ACME`` instrument, assigning a new version. Note
 that the logic to create the new version of an instrument can also be encoded in the lifecycle rule.
 The new version is then automatically produced when processing the event as described in the next
 step.

--- a/docs/2.7.0/docs/daml-finance/overview/intro.rst
+++ b/docs/2.7.0/docs/daml-finance/overview/intro.rst
@@ -45,7 +45,7 @@ Daml Finance optimizes for the following aspects:
 * Extensibility
 
    Various extension points allow customization and extension of the library as required. If an
-   existing implementation does not fulfil the requirements it is straightforward to provide a
+   existing implementation does not fulfill the requirements it is straightforward to provide a
    custom extension.
 
 Scope

--- a/docs/2.7.0/docs/daml-finance/packages/implementations/daml-finance-data.rst
+++ b/docs/2.7.0/docs/daml-finance/packages/implementations/daml-finance-data.rst
@@ -12,7 +12,7 @@ This package implements templates containing reference data. It includes the fol
 - :ref:`Reference.HolidayCalendar <module-daml-finance-data-reference-holidaycalendar-10773>`:
   A holiday calendar of an entity (typically an exchange or a currency)
 - :ref:`Time.DateClock.Types <module-daml-finance-data-time-dateclock-types-48777>`:
-  A date type which can be converted to time, and time-related utility funtions
+  A date type which can be converted to time, and time-related utility functions
 - :ref:`Time.DateClock <module-daml-finance-data-time-dateclock-65212>`:
   A contract specifying what is the current local date. It is used to inject date information in
   lifecycle processing rules

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
@@ -35,7 +35,7 @@ Reference App
 *************
 
 In addition to Daml Finance, there is also a separate ``Daml Finance Reference App``. It showcases
-several of the Daml Finance capabilites in a web-based graphical user interface.
+several of the Daml Finance capabilities in a web-based graphical user interface.
 
 If you are interested in trying out the app locally, you can clone the
 corresponding repo and follow the installation instructions on the

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/settlement.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/settlement.rst
@@ -56,7 +56,7 @@ We first give a quick outline of the settlement process:
 +--------------------+-----------------------------------------------------------------------------+
 | 4. Settle the      | A :ref:`Batch <type-daml-finance-interface-settlement-batch-batch-97497>`   |
 |    batch           | contract is used to settle all instructions atomically according to the     |
-|                    | specified preferences (e.g. by transfering all allocated holdings to the    |
+|                    | specified preferences (e.g. by transferring all allocated holdings to the    |
 |                    | corresponding receiving accounts).                                          |
 |                    |                                                                             |
 |                    | This batch contract is created in step 2, together with the settlement      |

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/settlement.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/settlement.rst
@@ -56,7 +56,7 @@ We first give a quick outline of the settlement process:
 +--------------------+-----------------------------------------------------------------------------+
 | 4. Settle the      | A :ref:`Batch <type-daml-finance-interface-settlement-batch-batch-97497>`   |
 |    batch           | contract is used to settle all instructions atomically according to the     |
-|                    | specified preferences (e.g. by transferring all allocated holdings to the    |
+|                    | specified preferences (e.g. by transferring all allocated holdings to the   |
 |                    | corresponding receiving accounts).                                          |
 |                    |                                                                             |
 |                    | This batch contract is created in step 2, together with the settlement      |

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/transfer.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/transfer.rst
@@ -218,7 +218,7 @@ In order to fully understand these instructions, we need to keep in mind the int
 used by our holding implementation.
 
 .. image:: ../../images/interface_hierarchy.png
-  :alt: A diagram of t he interface heirarchy. From left to right, Disclosure, Holding,
+  :alt: A diagram of t he interface hierarchy. From left to right, Disclosure, Holding,
         Transferable, and Fungible are each linked by arrows pointing left. Below is an arrow, also
         pointing left, labelled Implements.
 

--- a/docs/2.7.0/docs/daml-finance/tutorials/instrument-extension-packages/bond-extension.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/instrument-extension-packages/bond-extension.rst
@@ -251,7 +251,7 @@ Frequently Asked Questions
 How do I transfer or trade a bond?
 ==================================
 
-When you have created a holding on a bond instrument this can be transfered to another party.
+When you have created a holding on a bond instrument this can be transferred to another party.
 This is described in the :doc:`Getting Started: Transfer <../getting-started/transfer>` tutorial.
 
 In order to trade a bond (transfer it in exchange for cash) you can also initiate a delivery versus

--- a/docs/2.7.0/docs/daml-finance/tutorials/instrument-extension-packages/equity-extension.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/instrument-extension-packages/equity-extension.rst
@@ -306,7 +306,7 @@ Frequently Asked Questions
 How do I transfer or trade an Equity?
 =====================================
 
-When you have created a holding on an Equity instrument this can be transfered to another party.
+When you have created a holding on an Equity instrument this can be transferred to another party.
 This is described in the :doc:`Getting Started: Transfer <../getting-started/transfer>` tutorial.
 
 In order to trade an Equity (transfer it in exchange for cash) you can also initiate a delivery

--- a/docs/2.7.0/docs/daml-finance/tutorials/instrument-extension-packages/option-extension.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/instrument-extension-packages/option-extension.rst
@@ -161,7 +161,7 @@ Frequently Asked Questions
 How do I transfer or trade an option?
 =====================================
 
-When you have created a holding on an option instrument this can be transfered to another party.
+When you have created a holding on an option instrument this can be transferred to another party.
 This is described in the :doc:`Getting Started: Transfer <../getting-started/transfer>` tutorial.
 
 In order to trade an option (transfer it in exchange for cash) you can also initiate a delivery

--- a/docs/2.7.0/docs/daml-finance/tutorials/payoff-modeling/generic-extension.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/payoff-modeling/generic-extension.rst
@@ -170,7 +170,7 @@ election and *electorIsOwner = True*, then only a holding where *owner = alice* 
 How To Trade and Transfer a Generic Instrument
 **********************************************
 
-When you have created a holding on the above instrument it can be transfered to another party. This
+When you have created a holding on the above instrument it can be transferred to another party. This
 is described in :doc:`Getting Started: Transfer <../getting-started/transfer>`.
 
 In order to trade the instrument (transfer it in exchange for cash) you can also initiate a delivery

--- a/docs/2.7.0/docs/daml-script/index.rst
+++ b/docs/2.7.0/docs/daml-script/index.rst
@@ -240,7 +240,7 @@ the result of parsing the input file as its argument. For example, we
 can initialize our ledger using the ``initialize`` function defined
 above.
 
-Using the previosuly created ``-ledger-parties.json`` file, we can
+Using the previously created ``-ledger-parties.json`` file, we can
 initialize our ledger as follows:
 
 ``daml script --dar .daml/dist/script-example-0.0.1.dar --script-name ScriptExample:initialize --ledger-host localhost --ledger-port 6865 --input-file ledger-parties.json``
@@ -417,7 +417,7 @@ Run Daml Script Against the HTTP JSON API
 
 In some cases, you only have access to the
 :doc:`HTTP JSON API </json-api/index>` but not to the gRPC of a ledger, e.g., on
-`Daml Hub <https://hub.daml.com>`_. For this usecase, Daml
+`Daml Hub <https://hub.daml.com>`_. For this use case, Daml
 script can be run against the JSON API. Note that if you do have
 access to the gRPC Ledger API, running Daml script against the JSON API does
 not have any advantages.

--- a/docs/2.7.0/docs/daml/considerations.rst
+++ b/docs/2.7.0/docs/daml/considerations.rst
@@ -42,7 +42,7 @@ Most components of Daml store state, so deployment techniques that follow statel
 The diagram below shows the components often used in a Daml deployment. High availability is achieved via either active-active (HTTP JSON API Service, sequencer) or active-passive (participant node, mediator) clustering. Node scaling is achieved via horizontal scaling with participant nodes requiring sharding across participants.
 
 .. image:: ./create-apps-intro.png
-   :alt: Common components of a Daml deployment. Starting at top left: The application is connected to the participant node and the HTTP JSON API service. The trigger service is connected to the HTTP JSON API service, the participant node, and OAuth 2.0 Auth Middleware. The participant node is additionally connected directly to the HTTP JSON API service and the sequencer; the sequencer is further connected to the mediator, topology manager, and Postgres HA for Synchronoization layer.
+   :alt: Common components of a Daml deployment. Starting at top left: The application is connected to the participant node and the HTTP JSON API service. The trigger service is connected to the HTTP JSON API service, the participant node, and OAuth 2.0 Auth Middleware. The participant node is additionally connected directly to the HTTP JSON API service and the sequencer; the sequencer is further connected to the mediator, topology manager, and Postgres HA for Synchronization layer.
 
 Next Steps
 **********

--- a/docs/2.7.0/docs/daml/intro/13_Interfaces.rst
+++ b/docs/2.7.0/docs/daml/intro/13_Interfaces.rst
@@ -179,7 +179,7 @@ For instance, both ``Cash`` and ``NFT`` are ``Asset``\s, which means that
 contracts of either template have an owner who can propose to transfer the
 contract to a third party. Thus, you can use Daml Script (see
 :ref:`testing-using-script`) to test that the same contract can be created by
-``Alice`` and successively transfered to ``Bob`` and then ``Charlie``, who then
+``Alice`` and successively transferred to ``Bob`` and then ``Charlie``, who then
 proposes to transfer to ``Dominic``, who rejects the proposal, and finally to
 ``Emily`` before withdrawing the proposal, so in the end the contract remains in
 ``Charlie``'s ownership. This procedure is tested on the ``Cash`` and ``NFT``

--- a/docs/2.7.0/docs/daml/intro/8_Exceptions.rst
+++ b/docs/2.7.0/docs/daml/intro/8_Exceptions.rst
@@ -17,7 +17,7 @@ also has two major downsides. First, it can
 be invasive for operations where aborting the transaction is often the
 desired behavior, e.g., changing division to return ``Either`` or an
 ``Option`` to handle division by zero would be a very invasive change
-and many callsites might not want to handle the error case explicitly.
+and many call sites might not want to handle the error case explicitly.
 Second, and more importantly, this approach does not allow rolling
 back ledger actions that have happened before the point where failure is
 detected; if a contract

--- a/docs/2.7.0/docs/daml/patterns/initaccept.rst
+++ b/docs/2.7.0/docs/daml/patterns/initaccept.rst
@@ -47,7 +47,7 @@ Result Contract
     :end-before: -- END_COIN_ISSUE_AGREEMENT
 
 .. figure:: images/initiateaccept.png
-   :alt: The Intiate and Accept Pattern, showing how the CoinIssueProposal contract (an initiate contract), when accepted, returns the CoinIssueAgreement result contract.
+   :alt: The Initiate and Accept Pattern, showing how the CoinIssueProposal contract (an initiate contract), when accepted, returns the CoinIssueAgreement result contract.
 
    Initiate and Accept pattern diagram
 

--- a/docs/2.7.0/docs/daml/reference/data-types.rst
+++ b/docs/2.7.0/docs/daml/reference/data-types.rst
@@ -62,7 +62,7 @@ Table of built-in primitive types
      - models differences between time values
      - ``seconds 1``, ``seconds (-2)``
      - ``RelTime`` values have microsecond precision with allowed range from `-9,223,372,036,854,775,808ms` to `9,223,372,036,854,775,807ms`
-       There are no literals for ``RelTime``. Instead they are created using one of ``days``, ``hours``, ``minutes``, ``seconds``, ``miliseconds`` and ``microseconds``  (to get these functions, import ``DA.Time``).
+       There are no literals for ``RelTime``. Instead they are created using one of ``days``, ``hours``, ``minutes``, ``seconds``, ``milliseconds`` and ``microseconds``  (to get these functions, import ``DA.Time``).
 
 Escaping Characters
 ===================

--- a/docs/2.7.0/docs/daml/reference/interfaces.rst
+++ b/docs/2.7.0/docs/daml/reference/interfaces.rst
@@ -19,7 +19,7 @@ Configuration
 
 In order to use this new feature, your Daml project needs to
 explicitly target Daml-LF version ``1.15`` or higher which is
-specificed by adding the following line to the project's ``daml.yaml``
+specified by adding the following line to the project's ``daml.yaml``
 file:
 
 .. code-block:: yaml

--- a/docs/2.7.0/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/understanding-ha.rst
+++ b/docs/2.7.0/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/understanding-ha.rst
@@ -5,9 +5,9 @@ High Availability From a Business Perspective
 #############################################
 
 .. IMPORTANT::
-    
-    This section contains information for those unfamiliar with HA and how it is fundamental to operational efficiency. We look at how business goals drive the configuration and operational aspects of the HA deployment. 
-    
+
+    This section contains information for those unfamiliar with HA and how it is fundamental to operational efficiency. We look at how business goals drive the configuration and operational aspects of the HA deployment.
+
     **Those familiar with these principles may skip this page.**
 
 **Definition**
@@ -22,12 +22,12 @@ High Availability From a Business Perspective
     1. Elimination of `single points of failure <https://en.wikipedia.org/wiki/Single_point_of_failure>`_. This means adding or building redundancy into the system so that failure of a component does not mean failure of the entire system.
     2. Reliable crossover. In `redundant systems <https://en.wikipedia.org/wiki/Redundancy_(engineering)>`_, the crossover point itself tends to become a single point of failure. Reliable systems must provide for reliable crossover.
     3. Detection of failures as they occur. If the two principles above are observed, then a user may never see a failure - but the maintenance activity must."
-    
+
 Daml solution design honors these principles by:
 
 1. Eliminating single points of failure through redundant components.
-2. Executing reliable crossover through networking best practices, in conjunction with the Canton transaction consensus protocol, to eliminate partially processed requests. 
-3. Ensuring automated failover when a single failure is detected. 
+2. Executing reliable crossover through networking best practices, in conjunction with the Canton transaction consensus protocol, to eliminate partially processed requests.
+3. Ensuring automated failover when a single failure is detected.
 
 **Useful External Resources**
 
@@ -40,24 +40,24 @@ Daml solution design honors these principles by:
 Availability
 ************
 
-Availability defines whether a system is able to fulfill its intended function over a period of time, i.e. the system works as intended 99.5% or 99.999% of the time. 
+Availability defines whether a system is able to fulfill its intended function over a period of time, i.e. the system works as intended 99.5% or 99.999% of the time.
 
-The inverse is the percentage of time it is expected to fail, such as 0.5% or 0.001%. 
+The inverse is the percentage of time it is expected to fail, such as 0.5% or 0.001%.
 
 Time-based availability
 =======================
 
-Availability is usually measured in whole system uptime percentage, rather than the uptime percentages of separate components. 
+Availability is usually measured in whole system uptime percentage, rather than the uptime percentages of separate components.
 
 A refinement of this metric is *unplanned downtime*, i.e. the amount of time that the system is unexpectedly unavailable. This is because well-published maintenance activities have no business impact whereas unplanned downtime can cause lost revenue, reputational harm, customers switching to a competitor, etc.
 
-The general formula is: 
+The general formula is:
 
     :math:`availability = uptime / (uptime + downtime)`
 
-This formula calculates how many minutes of downtime are allowed in a given period. For example, a system with an availability target of 99.99% can be down for up to 52.56 minutes in an entire year and stay within its availability level. 
+This formula calculates how many minutes of downtime are allowed in a given period. For example, a system with an availability target of 99.99% can be down for up to 52.56 minutes in an entire year and stay within its availability level.
 
-The table below shows estimated downtimes for a number of given availability levels. 
+The table below shows estimated downtimes for a number of given availability levels.
 
 ..  .. list-table:: Availability calculator table
     :widths: 14 14 14 14 14 14 16
@@ -66,9 +66,9 @@ The table below shows estimated downtimes for a number of given availability lev
     - * Availability level
       * Downtime per year
       * Downtime per quarter
-      * Downtime per month 
-      * Downtime per week 
-      * Downtime per day 
+      * Downtime per month
+      * Downtime per week
+      * Downtime per day
       * Downtime per hour
     - * 90%
       * 36.52 days
@@ -154,23 +154,23 @@ The table below shows estimated downtimes for a number of given availability lev
 
 Data like this helps a business define an error budget or "the maximum amount of time that a technical system can fail without contractual consequences.”[#f2]_ which may also be a KPI for SREs.
 
-For example, over a 30 day (43,200 minutes) time-window, with an availability target of 99.9%, the system must not be down for more than 43.2 minutes. This 43.2 minute figure is a concrete target to plan around, and is often referred to as the error budget. If you exceed 43.2 minutes of downtime over 30 days, you fail to meet your availability goal. 
+For example, over a 30 day (43,200 minutes) time-window, with an availability target of 99.9%, the system must not be down for more than 43.2 minutes. This 43.2 minute figure is a concrete target to plan around, and is often referred to as the error budget. If you exceed 43.2 minutes of downtime over 30 days, you fail to meet your availability goal.
 
 Aggregate request availability
 ==============================
 
-In contrast to time-based availabilty, the fine-grained aggregate request availability metric considers the number of failed requests i.e. x% of total failed requests.
+In contrast to time-based availability, the fine-grained aggregate request availability metric considers the number of failed requests i.e. x% of total failed requests.
 
-This metric is most useful for services that may be partially available or whose load varies over the course of a day or week rather than remaining constant, or to monitor specific, business-critical endpoints. 
+This metric is most useful for services that may be partially available or whose load varies over the course of a day or week rather than remaining constant, or to monitor specific, business-critical endpoints.
 
-The general formula is: 
+The general formula is:
 
     :math:`availability = successfulRequests / totalRequests`
 
 Although not all requests have equal business value, this metric is often calculated over all requests made to the system. For example, a system that serves 2.5M requests per day, with a daily availability target of 99.99%, can serve up to 250 errors and still hit the target.
 
 .. NOTE::
-    If a failing request retries and succeeds, it is not considered failed since the end-user sees no failure. 
+    If a failing request retries and succeeds, it is not considered failed since the end-user sees no failure.
 
 Resiliency
 **********
@@ -189,22 +189,22 @@ Other Common Metrics / RTO and RPO
 
 **Recovery Time Objective** (RTO) is the maximum acceptable delay between the interruption of service and restoration of service. This value determines an acceptable duration over which the service is impaired. It is a slice of the error budget but for a single instance of downtime.
 
-**Recovery Point Objective** (RPO) is the maximum acceptable amount of time since the last data recovery point. This determines the acceptable data loss between the latest recovery point and a service interruption. 
+**Recovery Point Objective** (RPO) is the maximum acceptable amount of time since the last data recovery point. This determines the acceptable data loss between the latest recovery point and a service interruption.
 
-Financial systems often require support for an RPO of zero. 
+Financial systems often require support for an RPO of zero.
 
 HA Cost Trade-Offs
 ******************
 
-High availability can be costly and thus require trade-offs. 
+High availability can be costly and thus require trade-offs.
 
-To illustrate, extreme events that are highly improbable and costly to guard against - such as an asteroid strike that wipes out a continent's data centers - may not need consideration. This highlights the trade-off between the cost of avoiding an outage, the probability of a single failure (single component redundancy), and the probability of multiple simultaneous failures (multiple component, integrated redundancy). 
+To illustrate, extreme events that are highly improbable and costly to guard against - such as an asteroid strike that wipes out a continent's data centers - may not need consideration. This highlights the trade-off between the cost of avoiding an outage, the probability of a single failure (single component redundancy), and the probability of multiple simultaneous failures (multiple component, integrated redundancy).
 
 We can analyze the trade-offs by deriving the cost of loss of availability using unplanned downtime as follows:
 
     :math:`cost = errorBudget * revenueLostPerMinuteOfDowntime`
 
-where the revenue lost per minute of downtime is a projected or measured statistic. 
+where the revenue lost per minute of downtime is a projected or measured statistic.
 
 Use this formula in different configurations to compare increasing cost against availability to determine an appropriate trade-off for your business goals.
 

--- a/docs/2.7.0/docs/getting-started/path-variables.rst
+++ b/docs/2.7.0/docs/getting-started/path-variables.rst
@@ -14,7 +14,7 @@ Set the JAVA_HOME Variable
 1. Search for Advanced System Settings (open ``Search``, type "advanced system settings" and hit ``Enter``).
 2. Find the ``Advanced`` tab and click ``Environment Variables``.
 3. Click ``New`` in the ``System variables`` section (if you want to set ``JAVA_HOME`` system wide) or in the ``User variables`` section (if you want to set ``JAVA_HOME`` for a single user). This will open a modal window for ``Variable name``.
-4. In the ``Variable name`` window type ``JAVA_HOME``, and for the ``Variable value`` set the path to the JDK installation. 
+4. In the ``Variable name`` window type ``JAVA_HOME``, and for the ``Variable value`` set the path to the JDK installation.
 5. Click OK in the ``Variable name`` window.
 6. Click OK in the tab and click Apply to apply the changes.
 
@@ -31,14 +31,14 @@ First, determine whether you are running Bash or zsh. Open a Terminal and run::
         echo $SHELL
 
 This should return either ``/bin/bash``, in which case you are running Bash, or
-``/bin/zsh``, in which case you are running zsh. 
+``/bin/zsh``, in which case you are running zsh.
 
 If you get any other output, you have a non-standard setup. If you're not sure
 how to set up environment variables in your setup, ask on the
 `Daml forum <https://discuss.daml.com>`_ and we will be happy to help.
 
 Open a terminal and run the following commands. Copy/paste one line at a time if possible. None of these should produce any
-output on success. 
+output on success.
 
 To set the variables in **bash**::
 
@@ -51,7 +51,7 @@ To set the variables in **zsh**::
         echo 'export PATH="$HOME/.daml/bin:$PATH"' >> ~/.zprofile
 
 For both shells, the above will update the configuration for future, newly
-opened terminals, but will not affect any exsting one. 
+opened terminals, but will not affect any existing one.
 
 To test the
 configuration of ``JAVA_HOME`` (on either shell), open a new terminal and run::

--- a/docs/2.7.0/docs/tools/assistant.rst
+++ b/docs/2.7.0/docs/tools/assistant.rst
@@ -256,7 +256,7 @@ Run Commands Outside of the Project Directory
 *********************************************
 
 In some cases, it can be convenient to run a command in a project
-without having to change directories. For that usecase, you can set
+without having to change directories. For that use case, you can set
 the ``DAML_PROJECT`` environment variable to the path to the project:
 
 .. code-block:: sh

--- a/docs/2.7.0/docs/triggers/index.rst
+++ b/docs/2.7.0/docs/triggers/index.rst
@@ -61,7 +61,7 @@ Our example for this tutorial builds upon the Getting Started Guide,
 specifically picking up right after the :doc:`/getting-started/first-feature`
 section.
 
-We assume that our requirements are to build a chatbot that reponds to every
+We assume that our requirements are to build a chatbot that responds to every
 message with:
 
   "Please, tell me more about that."
@@ -325,7 +325,7 @@ Command Deduplication
 =====================
 
 Daml Triggers react to many things, and it's usually important to make sure
-that the same command is not sent mutiple times.
+that the same command is not sent multiple times.
 
 For example, in our ``autoReply`` chatbot above, the rule will be triggered not
 only when we receive a message, but also when we send one, as well as when we


### PR DESCRIPTION
I'm sorry that my end-of-line white spaces trimmer is adding all that noise; I hope that you'll forgive me. To spell check, I 
```
$ for f in $(find . -type f -name "*.rst" ); do echo $f ; aspell list < $f ; done | sort | uniq -c > wrong.txt
```

and then manually scanned the result and fixed it in vscode. 99% of the result are false positives, but it took me about 20 minutes to scan through the entire list.