### PR TITLE
Restructuring of holdings tutorial

### DIFF
--- a/docs/2.7.0/_toc.yml
+++ b/docs/2.7.0/_toc.yml
@@ -636,8 +636,8 @@ subtrees:
       - file: daml-finance/tutorials/getting-started/intro
         title: "Getting Started"
         entries:
-        - file: daml-finance/tutorials/getting-started/holding
-          title: "Holding"
+        - file: daml-finance/tutorials/getting-started/holdings
+          title: "Holdings"
         - file: daml-finance/tutorials/getting-started/transfer
           title: "Transfer"
         - file: daml-finance/tutorials/getting-started/settlement

--- a/docs/2.7.0/docs/daml-finance/concepts/asset-model.rst
+++ b/docs/2.7.0/docs/daml-finance/concepts/asset-model.rst
@@ -209,8 +209,8 @@ The account can be created with arbitrary
 In our examples, we typically let accounts be owners-controlled, i.e., both the current owner and
 the new owner must authorize transfers.
 
-Examples
-********
+Example setups
+**************
 
 We can now look at a few examples of how real-world rights and obligations can be modeled using the
 Daml Finance asset model.

--- a/docs/2.7.0/docs/daml-finance/reference/patterns.rst
+++ b/docs/2.7.0/docs/daml-finance/reference/patterns.rst
@@ -6,32 +6,39 @@ Patterns
 
 This page explains some common design patterns used in the Daml Finance library.
 
-.. _factory-concept:
+.. _factory-pattern:
 
-Factory concept
+Factory pattern
 ---------------
 
-Factories are helper contracts that are used to create instruments, holdings and some other
-important contracts. The reason why using factories is a recommended pattern when using Daml Finance
+Factories are helper contracts that are used to create instruments, holdings, and other contracts.
+The reason why using factories is a recommended pattern when using Daml Finance
 has to do with application decoupling / upgradeability of your application.
 
-For example, suppose that you are writing Daml code to issue equity instruments. Your workflow would
-reference the
-:ref:`Equity implementation package <module-daml-finance-instrument-equity-instrument-69265>` v0.2.1
-and at some point do a
-``create Equity.Instrument with issuer = myParty, id = "MyCompany", ..`` to create the instrument.
+For example, suppose that you are writing Daml code to issue equity instruments. Your workflow
+references the version ``0.2.1`` of the
+:ref:`Equity implementation package <module-daml-finance-instrument-equity-instrument-69265>`
+and at some point creates an instrument as follows.
 
-If the equity package gets updated to v0.2.2 and a new field is added to the instrument (or a choice
-is changed, or a new lifecycle event is added, …) then you are forced to upgrade your Daml code in
-order to use the new feature and will have to deal with upgrading multiple templates on the ledger.
+.. code-block:: daml
+
+   create Equity.Instrument with
+     issuer = myParty
+     id = Id "MyCompany"
+     ..
+
+If the equity package gets updated to version ``0.2.2`` and a new field is added to the instrument
+(or a choice is changed, or a new lifecycle event is added, …) then you are forced to upgrade your
+Daml code in order to use the new feature and will have to deal with upgrading multiple templates
+on the ledger.
 
 A safer approach is for your Daml code to only reference the
 :ref:`Equity interface package <module-daml-finance-interface-instrument-equity-instrument-13224>`,
 which contains interface definitions and is updated less frequently.
 
 However, you would now need a way to create equity instruments without referencing
-Daml.Finance.Instrument.Equity in your main Daml workflow. To do this, you can setup a Script to run
-during ledger initialisation that will create a
+``Daml.Finance.Instrument.Equity`` in your main Daml workflow. To do this, you can setup a Script
+to run during ledger initialisation that will create a
 :ref:`factory contract <module-daml-finance-instrument-equity-factory-96899>`
 and cast it to the corresponding
 :ref:`interface <module-daml-finance-interface-instrument-equity-factory-97140>`.
@@ -41,7 +48,7 @@ When an upgraded instrument comes along, you would need to write code to archive
 create the new one, in order to issue the new instruments. However, the Daml code for your workflow
 could in principle stay untouched.
 
-For an example on where the Factory pattern is used, check out the
+For an example where the Factory pattern is used, check out the
 :doc:`Holdings tutorial <../tutorials/getting-started/holdings>`.
 
 .. _getview:

--- a/docs/2.7.0/docs/daml-finance/reference/patterns.rst
+++ b/docs/2.7.0/docs/daml-finance/reference/patterns.rst
@@ -42,7 +42,7 @@ create the new one, in order to issue the new instruments. However, the Daml cod
 could in principle stay untouched.
 
 For an example on where the Factory pattern is used, check out the
-:doc:`Holding tutorial <../tutorials/getting-started/holding>`.
+:doc:`Holdings tutorial <../tutorials/getting-started/holdings>`.
 
 .. _getview:
 

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/holdings.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/holdings.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Holding
-#######
+Holdings
+########
 
 This tutorial introduces the core asset model of the library through a simple example. The purpose
 is to illustrate the concepts of :ref:`account <account>`, :ref:`instrument <instrument>`, and
@@ -18,9 +18,6 @@ We expect the reader to be familiar with the basic building blocks of Daml. If t
 a suitable introduction can be found `here <https://www.digitalasset.com/developers/learn>`_.
 In particular, `An Introduction to Daml <https://docs.daml.com/daml/intro/0_Intro.html>`_
 would be a good starting point.
-
-This example refers to the :doc:`Transfer <transfer>` tutorial script in the sense that it explains
-the accounts and holdings required for that tutorial.
 
 Explanation of Holdings
 ***********************

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/holdings.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/holdings.rst
@@ -14,11 +14,6 @@ We are going to:
 #. issue a cash instrument
 #. credit a cash holding to Alice’s account
 
-We expect the reader to be familiar with the basic building blocks of Daml. If that is not the case,
-a suitable introduction can be found `here <https://www.digitalasset.com/developers/learn>`_.
-In particular, `An Introduction to Daml <https://docs.daml.com/daml/intro/0_Intro.html>`_
-would be a good starting point.
-
 Explanation of Holdings
 ***********************
 

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/holdings.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/holdings.rst
@@ -8,147 +8,113 @@ This tutorial introduces the core asset model of the library through a simple ex
 is to illustrate the concepts of :ref:`account <account>`, :ref:`instrument <instrument>`, and
 :ref:`holding <holding>`, as well as to show some useful patterns when working with Daml interfaces.
 
-We are going to:
+We are going to use the Daml Finance library to create tokenized cash on the ledger. This is done
+in three steps:
 
-#. create accounts for Alice and Bob at the Bank
-#. issue a cash instrument
-#. credit a cash holding to Alice’s account
+#. we first create accounts for Alice and Bob at the Bank
+#. we then proceed to issue a cash instrument, representing tokenized dollars
+#. we finally credit a cash holding to Alice’s account
 
-Explanation of Holdings
-***********************
+The holding contract represents the record of ownership on the ledger for Alice's tokenized cash.
 
-As described in the :ref:`Asset model <holding-asset-model>`, a holding contract represents the
-ownership of a certain amount of an :ref:`instrument <instrument>` by an owner at a custodian.
-
-A holding implementation can have specific properties such as being :ref:`fungible <fungibility>` or
-:ref:`non-transferable <transferability>`.
-
-Instruments vs Holdings
-=======================
-
-* An instrument defines *what* a party holds (the rights and obligations).
-* A holding defines *how much* (i.e., the amount) of an instrument and *against which party* (i.e.,
-  the custodian) the instrument is being held.
-
-Bearer Tokens vs Holdings
-=========================
-
-* Bearer tokens mean that *any* party in possession of the token is presumed to be the owner of the
-  asset.
-* Holdings, on the other hand, *restrict* the ownership of the asset to parties that have an account
-  (a vetted relationship) at a custodian.
-
-Sample Code
-***********
+Run the script
+**************
 
 In order to show how this works in practice, let us explore the ``Holding`` script step-by-step.
 
-Create ``Holding`` and ``Account`` Factories
-============================================
+Create Account, Holding, and Instrument Factories
+=================================================
 
 The first instruction instantiates an account factory. This is a template that is used by a party
 (the Bank in this case) to create accounts as part of the ``CreateAccount`` workflow.
 
-.. literalinclude:: /_templates/quickstart-finance/daml/Scripts/Holding.daml
+.. literalinclude:: ../../quickstart-finance/daml/Scripts/Holding.daml
   :language: daml
   :start-after: -- CREATE_ACCOUNT_FACTORY_BEGIN
   :end-before: -- CREATE_ACCOUNT_FACTORY_END
 
 Notice how the ``ContractId`` is immediately converted to an interface upon creation: this is
-because our workflows do not have any knowledge of concrete template implementations.
+because our workflows, such as ``CreateAccount``, do not have any knowledge of concrete template
+implementations.
 
-Similarly, we define a holding factory, which is used within an account to ``Credit`` and ``Debit``
-holdings.
+Similarly, we define a :ref:`holding factory <type-daml-finance-holding-fungible-factory-35358>`,
+which is used within an account to create (``Credit``) holdings.
 
-.. literalinclude:: /_templates/quickstart-finance/daml/Scripts/Holding.daml
+.. literalinclude:: ../../quickstart-finance/daml/Scripts/Holding.daml
   :language: daml
   :start-after: -- CREATE_HOLDING_FACTORY_BEGIN
   :end-before: -- CREATE_HOLDING_FACTORY_END
 
-This factory contract can be used to create
-:ref:`Fungible <type-daml-finance-holding-fungible-factory-35358>` holdings, which are defined in
+This factory contract instantiates a specific implementation of holdings, which are defined in
 :ref:`Daml.Finance.Holding.Fungible <module-daml-finance-holding-fungible-7201>`
 and are both :ref:`fungible <fungibility>`, as well as :ref:`transferable <transferability>`.
 
-We are adding a so-called *public party* as an observer to the holding factory. This is done to
-ensure that parties, which have `readAs` rights of the public party, have visibility over the
-contract. This is required when you want to transfer the holding, which will be shown in the next
-tutorial.
+Finally, we create a factory template which is used to instantiate :ref:`token instruments
+<type-daml-finance-instrument-token-instrument-instrument-62305>`.
+
+.. literalinclude:: ../../quickstart-finance/daml/Scripts/Holding.daml
+  :language: daml
+  :start-after: -- CREATE_INSTRUMENT_FACTORY_BEGIN
+  :end-before: -- CREATE_INSTRUMENT_FACTORY_END
 
 Open Alice’s and Bob’s Accounts
 ===============================
 
-Once the factory templates are setup, we leverage our ``CreateAccount`` workflow to create accounts
+Once the factory templates are setup, we leverage the ``CreateAccount`` workflow to create accounts
 at the Bank for Alice and Bob.
 
-The creation of an account needs to be authorized by both the ``custodian`` and the ``owner``, i.e.,
-by the Bank and Alice in our case. Authorization is collected using an propose / accept pattern.
+The creation of an account needs to be authorized by both Alice and the Bank. Authorization is
+collected using a propose / accept pattern.
 
-.. literalinclude:: /_templates/quickstart-finance/daml/Scripts/Holding.daml
+.. literalinclude:: ../../quickstart-finance/daml/Scripts/Holding.daml
   :language: daml
   :start-after: -- SETUP_ALICE_ACCOUNT_BEGIN
   :end-before: -- SETUP_ALICE_ACCOUNT_END
 
+The Bank acts as the ``custodian``, or account provider, whereas Alice is the account ``owner``.
 Bob’s account is created in a similar fashion.
 
 Create the Cash Instrument
 ==========================
 
-In order to credit Alice’s account with some cash, we first introduce a cash
-:ref:`Instrument <type-daml-finance-interface-instrument-token-instrument-instrument-4350>`
-in our model.
+In order to credit Alice’s account with some cash, we first create a cash instrument. An instrument
+is a representation of what it is that we are holding against the Bank. It can be as simple as just
+a textual label (like the
+:ref:`Token Instrument <type-daml-finance-interface-instrument-token-instrument-instrument-4350>`
+used in this case) or it can include complex on-ledger lifecycling logic.
 
-.. literalinclude:: /_templates/quickstart-finance/daml/Scripts/Holding.daml
+.. literalinclude:: ../../quickstart-finance/daml/Scripts/Holding.daml
   :language: daml
   :start-after: -- ISSUE_CASH_INSTRUMENT_BEGIN
   :end-before: -- ISSUE_CASH_INSTRUMENT_END
 
-An instrument is a representation of what it is that we are holding against the Bank. It can be as
-simple as just a textual label (like in this case) or it can include complex on-ledger lifecycling
-logic.
-
-To hold one unit of the cash instrument in this scenario means that we can claim ``USD 1``
-(commercial bank money) from the custodian of the holding.
-
 Notice how in this case the Bank acts both as the issuer and depository of the cash instrument. This
-means that we fully trust the Bank with any action concerning the instrument.
+means that we fully trust the Bank with any action concerning the instrument contract.
 
 Deposit Cash in Alice’s Account
 ===============================
 
-We can now deposit cash in Alice’s account. It is possible to create a holding directly using the
-``Fungible`` template:
+We can now deposit cash in Alice’s account, using the ``CreditAccount`` workflow.
+Alice creates a request to deposit ``USD 1000`` at the Bank, the Bank then accepts the request and
+a corresponding :ref:`Holding <type-daml-finance-interface-holding-base-base-14854>` is created.
 
-.. code-block:: daml
-
-  aliceHoldingRequest <- submit alice do
-    createCmd HoldingRequest with
-      instrument = instrumentKey
-      account = aliceAccount
-      amount = 1000.0
-      owner = alice
-      custodian = bank
-
-  aliceHoldingCid <- submit bank do exerciseCmd aliceHoldingRequest Accept
-
-However, this makes the application dependent on the implementation package. As explained in
-:ref:`Application Architecture <application-architecture>`, it is better to depend on the interface
-layer to maximize upgradability and minimize the impact of incremental changes to your application
-or Daml Finance.
-
-Instead, we create the holding using the ``CreditAccount`` workflow, which uses the interface layer.
-
-.. literalinclude:: /_templates/quickstart-finance/daml/Scripts/Holding.daml
+.. literalinclude:: ../../quickstart-finance/daml/Scripts/Holding.daml
   :language: daml
   :start-after: -- CREATE_ALICE_HOLDING_BEGIN
   :end-before: -- CREATE_ALICE_HOLDING_END
 
-Alice creates a request to deposit ``USD 1000`` at the Bank, the Bank then accepts the request and
-a corresponding
-:ref:`Holding <type-daml-finance-interface-holding-base-base-14854>` is created.
-
 You can imagine that the latter step happens only after Alice has shown up at the Bank and
 delivered physical banknotes corresponding to the amount of the deposit.
+
+The holding contract represents the record of ownership on the ledger. In this scenario,
+Alice's holding of ``1000`` units of the cash instrument means that she is entitled to claim
+``USD 1000`` from holding's custodian, the Bank.
+
+To summarize
+
+* an instrument defines *what* a party holds (the rights and obligations).
+* a holding defines *how much* (i.e., the amount) of an instrument and *against which party* (i.e.,
+  the custodian) the instrument is being held.
 
 Frequently Asked Questions
 **************************
@@ -162,9 +128,9 @@ may transfer cash to Bob because Bob has a valid account at the Bank.
 This is done to avoid that Alice transfers cash to Charlie without Charlie being vetted and
 acknowledged by the Bank.
 
-The account is also used to determine who actually authorizes incoming and outgoing transfers. For
-the account at hand, the owner acts as a controller for both incoming and outgoing transfers. For an
-other account, you could for example let the custodian be the controller instead.
+The account is also used to determine who is required to authorize incoming and outgoing transfers.
+For the account at hand, the owner acts as a controller for both incoming and outgoing transfers.
+The other options are explained as part of the settlement tutorials.
 
 Why do we need factories?
 =========================
@@ -174,16 +140,18 @@ You might be wondering why we use account factories and holding factories instea
 :ref:`Holding <type-daml-finance-holding-fungible-fungible-28517>`
 directly.
 
-This is done to avoid having to reference ``Daml.Finance.Holding`` directly in user workflows (and
-hence simplify upgrading procedures).
+This is done to avoid having to reference the ``Daml.Finance.Holding`` package directly in the
+user workflows (and hence simplify upgrading procedures).
 
-This is based on the assumption that there are very few factory contracts which are setup on ledger
-initialization.
+This pattern is described in detail in the :ref:`Daml Finance Patterns <factory-pattern>` page and
+is based on the assumption that there are very few factory contracts which are setup on
+ledger initialization.
 
 Summary
 *******
 
-You know how to setup basic accounts, holdings, and instruments. The key concepts to take away are:
+You now know how to setup basic accounts, holdings, and instruments. The key concepts to take
+away are:
 
 * Holdings represent the ownership of a financial instrument at a custodian.
 * Instruments define the economic terms of a financial contract.

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/holdings.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/holdings.rst
@@ -6,7 +6,7 @@ Holdings
 
 This tutorial introduces the core asset model of the library through a simple example. The purpose
 is to illustrate the concepts of :ref:`account <account>`, :ref:`instrument <instrument>`, and
-:ref:`holding <holding>`, as well as showing how to work with Daml interfaces.
+:ref:`holding <holding>`, as well as to show some useful patterns when working with Daml interfaces.
 
 We are going to:
 
@@ -37,41 +37,6 @@ Bearer Tokens vs Holdings
   asset.
 * Holdings, on the other hand, *restrict* the ownership of the asset to parties that have an account
   (a vetted relationship) at a custodian.
-
-.. _structure-of-code-dependencies:
-
-Structure of the Code and Dependencies
-**************************************
-
-The code includes
-
-- four workflows defined in the ``Workflows`` folder
-- four Daml scripts defined in the ``Scripts`` folder
-
-The ``Workflows`` encapsulate the core business logic of the application, whereas the ``Scripts``
-are meant to be executed on a one-off basis.
-
-If you take a closer look at the ``Workflows``, you will recognize three propose / accept patterns
-to:
-
-- create an account
-- make a deposit to the account
-
-The ``Transfer`` and `DvP`` workflows will be used in the next tutorials, so please ignore those for
-now.
-
-Modules in the ``Workflows`` folder depend only on *interface* packages of ``daml-finance`` (the
-packages that start with ``Daml.Finance.Interface.*``), as you can see from the import list.
-
-This is important, as it decouples the user-defined business logic from the template implementations
-used in ``daml-finance`` which makes it easier to upgrade the application. The user-defined business
-logic in the ``Workflows`` will not need to be modified nor re-compiled to work with
-upgraded (ie., newer versions of) *implementation* packages.
-
-On the other hand, modules in the ``Scripts`` folder depend on both the *interface* packages and
-the *implementation* packages (in this case, ``Daml.Finance.Account``, ``Daml.Finance.Holding``,
-and ``Daml.Finance.Instrument.Token``). This is not problematic as scripts are meant to be run only
-once when the application is initialized.
 
 Sample Code
 ***********

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
@@ -9,7 +9,7 @@ step description of different workflows with supporting Daml code.
 
 The following tutorials are available:
 
-* :doc:`Holding <holding>`: describes the core asset model used in Daml Finance.
+* :doc:`Holdings <holdings>`: describes the core asset model used in Daml Finance.
 * :doc:`Transfer <transfer>`: shows how to transfer ownership of a holding.
 * :doc:`Settlement <settlement>`: explains how to execute multiple asset movements atomically.
 * :doc:`Lifecycling <lifecycling>`: describes how lifecycle rules and events can be used to evolve

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
@@ -10,7 +10,7 @@ step description of different workflows with supporting Daml code.
 The following tutorials are available:
 
 * :doc:`Holdings <holdings>`: describes the core asset model used in Daml Finance.
-* :doc:`Transfer <transfer>`: shows how to transfer ownership of a holding.
+* :doc:`Transfer <transfer>`: shows how to transfer ownership of a holding to another party.
 * :doc:`Settlement <settlement>`: explains how to execute multiple asset movements atomically.
 * :doc:`Lifecycling <lifecycling>`: describes how lifecycle rules and events can be used to evolve
   instruments over time.

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
@@ -17,13 +17,23 @@ The following tutorials are available:
 
 Each tutorial builds on top of the previous ones, so they should ideally be followed in order.
 
+Prerequisites
+*************
+
+We expect the reader to be familiar with the basic building blocks of Daml. If that is not the case,
+a suitable introduction can be found `here <https://www.digitalasset.com/developers/learn>`_.
+
+An understanding of :doc:`Daml Interfaces <../../../daml/reference/interfaces>` is very helpful, as
+these are used extensively throughout the library. However, you should be able to follow along and
+grasp the fundamental concepts also without detailed knowledge on interfaces.
+
+Finally, make sure that the :doc:`Daml SDK <../../../getting-started/installation>`
+is installed on your machine.
+
 Download the code for the tutorials
 ***********************************
 
-As a prerequisite, make sure that the :doc:`Daml SDK <../../../getting-started/installation>`
-is installed on your machine.
-
-Open a terminal and run:
+Open a new terminal window and run:
 
 .. code-block:: shell
 

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/intro.rst
@@ -57,3 +57,29 @@ Finally, you can start Daml Studio to inspect the code and run the project's scr
 .. code-block:: shell
 
    daml studio
+
+.. _structure-of-code-dependencies:
+
+Structure of the Code and Dependencies
+**************************************
+
+The project includes
+
+- four workflows defined in the ``Workflows`` folder
+- four Daml scripts defined in the ``Scripts`` folder
+
+The ``Workflows`` encapsulate the core business logic of the application, whereas the ``Scripts``
+are meant to be executed on a one-off basis.
+
+As you can see from the import list, modules in the ``Workflows`` folder depend only on
+*interface* packages of Daml Finance (the packages that start with ``Daml.Finance.Interface.*``).
+
+This is important, as it decouples the user-defined business logic from the template implementations
+used in Daml Finance, which makes it easier to upgrade the application. The user-defined business
+logic in the ``Workflows`` will not need to be modified nor re-compiled to work with
+upgraded (ie., newer versions of) *implementation* packages.
+
+On the other hand, modules in the ``Scripts`` folder depend on both the *interface* packages and
+the *implementation* packages (in this case, ``Daml.Finance.Account``, ``Daml.Finance.Holding``,
+and ``Daml.Finance.Instrument.Token``). This is not problematic as scripts are meant to be run only
+once when the application is initialized.

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/transfer.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/transfer.rst
@@ -7,10 +7,11 @@ Transfer
 This tutorial builds on the previous chapter, which introduced :ref:`account <account>`,
 :ref:`instrument <instrument>`, and :ref:`holding <holding>`.
 
-We are now going to transfer a holding from Alice to Bob.
+We are now going to transfer the holding that we created in the previous tutorial
+from Alice to Bob.
 
-Run the Transfer Script
-***********************
+Run the Script
+**************
 
 Let us now explore the ``Transfer`` script step-by-step. It builds on the previous
 :doc:`Holdings <holdings>` tutorial script in the sense that the same accounts and the existing
@@ -148,8 +149,7 @@ you can use the :ref:`Account.exerciseInterfaceByKey
 Summary
 *******
 
-You know how to setup basic accounts, holdings and instruments. You also learned how to perform a
-simple transfer. The key concepts to take away are:
+You now learned how to perform a simple transfer. The key concepts to take away are:
 
 * Holdings represent the ownership of a financial instrument at a custodian.
 * Transfers change ownership of a holding.

--- a/docs/2.7.0/docs/daml-finance/tutorials/getting-started/transfer.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/getting-started/transfer.rst
@@ -13,7 +13,7 @@ Run the Transfer Script
 ***********************
 
 Let us now explore the ``Transfer`` script step-by-step. It builds on the previous
-:doc:`Holding <holding>` tutorial script in the sense that the same accounts and the existing
+:doc:`Holdings <holdings>` tutorial script in the sense that the same accounts and the existing
 holdings are used.
 
 Transfer Cash from Alice to Bob

--- a/docs/2.7.0/docs/daml-finance/tutorials/lifecycling/fixed-rate-bond.rst
+++ b/docs/2.7.0/docs/daml-finance/tutorials/lifecycling/fixed-rate-bond.rst
@@ -61,7 +61,7 @@ We also create a bond holding in Bob's account:
   :end-before: -- CREATE_FIXED_RATE_BOND_HOLDING_END
 
 A holding represents the ownership of a certain amount of an :ref:`instrument <instrument>` by an
-owner at a custodian. Check out the :doc:`Holding <../getting-started/holding>` tutorial for more
+owner at a custodian. Check out the :doc:`Holdings <../getting-started/holdings>` tutorial for more
 details.
 
 Now, we have both an instrument definition and a holding. Let us proceed to lifecycle the bond,


### PR DESCRIPTION
Fixes https://github.com/digital-asset/daml-finance/issues/937

- rename `Holding` tutorial to `Holdings`
- move pre-requisite section to getting-started intro
- move section outlining structure of the project to getting-started intro
- simplify description of holding tutorial
- fix code snippet rendering