### PR TITLE
Move Reference App section

### DIFF
--- a/docs/2.7.0/docs/daml-finance/overview/intro.rst
+++ b/docs/2.7.0/docs/daml-finance/overview/intro.rst
@@ -112,12 +112,12 @@ This downloads all required packages and builds the project. You can then run:
 
 to open the code editor and inspect the code.
 
-Reference App
-*************
+Demo Application
+****************
 
-In addition to Daml Finance, there is also a separate ``Daml Finance Reference App``. It showcases
-several of the Daml Finance capabilities in a web-based graphical user interface.
+In addition to Daml Finance, there is also a separate Demo Application, showcasing
+several of the library's capabilities in a web-based graphical user interface.
 
 If you are interested in trying out the app locally, you can clone the
 corresponding repo and follow the installation instructions on the
-`Daml Finance Reference App GitHub page <https://github.com/digital-asset/daml-finance-app>`_.
+`Daml Finance Demo App GitHub page <https://github.com/digital-asset/daml-finance-app>`_.

--- a/docs/2.7.0/docs/daml-finance/overview/intro.rst
+++ b/docs/2.7.0/docs/daml-finance/overview/intro.rst
@@ -111,3 +111,13 @@ This downloads all required packages and builds the project. You can then run:
    daml studio
 
 to open the code editor and inspect the code.
+
+Reference App
+*************
+
+In addition to Daml Finance, there is also a separate ``Daml Finance Reference App``. It showcases
+several of the Daml Finance capabilities in a web-based graphical user interface.
+
+If you are interested in trying out the app locally, you can clone the
+corresponding repo and follow the installation instructions on the
+`Daml Finance Reference App GitHub page <https://github.com/digital-asset/daml-finance-app>`_.

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
@@ -31,16 +31,6 @@ On Windows-based systems execute:
    get-dependencies.bat
    daml studio
 
-Reference App
-*************
-
-In addition to Daml Finance, there is also a separate ``Daml Finance Reference App``. It showcases
-several of the Daml Finance capabilities in a web-based graphical user interface.
-
-If you are interested in trying out the app locally, you can clone the
-corresponding repo and follow the installation instructions on the
-`Daml Finance Reference App GitHub page <https://github.com/digital-asset/daml-finance-app>`_.
-
 Next Steps
 **********
 


### PR DESCRIPTION
I moved the reference to the [Daml Finance Reference App](https://github.com/digital-asset/daml-finance-app) to the main `intro` section.

It was previously sitting in the intro to the getting started tutorials.

I feel that the previous placement positioned the `Reference App` as a graphical-based alternative to the getting started scripts. However, it should not be the case as the Reference App is not documented to a sufficient extent.

Happy to know what you think