### PR TITLE
fix javadoc search

### DIFF
--- a/docs/2.6.5/bin/build
+++ b/docs/2.6.5/bin/build
@@ -62,6 +62,19 @@ rm -r $BUILD_DIR/sphinx-target/html/.buildinfo $BUILD_DIR/sphinx-target/html/.do
     echo $SMFOOT >> sitemap.xml
 )
 
+# fix java module path because I don't know how to do it in Bazel
+
+(
+    for f in $(find $BUILD_DIR -type f -name search.js); do
+        # See https://stackoverflow.com/questions/52326318/maven-javadoc-search-redirects-to-undefined-url
+        # TL;DR: The JS code in getURLPrefix tries to add the module name to
+        # the URL ("item.m" in the code), but that property is not defined.
+        # We override that function.
+        chmod +w $f
+        echo 'getURLPrefix = function(ui) { return ""; };' >> $f
+    done
+)
+
 # add Finance entries to Hoogle
 
 (

--- a/docs/2.7.0/bin/build
+++ b/docs/2.7.0/bin/build
@@ -62,6 +62,19 @@ rm -r $BUILD_DIR/sphinx-target/html/.buildinfo $BUILD_DIR/sphinx-target/html/.do
     echo $SMFOOT >> sitemap.xml
 )
 
+# fix java module path because I don't know how to do it in Bazel
+
+(
+    for f in $(find $BUILD_DIR -type f -name search.js); do
+        # See https://stackoverflow.com/questions/52326318/maven-javadoc-search-redirects-to-undefined-url
+        # TL;DR: The JS code in getURLPrefix tries to add the module name to
+        # the URL ("item.m" in the code), but that property is not defined.
+        # We override that function.
+        chmod +w $f
+        echo 'getURLPrefix = function(ui) { return ""; };' >> $f
+    done
+)
+
 # add Finance entries to Hoogle
 
 (


### PR DESCRIPTION
This fixes #336. The issue lies in the javadoc produced by the daml repo, but I don't know how to fix it over there, because Bazel. This is an ugly workaround, but it works for now.

Thanks to @wallacekelly-da for reporting.