### PR TITLE
Clarify KMS permissions

### DIFF
--- a/docs/2.7.0/docs/canton/usermanual/security.rst
+++ b/docs/2.7.0/docs/canton/usermanual/security.rst
@@ -418,23 +418,21 @@ Configure AWS Credentials and Permissions
 When using AWS KMS to directly encrypt the private keys stored in Canton, the AWS KMS needs to be configured
 with the following list of authorized actions (i.e. IAM permissions):
 
-    - `"kms:CreateKey"`
-    - `"kms:ScheduleKeyDeletion"`
-    - `"kms:Encrypt"`
-    - `"kms:Decrypt"`
-    - `"kms:DescribeKey"`
+    - `kms:CreateKey`
+    - `kms:Encrypt`
+    - `kms:Decrypt`
+    - `kms:DescribeKey`
 
 When we rely on AWS KMS to generate, store, and manage the necessary private keys, it must be configured
 with the following list of authorized actions:
 
     - `kms:CreateKey`
-    - `kms:ScheduleKeyDeletion`
     - `kms:Decrypt`
     - `kms:Sign`
     - `kms:DescribeKey`
     - `kms:GetPublicKey`
 
-If you plan to use cross-account key usage then the permissions for key rotation in Canton, namely `kms:CreateKey` and `kms:ScheduleKeyDeletion`, do not have to be configured as they do not apply in that use case.
+If you plan to use cross-account key usage then the permission for key rotation in Canton, namely `kms:CreateKey`, does not have to be configured as it does not apply in that use case.
 
 Canton uses the `standard AWS credential access
 <https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html>`_ to

--- a/docs/2.7.0/docs/canton/usermanual/security.rst
+++ b/docs/2.7.0/docs/canton/usermanual/security.rst
@@ -427,14 +427,14 @@ with the following list of authorized actions (i.e. IAM permissions):
 When we rely on AWS KMS to generate, store, and manage the necessary private keys, it must be configured
 with the following list of authorized actions:
 
-    - `"kms:CreateKey"`
-    - `"kms:ScheduleKeyDeletion"`
-    - `"kms:Decrypt"`
-    - `"kms:Sign"`
-    - `"kms:DescribeKey"`
-    - `"kms:GetPublicKey"`
-    - `kms:ImportKeyMaterial`
-    - `kms:ListKeys`
+    - `kms:CreateKey`
+    - `kms:ScheduleKeyDeletion`
+    - `kms:Decrypt`
+    - `kms:Sign`
+    - `kms:DescribeKey`
+    - `kms:GetPublicKey`
+
+If you plan to use cross-account key usage then the permissions for key rotation in Canton, namely `kms:CreateKey` and `kms:ScheduleKeyDeletion`, do not have to be configured as they do not apply in that use case.
 
 Canton uses the `standard AWS credential access
 <https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html>`_ to


### PR DESCRIPTION
Updated the required permissions for AWS KMS usage and added a note on cross-account key usage.