### PR TITLE
Move daml finance codegen section

### DIFF
--- a/docs/2.7.0/docs/daml-finance/overview/building-applications.rst
+++ b/docs/2.7.0/docs/daml-finance/overview/building-applications.rst
@@ -54,7 +54,7 @@ that your application follows a similar split between interface (API) and implem
 order to maximize upgradability and minimize the impact of incremental changes to your application
 or Daml Finance.
 
-The following picture shows a suggested architecture that minimizes undesireable coupling and
+The following picture shows a suggested architecture that minimizes undesirable coupling and
 optimizes for upgradability of your application:
 
 .. image:: ../images/application_architecture.png

--- a/docs/2.7.0/docs/daml-finance/overview/building-applications.rst
+++ b/docs/2.7.0/docs/daml-finance/overview/building-applications.rst
@@ -105,3 +105,26 @@ overall application:
 
 In general, we will provide upgrade contracts and scripts to facilitate migration between major
 version updates of packages within the Daml Finance perimeter.
+
+Using Daml Codegen
+******************
+
+The Daml Finance packages are compatible with the :doc:`Daml Codegen tool<../../tools/codegen>`.
+
+If you, e.g., want to create a *JavaScript* app that uses Daml Finance, it is possible to generate
+*JavaScript* classes from the Daml Finance packages you need. Use
+:doc:`daml codegen js <../../app-dev/bindings-ts/daml2js>`, for example:
+
+.. code-block:: shell
+
+   daml codegen js -o ./output .lib/daml-finance-interface-instrument-swap.dar .lib/daml-finance-interface-instrument-bond.dar
+
+Alternatively, if your app uses *Java*, you can run
+:doc:`daml codegen java <../../app-dev/bindings-java/index>` in a similar way:
+
+.. code-block:: shell
+
+   daml codegen java -o ./output .lib/daml-finance-interface-instrument-swap.dar .lib/daml-finance-interface-instrument-bond.dar
+
+Note, this Daml Finance codegen is only supported on SDK versions 2.5.x and higher.
+

--- a/docs/2.7.0/docs/daml-finance/overview/building-applications.rst
+++ b/docs/2.7.0/docs/daml-finance/overview/building-applications.rst
@@ -117,14 +117,14 @@ If you, e.g., want to create a *JavaScript* app that uses Daml Finance, it is po
 
 .. code-block:: shell
 
-   daml codegen js -o ./output .lib/daml-finance-interface-instrument-swap.dar .lib/daml-finance-interface-instrument-bond.dar
+   daml codegen js -o ./output .lib/daml-finance-interface-instrument-swap-0.2.1.dar .lib/daml-finance-interface-instrument-bond-0.2.1.dar
 
 Alternatively, if your app uses *Java*, you can run
 :doc:`daml codegen java <../../app-dev/bindings-java/index>` in a similar way:
 
 .. code-block:: shell
 
-   daml codegen java -o ./output .lib/daml-finance-interface-instrument-swap.dar .lib/daml-finance-interface-instrument-bond.dar
+   daml codegen java -o ./output .lib/daml-finance-interface-instrument-swap-0.2.1.dar .lib/daml-finance-interface-instrument-bond-0.2.1.dar
 
 Note, this Daml Finance codegen is only supported on SDK versions 2.5.x and higher.
 

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
@@ -41,26 +41,6 @@ If you are interested in trying out the app locally, you can clone the
 corresponding repo and follow the installation instructions on the
 `Daml Finance Reference App GitHub page <https://github.com/digital-asset/daml-finance-app>`_.
 
-Create your own App
-*******************
-
-If you want to create a *JavaScript* app that uses Daml Finance, it is possible to generate
-*JavaScript* code from the Daml Finance packages you need. Simply run
-`daml codegen js <https://docs.daml.com/app-dev/bindings-ts/daml2js.html>`_, for example:
-
-.. code-block:: shell
-
-   daml codegen js -o ./output .lib/daml-finance-interface-instrument-swap.dar .lib/daml-finance-interface-instrument-bond.dar
-
-Alternatively, if your app uses *Java*, you can run
-`daml codegen java <https://docs.daml.com/app-dev/bindings-java/index.html>`_ in a similar way:
-
-.. code-block:: shell
-
-   daml codegen java -o ./output .lib/daml-finance-interface-instrument-swap.dar .lib/daml-finance-interface-instrument-bond.dar
-
-Note, this Daml Finance codegen is only supported on SDK versions 2.5.x and higher.
-
 Next Steps
 **********
 


### PR DESCRIPTION
- fix typo
- move section explaining how to run the codegen from "getting started" to "building applications"
- replace URL link with `:doc:` link

For @digital-asset/daml-docs fyi, the [codegen page](https://docs.daml.com/tools/codegen.html)
- is disconnected from example explaining how to use the tool, such as [here](https://docs.daml.com/app-dev/bindings-ts/daml2js.html) and [here](https://docs.daml.com/app-dev/bindings-java/index.html)
- references a GH issue that has been closed 2.5 years ago