### PR TITLE
Remove todo for issue 156

### DIFF
--- a/docs/2.7.0/docs/canton/architecture/requirements/requirements.rst
+++ b/docs/2.7.0/docs/canton/architecture/requirements/requirements.rst
@@ -127,9 +127,6 @@ and design limitations :ref:`later in the section
   can resend change requests in case of a restart without adding the
   changes to the ledger twice.
 
-  .. todo::
-      #. `Change request deduplication / disaster recovery <https://github.com/DACH-NY/canton/issues/156>`_
-
   .. _bounded-decision-time-hlreq:
 
 * **Bounded decision time**. I want to be able to learn within some


### PR DESCRIPTION
After fixing the canton todo checker, this todo will be reported and blocks PR merges on the canton repository. Because the related issue has been closed for sometime this todo is simply removed.

Relates to [canton issue 13862](https://github.com/DACH-NY/canton/pull/13862)