### PR TITLE
temporarily remove dev from dropdown

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,13 +162,14 @@ jobs:
              make_dropdown() (
                  dev=$(cd docs; echo * | tr ' ' '\n' | sort -V | tail -1)
                  cat $DIR/dropdown_versions \
-                  | to_version_json_format \
-                  | jq --arg dev "$dev" \
-                       '
-                       .
-                       | to_entries
-                       | [.[0], {"key": $dev, "value": ($dev + " preview")}] + .[1:]
-                       | from_entries'
+                  | to_version_json_format
+                  #\
+                  #| jq --arg dev "$dev" \
+                  #     '
+                  #     .
+                  #     | to_entries
+                  #     | [.[0], {"key": $dev, "value": ($dev + " preview")}] + .[1:]
+                  #     | from_entries'
              )
 
              root=$(cat root)


### PR DESCRIPTION
The daml assistant (`daml` cli utility) depends on the `versions.json` file (it really shouldn't, but here we are). This means that it now reports `2.7.0` as the latest available version, and that's bad as that doesn't exist yet.

It also means we can't currently do smart things for the docs like having versions per minor instead of per patch (i.e. `docs/2.6` instead of `docs/2.6.4` that we need to rename when a 2.6.5 comes out).

We clearly do want a version of the dropdown that includes the dev preview, but the current solution is not working out. I'm disabling it temporarily and will be looking into finding a better one over the next couple days.