### PR TITLE
correct js and java codegen daml finance for 2.6.4 and 2.7.0

### DIFF
--- a/docs/2.6.4/docs/daml-finance/tutorials/getting-started/intro.rst
+++ b/docs/2.6.4/docs/daml-finance/tutorials/getting-started/intro.rst
@@ -50,14 +50,14 @@ If you want to create a *JavaScript* app that uses Daml Finance, it is possible 
 
 .. code-block:: shell
 
-   daml codegen js -o ./output daml-finance-interface-swap.dar daml-finance-interface-instrument-bond.dar
+   daml codegen js -o ./output .lib/daml-finance-interface-instrument-swap.dar .lib/daml-finance-interface-instrument-bond.dar
 
 Alternatively, if your app uses *Java*, you can run
 `daml codegen java <https://docs.daml.com/app-dev/bindings-java/index.html>`_ in a similar way:
 
 .. code-block:: shell
 
-   daml codegen java -o ./output daml-finance-interface-swap.dar daml-finance-interface-instrument-bond.dar
+   daml codegen java -o ./output .lib/daml-finance-interface-instrument-swap.dar .lib/daml-finance-interface-instrument-bond.dar
 
 Note, this Daml Finance codegen is only supported on SDK versions 2.5.x and higher.
 

--- a/docs/2.6.4/docs/daml-finance/tutorials/getting-started/intro.rst
+++ b/docs/2.6.4/docs/daml-finance/tutorials/getting-started/intro.rst
@@ -50,14 +50,14 @@ If you want to create a *JavaScript* app that uses Daml Finance, it is possible 
 
 .. code-block:: shell
 
-   daml codegen js -o ./output daml-finance-interface-swap-0.1.7.dar daml-finance-interface-instrument-bond-0.1.7.dar
+   daml codegen js -o ./output daml-finance-interface-swap.dar daml-finance-interface-instrument-bond.dar
 
 Alternatively, if your app uses *Java*, you can run
 `daml codegen java <https://docs.daml.com/app-dev/bindings-java/index.html>`_ in a similar way:
 
 .. code-block:: shell
 
-   daml codegen java -o ./output daml-finance-interface-swap-0.1.7.dar daml-finance-interface-instrument-bond-0.1.7.dar
+   daml codegen java -o ./output daml-finance-interface-swap.dar daml-finance-interface-instrument-bond.dar
 
 Note, this Daml Finance codegen is only supported on SDK versions 2.5.x and higher.
 

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
@@ -50,14 +50,14 @@ If you want to create a *JavaScript* app that uses Daml Finance, it is possible 
 
 .. code-block:: shell
 
-   daml codegen js -o ./output daml-finance-interface-swap.dar daml-finance-interface-instrument-bond.dar
+   daml codegen js -o ./output .lib/daml-finance-interface-instrument-swap.dar .lib/daml-finance-interface-instrument-bond.dar
 
 Alternatively, if your app uses *Java*, you can run
 `daml codegen java <https://docs.daml.com/app-dev/bindings-java/index.html>`_ in a similar way:
 
 .. code-block:: shell
 
-   daml codegen java -o ./output daml-finance-interface-swap.dar daml-finance-interface-instrument-bond.dar
+   daml codegen java -o ./output .lib/daml-finance-interface-instrument-swap.dar .lib/daml-finance-interface-instrument-bond.dar
 
 Note, this Daml Finance codegen is only supported on SDK versions 2.5.x and higher.
 

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
@@ -50,14 +50,14 @@ If you want to create a *JavaScript* app that uses Daml Finance, it is possible 
 
 .. code-block:: shell
 
-   daml codegen js -o ./output daml-finance-interface-swap-0.1.7.dar daml-finance-interface-instrument-bond-0.1.7.dar
+   daml codegen js -o ./output daml-finance-interface-swap.dar daml-finance-interface-instrument-bond.dar
 
 Alternatively, if your app uses *Java*, you can run
 `daml codegen java <https://docs.daml.com/app-dev/bindings-java/index.html>`_ in a similar way:
 
 .. code-block:: shell
 
-   daml codegen java -o ./output daml-finance-interface-swap-0.1.7.dar daml-finance-interface-instrument-bond-0.1.7.dar
+   daml codegen java -o ./output daml-finance-interface-swap.dar daml-finance-interface-instrument-bond.dar
 
 Note, this Daml Finance codegen is only supported on SDK versions 2.5.x and higher.
 


### PR DESCRIPTION
The libs used for codegen are no longer versioned -- correct in the docs

Fixes https://github.com/digital-asset/daml-finance/issues/841