### PR TITLE
Fix unnecessary warning when starting the monitoring

### DIFF
--- a/docs/2.7.0/docs/canton/usermanual/monitoring/etc/network-docker-compose.yml
+++ b/docs/2.7.0/docs/canton/usermanual/monitoring/etc/network-docker-compose.yml
@@ -1,10 +1,11 @@
 
 # Create with `docker network create monitoring`
+# Note that `external: false` will fail the docker-compose execution if the network `monitoring` already exists
 
 version: "3.8"
 
 networks:
   default:
     name: monitoring
-    external: true
+    external: false
 


### PR DESCRIPTION
When running the monitoring example with `./dc.sh up -d` then the error `network monitoring declared as external, but could not be found` is reported.

This change defines the "monitoring network" as non-external which prevents this error.

Using `external: true` was helpful during the development only, so that docker-compose could be run many times, and adding new nodes to the network.