### PR TITLE
Fix failing publish-snapshots job for canton 2.8.0 tarball

### DIFF
--- a/bin/publish-snapshots
+++ b/bin/publish-snapshots
@@ -55,6 +55,7 @@ broken() (
 2.7.0-snapshot.20230327.11615.0.9aa586fb
 2.7.0-snapshot.20230515.11783.0.36293a4e
 2.7.0-snapshot.20230518.11799.0.50b2c595
+2.8.0-snapshot.20230808.10971.0.v886a4311
 EOF
   echo "$known_broken" | grep $version >/dev/null
 )


### PR DESCRIPTION
The job fails on canton's 2.8.0-snapshot.20230808.10971.0.v886a4311 tarball because it misses two include files which are required.

The updated tarball, stated in the versions.json, 2.8.0-snapshot.20230809.10977.0.vf08ea807 fixes this problem.

The broken tarball version has been added to broken list of the publish-snapshots script.

Example failing job:
https://app.circleci.com/pipelines/github/digital-asset/docs.daml.com/13404/workflows/b6438a73-5757-4ca9-a334-26c40e03859e/jobs/13841