### PR TITLE
make a change to trigger update

### DIFF
--- a/docs/2.7.0/README.md
+++ b/docs/2.7.0/README.md
@@ -76,4 +76,4 @@ bump
 
 :information_desk_person: DEPRECATED: For interested parties, the `deps` function renders a list of recent snapshot updates with the latest at the end of the list. Run `deps list daml` or `deps list canton` to see them.
 
-5. Changes to `main` are reflected immediately on the live (versioned) website. When a new or updated version is built it pulls all of the docs changes submitted for each prefix (version). For example, the url resulting from building the documentation in the `docs/2.6.0` folder is https://docs.daml.com/2.6.0.
+5. Changes to `main` are reflected immediately on the live (versioned) website. When a new or updated version is built it pulls all of the docs changes submitted for each prefix (version). For example, the url resulting from building the documentation in the `docs/2.7.0` folder is https://docs.daml.com/2.7.0.


### PR DESCRIPTION
It turns out the update script is a little bit broken: it only checks if the commit of the docs has changed, not the version. I'll fix it later, but for now let's get 2.7.0 out.

(What happened here is that the last [commit](https://github.com/digital-asset/docs.daml.com/pull/415) to touch 2.7.0 _also_ touched 2.6.5 so the commit was correct and it did not make any update.)