### PR TITLE
fix live-preview for canton

### DIFF
--- a/docs/2.7.0/bin/live-preview
+++ b/docs/2.7.0/bin/live-preview
@@ -24,5 +24,16 @@ $DIR/setup-sphinx-source-tree
 DATE=$(date +"%Y-%m-%d")
 echo { \"$DATE\" : \"$DATE\" } >  $BUILD_DIR/gen/versions.json
 
+## Canton Snippets workaround: disable canton snippets
+SPHINX_DIR=$DIR/../workdir/build/source
+cp $SPHINX_DIR/source/canton/exts/snippets.py $SPHINX_DIR/configs/static/
+sed -i "s/'sphinx.ext.extlinks',/'sphinx.ext.extlinks','snippets',/" $SPHINX_DIR/configs/html/conf.py
+for f in $(cd $DIR/../docs; find canton -type f); do
+  mkdir -p $SPHINX_DIR/source/$(dirname $f)
+  rm -f $SPHINX_DIR/source/$f
+  ln $DIR/../docs/$f $SPHINX_DIR/source/$f
+done
+## End Canton workaround
+
 cd $DIR/..
 sphinx-autobuild -c $BUILD_DIR/source/configs/html $BUILD_DIR/source/source $BUILD_DIR/gen

--- a/docs/2.7.0/docs/canton/architecture/domains/domains.rst
+++ b/docs/2.7.0/docs/canton/architecture/domains/domains.rst
@@ -284,7 +284,7 @@ ranging from a relational database to a distributed blockchain. Components can
 be shared among integrations, for example, a mediator implemented on a
 relational database can be used together with a blockchain-based sequencer.
 
-.. toctree::
+.. .. toctree::
    :maxdepth: 1
 
    ethereum.rst

--- a/docs/2.7.0/docs/canton/exts/snippets.py
+++ b/docs/2.7.0/docs/canton/exts/snippets.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+
+class IgnoreSnippets(Directive):
+    has_content = True
+    def run(self):
+        p = nodes.important()
+        p += nodes.paragraph(text="Snippet removed for live-preview.")
+        return [p]
+
+def setup(app):
+    app.add_directive('snippet', IgnoreSnippets)

--- a/docs/2.7.0/docs/canton/usermanual/domains/domains.rst
+++ b/docs/2.7.0/docs/canton/usermanual/domains/domains.rst
@@ -11,7 +11,7 @@ Enterprise Drivers
 The Daml Enterprise edition of the Canton ledger provides the following drivers in
 addition to the PostgreSQL-based domain in the open-source edition.
 
-.. toctree::
+.. .. toctree::
    :maxdepth: 1
 
    oracle.rst


### PR DESCRIPTION
Tested:
- Changing text in `canton/tutorials/getting_started.rst` updates as expected.
- Changing a title in `canton/tutorials/getting_started.rst` updates the title in the toc on the left.
- Changing a title in `_toc.yml` refreshes the page and updates the toc on the left with `http://localhost:8000/canton/tutorials/getting_started.html` open.

As far as I can tell it's all working as expected, but I'm not working with `live-preview` much so please report any further issue.