### PR TITLE
Fix broken 'Further Reading' links on the 'System Architecture FAQ' page

### DIFF
--- a/docs/2.7.0/docs/canton/usermanual/persistence.rst
+++ b/docs/2.7.0/docs/canton/usermanual/persistence.rst
@@ -484,6 +484,9 @@ appearing too frequent, the queue size can be configured using:
 
 .. literalinclude:: /canton/includes/mirrored/community/app/src/test/resources/documentation-snippets/storage-queue-size.conf
 
+
+.. _backup-and-restore:
+
 Backup and Restore
 ------------------
 

--- a/docs/2.7.0/docs/canton/usermanual/repairing.rst
+++ b/docs/2.7.0/docs/canton/usermanual/repairing.rst
@@ -156,6 +156,8 @@ This guide has demonstrated how to import data from non-Canton Daml Participant 
 lower major version as part of a Canton upgrade.
 
 
+.. _repairing-participants:
+
 Repairing Participants
 ----------------------
 

--- a/docs/2.7.0/docs/ops/system_architecture_faq.rst
+++ b/docs/2.7.0/docs/ops/system_architecture_faq.rst
@@ -80,6 +80,6 @@ To be able to get snapshots from peers securely, nodes regularly exchange “com
 
 **Further Reading:**
 
-- `Repairing Participants <../canton/usermanual/operational_processes.html#repairing-participants>`__
-- `Backup and Restore <../canton/usermanual/operational_processes.html#backup-and-restore>`__
-- `Ledger Pruning <../canton/usermanual/operational_processes.html#ledger-pruning>`__
+- :ref:`Repairing Participants <repairing-participants>`
+- :ref:`Backup and Restore <backup-and-restore>`
+- :ref:`Ledger Pruning <ledger-pruning>`


### PR DESCRIPTION
The links under 'Further Reading' of the 'How is Canton able to recover from data loss?' section target the non-existing
`canton/usermanual/operational_processes.rst` file.

The content of `operational_processes.rst` has been split up into separate files, see [1].

The original fragile and broken links have now been replaced with more robust 'cross-referencing links' [2].

[1] https://github.com/DACH-NY/canton/pull/9673
[2] https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-arbitrary-locations