### PR TITLE
skip broken snapshot

### DIFF
--- a/bin/publish-snapshots
+++ b/bin/publish-snapshots
@@ -53,7 +53,9 @@ for version in $snapshots; do
   elif [ "$version" = "2.0.1-snapshot.20220419.9374.0.44df8f12" ] \
     || [ "$version" = "2.1.0-snapshot.20220411.9707.0.f6fed6ea" ] \
     || [ "$version" = "2.5.0-snapshot.20221010.10736.0.2f453a14" ] \
-    || [ "$version" = "2.7.0-snapshot.20230327.11615.0.9aa586fb" ]
+    || [ "$version" = "2.7.0-snapshot.20230327.11615.0.9aa586fb" ] \
+    || [ "$version" = "2.7.0-snapshot.20230515.11783.0.36293a4e" ] \
+    ;
   then echo " -> Skipping, known broken."
   else
     base=${version%-*}


### PR DESCRIPTION
The canton side of the docs is broken in (at least) two ways for this release:

1. There's a path issue with the literalinclude of Identifier.scala, which could be resolved by modifying setup-sphinx-source-tree.
2. There's a reference to a missing config file, which we can't really solve on this side of things.