### PR TITLE
match toc for explicit disclosure page

### DIFF
--- a/docs/2.7.0/_toc.yml
+++ b/docs/2.7.0/_toc.yml
@@ -217,7 +217,7 @@ subtrees:
       - file: app-dev/authorization
         title: "Authorization"
       - file: app-dev/explicit-contract-disclosure
-        title: "Explicit Contract Disclosure (Experimental)"
+        title: "Explicit Contract Disclosure (Alpha)"
   - file: daml/resource-management/index
     subtrees:
     - hidden: False


### PR DESCRIPTION
Since the title of the explicit contract disclosure page changed, update the TOC text to match it.