### PR TITLE
Improve the sample dot command call

### DIFF
--- a/docs/2.7.0/docs/tools/visual.rst
+++ b/docs/2.7.0/docs/tools/visual.rst
@@ -12,7 +12,7 @@ You can generate visual graphs for the contracts in your Daml project. To do thi
 2. Open a terminal and navigate to your project root directory.
 3. Generate a DAR from your project by running ``daml build -o project.dar``.
 4. Generate a `dot file <https://en.wikipedia.org/wiki/DOT_(graph_description_language)>`_ from that DAR by running ``daml damlc visual project.dar --dot project.dot``
-5. Generate the visual graph with Graphviz by running ``dot -Tpng project.dot > project.png``
+5. Generate the visual graph with Graphviz by running ``dot -T png project.dot -o project.png``
 
 You can of course choose different names for the files, as long as you're consistent between file creation and point of use.
 


### PR DESCRIPTION
In Windows PowerShell, the command `dot -Tpng .\daml-project.dot > daml-project.png` does not create a valid PNG file. Apparently, the `>` of the binary file did not work properly. Instead I used `dot -T png .\daml-project.dot -o daml-project.png` with `-o` instead of `>`. That is probably the preferred way.