### PR TITLE
fix bump

### DIFF
--- a/bin/publish-snapshots
+++ b/bin/publish-snapshots
@@ -46,16 +46,24 @@ graphql() (
   '
 )
 
+broken() (
+  version=$1
+  read -d '' known_broken <<'EOF'
+2.0.1-snapshot.20220419.9374.0.44df8f12
+2.1.0-snapshot.20220411.9707.0.f6fed6ea
+2.5.0-snapshot.20221010.10736.0.2f453a14
+2.7.0-snapshot.20230327.11615.0.9aa586fb
+2.7.0-snapshot.20230515.11783.0.36293a4e
+2.7.0-snapshot.20230518.11799.0.50b2c595
+EOF
+  echo "$known_broken" | grep $version >/dev/null
+)
+
 for version in $snapshots; do
   echo "> $version"
   if curl -Ifs https://docs.daml.com/$version/index.html &> /dev/null
   then echo "-> Nothing to do."
-  elif [ "$version" = "2.0.1-snapshot.20220419.9374.0.44df8f12" ] \
-    || [ "$version" = "2.1.0-snapshot.20220411.9707.0.f6fed6ea" ] \
-    || [ "$version" = "2.5.0-snapshot.20221010.10736.0.2f453a14" ] \
-    || [ "$version" = "2.7.0-snapshot.20230327.11615.0.9aa586fb" ] \
-    || [ "$version" = "2.7.0-snapshot.20230515.11783.0.36293a4e" ] \
-    ;
+  elif broken $version
   then echo " -> Skipping, known broken."
   else
     base=${version%-*}

--- a/docs/2.7.0/bin/deps
+++ b/docs/2.7.0/bin/deps
@@ -52,7 +52,9 @@ list() (
          --location \
          --silent \
       | jq -r '.children[].uri' \
-      | sed -e 's/^\///'
+      | sed -e 's/^\///' \
+      | grep -P '^\d+\.\d+\.\d+' \
+      | sort -V
 )
 
 fetch() (


### PR DESCRIPTION
Also mark latest snapshot as broken as it is broken.

Note: `bump` has not been ran as part of this PR because of https://github.com/digital-asset/daml/pull/16899, which requires https://github.com/digital-asset/docs.daml.com/pull/287.