### PR TITLE
fix snapshot ignore

### DIFF
--- a/bin/publish-snapshots
+++ b/bin/publish-snapshots
@@ -55,7 +55,7 @@ broken() (
 2.7.0-snapshot.20230327.11615.0.9aa586fb
 2.7.0-snapshot.20230515.11783.0.36293a4e
 2.7.0-snapshot.20230518.11799.0.50b2c595
-2.8.0-snapshot.20230808.10971.0.v886a4311
+2.8.0-snapshot.20230807.12017.0.v7ba1e675
 EOF
   echo "$known_broken" | grep $version >/dev/null
 )


### PR DESCRIPTION
@yves-da The snapshot ignore list is based on the overall snapshot version, which is the daml version the canton snapshot was built against, not the canton version itself.