### PR TITLE
Move jwt documentation to user manual

### DIFF
--- a/docs/2.7.0/docs/canton/usermanual/apis.rst
+++ b/docs/2.7.0/docs/canton/usermanual/apis.rst
@@ -150,11 +150,39 @@ In order to enable JWT authorization checks, your safe configuration options are
 
 .. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/jwt/certificate.conf
 
+- ``jwt-rs-256-crt``.
+  The sandbox will expect all tokens to be signed with RS256 (RSA Signature with SHA-256) with the public key loaded from the given X.509 certificate file.
+  Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
+  and DER-encoded certificates (binary files) are supported.
+
+- ``jwt-es-256-crt``.
+  The sandbox will expect all tokens to be signed with ES256 (ECDSA using P-256 and SHA-256) with the public key loaded from the given X.509 certificate file.
+  Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
+  and DER-encoded certificates (binary files) are supported.
+
+- ``jwt-es-512-crt``.
+  The sandbox will expect all tokens to be signed with ES512 (ECDSA using P-521 and SHA-512) with the public key loaded from the given X.509 certificate file.
+  Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
+  and DER-encoded certificates (binary files) are supported.
+
+Instead of specifying the path to a certificate, you can also a
+`JWKS <https://tools.ietf.org/html/rfc7517>`__ URL. In that case, the
+sandbox will expect all tokens to be signed with RS256 (RSA Signature
+with SHA-256) with the public key loaded from the given JWKS URL.
+
 .. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/jwt/jwks.conf
 
-while there is also unsafe ``HMAC256`` based support, which can be enabled using
+.. warning::
+
+  For testing purposes only, you can also specify a shared secret. In
+  that case, the participant will expect all tokens to be signed with
+  HMAC256 with the given plaintext secret. This is not considered safe for production.
 
 .. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/jwt/unsafe-hmac256.conf
+
+.. note:: To prevent man-in-the-middle attacks, it is highly recommended to use
+          TLS with server authentication as described in :ref:`tls-configuration` for
+          any request sent to the Ledger API in production.
 
 Note that you can define multiple authorization plugins. If more than one is defined, the system will use the claim of the
 first auth plugin that does not return Unauthorized.
@@ -185,6 +213,7 @@ The default audience (``aud`` field in the audience based token) for authenticat
 using the custom target audience configuration option:
 
 .. literalinclude:: /canton/includes/mirrored/community/app/src/test/resources/documentation-snippets/ledger-api-target-audience.conf
+
 
 Domain Configurations
 ---------------------

--- a/docs/2.7.0/docs/canton/usermanual/apis.rst
+++ b/docs/2.7.0/docs/canton/usermanual/apis.rst
@@ -141,33 +141,31 @@ group starts with ``ledger-api`` instead of ``admin-api``.
 JWT Authorization
 ^^^^^^^^^^^^^^^^^
 
-The Ledger Api supports `JWT <https://jwt.io/>`_ based authorization checks. Please consult the
-`Daml SDK manual <https://docs.daml.com/tools/sandbox.html#sandbox-authorization>`_
-to understand the various configuration options and their security aspects. Canton exposes precisely the same
-JWT authorization options as explained therein.
+The Ledger Api supports `JWT <https://jwt.io/>`_ based authorization checks as described in the
+:doc:`Authorization documentation </app-dev/authorization>`.
 
 In order to enable JWT authorization checks, your safe configuration options are
 
 .. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/jwt/certificate.conf
 
 - ``jwt-rs-256-crt``.
-  The sandbox will expect all tokens to be signed with RS256 (RSA Signature with SHA-256) with the public key loaded from the given X.509 certificate file.
+  The participant will expect all tokens to be signed with RS256 (RSA Signature with SHA-256) with the public key loaded from the given X.509 certificate file.
   Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
   and DER-encoded certificates (binary files) are supported.
 
 - ``jwt-es-256-crt``.
-  The sandbox will expect all tokens to be signed with ES256 (ECDSA using P-256 and SHA-256) with the public key loaded from the given X.509 certificate file.
+  The participant will expect all tokens to be signed with ES256 (ECDSA using P-256 and SHA-256) with the public key loaded from the given X.509 certificate file.
   Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
   and DER-encoded certificates (binary files) are supported.
 
 - ``jwt-es-512-crt``.
-  The sandbox will expect all tokens to be signed with ES512 (ECDSA using P-521 and SHA-512) with the public key loaded from the given X.509 certificate file.
+  The participant will expect all tokens to be signed with ES512 (ECDSA using P-521 and SHA-512) with the public key loaded from the given X.509 certificate file.
   Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
   and DER-encoded certificates (binary files) are supported.
 
 Instead of specifying the path to a certificate, you can also a
 `JWKS <https://tools.ietf.org/html/rfc7517>`__ URL. In that case, the
-sandbox will expect all tokens to be signed with RS256 (RSA Signature
+participant will expect all tokens to be signed with RS256 (RSA Signature
 with SHA-256) with the public key loaded from the given JWKS URL.
 
 .. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/jwt/jwks.conf

--- a/docs/2.7.0/docs/canton/usermanual/identity_management.rst
+++ b/docs/2.7.0/docs/canton/usermanual/identity_management.rst
@@ -467,6 +467,24 @@ If you want to prevent a user from accessing the ledger API it may be better to 
 
 .. _canton-add-party-to-a-participant:
 
+
+Configure a default Participant Admin
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Fresh participant nodes come with a default participant admin user called ``participant_admin``, which
+can be used to bootstrap other users.
+You might prefer to have an admin user with a different user id ready on a participant startup.
+For such situations, you can specify an additional participant admin user with the user id of your choice.
+
+.. note:: If a user with the specified id already exists, then no additional user will be created,
+          even if the preexisting user was not an admin user.
+
+.. code-block:: none
+   :caption: additional-admin.conf
+
+   canton.participants.myparticipant.ledger-api.user-management-service.additional-admin-user-id = "my-admin-id"
+
+
 Adding a new Party to a Participant
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The simplest operation is adding a new party to a participant. For this, we add it normally at the topology manager

--- a/docs/2.7.0/docs/tools/sandbox.rst
+++ b/docs/2.7.0/docs/tools/sandbox.rst
@@ -53,68 +53,13 @@ authorization service and the path to the certificate.
        //   jwt-rs-256-crt
        //   jwt-es-256-crt
        //   jwt-es-512-crt
+       //   jwt-rs-256-jwks with an additional url
+       //   unsafe-jwt-hmac-256 with an additional secret
        type = jwt-rs-256-crt
        certificate = my-certificate.cert
    }]
 
-- ``jwt-rs-256-crt``.
-  The sandbox will expect all tokens to be signed with RS256 (RSA Signature with SHA-256) with the public key loaded from the given X.509 certificate file.
-  Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
-  and DER-encoded certificates (binary files) are supported.
-
-- ``jwt-es-256-crt``.
-  The sandbox will expect all tokens to be signed with ES256 (ECDSA using P-256 and SHA-256) with the public key loaded from the given X.509 certificate file.
-  Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
-  and DER-encoded certificates (binary files) are supported.
-
-- ``jwt-es-512-crt``.
-  The sandbox will expect all tokens to be signed with ES512 (ECDSA using P-521 and SHA-512) with the public key loaded from the given X.509 certificate file.
-  Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
-  and DER-encoded certificates (binary files) are supported.
-
-Instead of specifying the path to a certificate, you can also a
-`JWKS <https://tools.ietf.org/html/rfc7517>`__ URL. In that case, the
-sandbox will expect all tokens to be signed with RS256 (RSA Signature
-with SHA-256) with the public key loaded from the given JWKS URL.
-
-.. code-block:: none
-   :caption: auth.conf
-
-   canton.participants.sandbox.ledger-api.auth-services = [{
-       type = jwt-rs-256-jwks
-       url = "https://path.to/jwks.key"
-   }]
-
-.. warning::
-
-  For testing purposes only, you can also specify a shared secret. In
-  that case, the sandbox will expect all tokens to be signed with
-  HMAC256 with the given plaintext secret. This is not considered safe for production.
-
-.. code-block:: none
-   :caption: auth.conf
-
-   canton.participants.sandbox.ledger-api.auth-services = [{
-       type = unsafe-jwt-hmac-256
-       secret = "not-safe-for-production"
-   }]
-
-.. note:: To prevent man-in-the-middle attacks, it is highly recommended to use
-          TLS with server authentication as described in :ref:`sandbox-tls` for
-          any request sent to the Ledger API in production.
-
-Fresh participant nodes come with a default participant admin user called ``participant_admin``, which
-can be used to bootstrap other users.
-You might prefer to have an admin user with a different user id ready on a participant startup.
-For such situations, you can specify an additional participant admin user with the user id of your choice.
-
-.. note:: If a user with the specified id already exists, then no additional user will be created,
-          even if the preexisting user was not an admin user.
-
-.. code-block:: none
-   :caption: additional-admin.conf
-
-   canton.participants.sandbox.ledger-api.user-management-service.additional-admin-user-id = "my-admin-id"
+The settings under ``auth-services`` are described in detail in `API configuration documentation </canton/usermanual/apis.html#jwt-authorization>`__
 
 
 Generate JSON Web Tokens (JWT)

--- a/docs/2.8.0/docs/canton/usermanual/apis.rst
+++ b/docs/2.8.0/docs/canton/usermanual/apis.rst
@@ -150,11 +150,39 @@ In order to enable JWT authorization checks, your safe configuration options are
 
 .. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/jwt/certificate.conf
 
+- ``jwt-rs-256-crt``.
+  The sandbox will expect all tokens to be signed with RS256 (RSA Signature with SHA-256) with the public key loaded from the given X.509 certificate file.
+  Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
+  and DER-encoded certificates (binary files) are supported.
+
+- ``jwt-es-256-crt``.
+  The sandbox will expect all tokens to be signed with ES256 (ECDSA using P-256 and SHA-256) with the public key loaded from the given X.509 certificate file.
+  Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
+  and DER-encoded certificates (binary files) are supported.
+
+- ``jwt-es-512-crt``.
+  The sandbox will expect all tokens to be signed with ES512 (ECDSA using P-521 and SHA-512) with the public key loaded from the given X.509 certificate file.
+  Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
+  and DER-encoded certificates (binary files) are supported.
+
+Instead of specifying the path to a certificate, you can also a
+`JWKS <https://tools.ietf.org/html/rfc7517>`__ URL. In that case, the
+sandbox will expect all tokens to be signed with RS256 (RSA Signature
+with SHA-256) with the public key loaded from the given JWKS URL.
+
 .. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/jwt/jwks.conf
 
-while there is also unsafe ``HMAC256`` based support, which can be enabled using
+.. warning::
+
+  For testing purposes only, you can also specify a shared secret. In
+  that case, the participant will expect all tokens to be signed with
+  HMAC256 with the given plaintext secret. This is not considered safe for production.
 
 .. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/jwt/unsafe-hmac256.conf
+
+.. note:: To prevent man-in-the-middle attacks, it is highly recommended to use
+          TLS with server authentication as described in :ref:`tls-configuration` for
+          any request sent to the Ledger API in production.
 
 Note that you can define multiple authorization plugins. If more than one is defined, the system will use the claim of the
 first auth plugin that does not return Unauthorized.
@@ -185,6 +213,7 @@ The default audience (``aud`` field in the audience based token) for authenticat
 using the custom target audience configuration option:
 
 .. literalinclude:: /canton/includes/mirrored/community/app/src/test/resources/documentation-snippets/ledger-api-target-audience.conf
+
 
 Domain Configurations
 ---------------------

--- a/docs/2.8.0/docs/canton/usermanual/apis.rst
+++ b/docs/2.8.0/docs/canton/usermanual/apis.rst
@@ -141,33 +141,31 @@ group starts with ``ledger-api`` instead of ``admin-api``.
 JWT Authorization
 ^^^^^^^^^^^^^^^^^
 
-The Ledger Api supports `JWT <https://jwt.io/>`_ based authorization checks. Please consult the
-`Daml SDK manual <https://docs.daml.com/tools/sandbox.html#sandbox-authorization>`_
-to understand the various configuration options and their security aspects. Canton exposes precisely the same
-JWT authorization options as explained therein.
+The Ledger Api supports `JWT <https://jwt.io/>`_ based authorization checks as described in the
+:doc:`Authorization documentation </app-dev/authorization>`.
 
 In order to enable JWT authorization checks, your safe configuration options are
 
 .. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/jwt/certificate.conf
 
 - ``jwt-rs-256-crt``.
-  The sandbox will expect all tokens to be signed with RS256 (RSA Signature with SHA-256) with the public key loaded from the given X.509 certificate file.
+  The participant will expect all tokens to be signed with RS256 (RSA Signature with SHA-256) with the public key loaded from the given X.509 certificate file.
   Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
   and DER-encoded certificates (binary files) are supported.
 
 - ``jwt-es-256-crt``.
-  The sandbox will expect all tokens to be signed with ES256 (ECDSA using P-256 and SHA-256) with the public key loaded from the given X.509 certificate file.
+  The participant will expect all tokens to be signed with ES256 (ECDSA using P-256 and SHA-256) with the public key loaded from the given X.509 certificate file.
   Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
   and DER-encoded certificates (binary files) are supported.
 
 - ``jwt-es-512-crt``.
-  The sandbox will expect all tokens to be signed with ES512 (ECDSA using P-521 and SHA-512) with the public key loaded from the given X.509 certificate file.
+  The participant will expect all tokens to be signed with ES512 (ECDSA using P-521 and SHA-512) with the public key loaded from the given X.509 certificate file.
   Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
   and DER-encoded certificates (binary files) are supported.
 
 Instead of specifying the path to a certificate, you can also a
 `JWKS <https://tools.ietf.org/html/rfc7517>`__ URL. In that case, the
-sandbox will expect all tokens to be signed with RS256 (RSA Signature
+participant will expect all tokens to be signed with RS256 (RSA Signature
 with SHA-256) with the public key loaded from the given JWKS URL.
 
 .. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/jwt/jwks.conf

--- a/docs/2.8.0/docs/canton/usermanual/identity_management.rst
+++ b/docs/2.8.0/docs/canton/usermanual/identity_management.rst
@@ -467,6 +467,24 @@ If you want to prevent a user from accessing the ledger API it may be better to 
 
 .. _canton-add-party-to-a-participant:
 
+
+Configure a default Participant Admin
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Fresh participant nodes come with a default participant admin user called ``participant_admin``, which
+can be used to bootstrap other users.
+You might prefer to have an admin user with a different user id ready on a participant startup.
+For such situations, you can specify an additional participant admin user with the user id of your choice.
+
+.. note:: If a user with the specified id already exists, then no additional user will be created,
+          even if the preexisting user was not an admin user.
+
+.. code-block:: none
+   :caption: additional-admin.conf
+
+   canton.participants.myparticipant.ledger-api.user-management-service.additional-admin-user-id = "my-admin-id"
+
+
 Adding a new Party to a Participant
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The simplest operation is adding a new party to a participant. For this, we add it normally at the topology manager

--- a/docs/2.8.0/docs/tools/sandbox.rst
+++ b/docs/2.8.0/docs/tools/sandbox.rst
@@ -53,68 +53,13 @@ authorization service and the path to the certificate.
        //   jwt-rs-256-crt
        //   jwt-es-256-crt
        //   jwt-es-512-crt
+       //   jwt-rs-256-jwks with an additional url
+       //   unsafe-jwt-hmac-256 with an additional secret
        type = jwt-rs-256-crt
        certificate = my-certificate.cert
    }]
 
-- ``jwt-rs-256-crt``.
-  The sandbox will expect all tokens to be signed with RS256 (RSA Signature with SHA-256) with the public key loaded from the given X.509 certificate file.
-  Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
-  and DER-encoded certificates (binary files) are supported.
-
-- ``jwt-es-256-crt``.
-  The sandbox will expect all tokens to be signed with ES256 (ECDSA using P-256 and SHA-256) with the public key loaded from the given X.509 certificate file.
-  Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
-  and DER-encoded certificates (binary files) are supported.
-
-- ``jwt-es-512-crt``.
-  The sandbox will expect all tokens to be signed with ES512 (ECDSA using P-521 and SHA-512) with the public key loaded from the given X.509 certificate file.
-  Both PEM-encoded certificates (text files starting with ``-----BEGIN CERTIFICATE-----``)
-  and DER-encoded certificates (binary files) are supported.
-
-Instead of specifying the path to a certificate, you can also a
-`JWKS <https://tools.ietf.org/html/rfc7517>`__ URL. In that case, the
-sandbox will expect all tokens to be signed with RS256 (RSA Signature
-with SHA-256) with the public key loaded from the given JWKS URL.
-
-.. code-block:: none
-   :caption: auth.conf
-
-   canton.participants.sandbox.ledger-api.auth-services = [{
-       type = jwt-rs-256-jwks
-       url = "https://path.to/jwks.key"
-   }]
-
-.. warning::
-
-  For testing purposes only, you can also specify a shared secret. In
-  that case, the sandbox will expect all tokens to be signed with
-  HMAC256 with the given plaintext secret. This is not considered safe for production.
-
-.. code-block:: none
-   :caption: auth.conf
-
-   canton.participants.sandbox.ledger-api.auth-services = [{
-       type = unsafe-jwt-hmac-256
-       secret = "not-safe-for-production"
-   }]
-
-.. note:: To prevent man-in-the-middle attacks, it is highly recommended to use
-          TLS with server authentication as described in :ref:`sandbox-tls` for
-          any request sent to the Ledger API in production.
-
-Fresh participant nodes come with a default participant admin user called ``participant_admin``, which
-can be used to bootstrap other users.
-You might prefer to have an admin user with a different user id ready on a participant startup.
-For such situations, you can specify an additional participant admin user with the user id of your choice.
-
-.. note:: If a user with the specified id already exists, then no additional user will be created,
-          even if the preexisting user was not an admin user.
-
-.. code-block:: none
-   :caption: additional-admin.conf
-
-   canton.participants.sandbox.ledger-api.user-management-service.additional-admin-user-id = "my-admin-id"
+The settings under ``auth-services`` are described in detail in `API configuration documentation </canton/usermanual/apis.html#jwt-authorization>`__
 
 
 Generate JSON Web Tokens (JWT)


### PR DESCRIPTION
A little rationalization of where the information is located. We prefer general information applicable to all platforms to be in the user manual where everyone can find it. It's not so great when it is located in sandbox where it may seem like only applicable to that tool.

- moved jwt config documentation from sandbox to user manual's api section
- moved additional admin documentation from sandbox to user manual's identity management section