### PR TITLE
For 2.7 and 2.8: add in trigger service ledger API client TLS configuration documentation

### DIFF
--- a/docs.daml.com.iml
+++ b/docs.daml.com.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/docs.daml.com.iml
+++ b/docs.daml.com.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="PYTHON_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/docs/2.7.0/docs/tools/trigger-service/index.rst
+++ b/docs/2.7.0/docs/tools/trigger-service/index.rst
@@ -154,6 +154,21 @@ alongside a few annotations with regards to the meaning of the configuration key
         // Authorization timeout. Defaults to 60 seconds.
         authorization-timeout = 60s
       }
+
+      // Optional. Trigger service ledger API client TLS configuration. By default TLS configuration is disabled.
+      //tls-config {
+      //   enabled = "true"
+      //
+      //   // the certificate to be used by the server
+      //   cert-chain-file = "/path/to/participant.crt"
+      //
+      //   // private key of the server
+      //   private-key-file = "/path/to/participant.pem"
+      //
+      //   // trust collection, which means that all client certificates that will be verified using the trusted
+      //   // certificates in this store. If omitted, the JVM default trust store is used.
+      //   trust-collection-file = "/path/to/root-ca.crt"
+      //}
     }
 
 The Trigger Service can also be started using command line arguments as shown below. The command ``daml trigger-service --help`` lists all available parameters.

--- a/docs/2.8.0/docs/tools/trigger-service/index.rst
+++ b/docs/2.8.0/docs/tools/trigger-service/index.rst
@@ -154,6 +154,21 @@ alongside a few annotations with regards to the meaning of the configuration key
         // Authorization timeout. Defaults to 60 seconds.
         authorization-timeout = 60s
       }
+
+      // Optional. Trigger service ledger API client TLS configuration. By default TLS configuration is disabled.
+      //tls-config {
+      //   enabled = "true"
+      //
+      //   // the certificate to be used by the server
+      //   cert-chain-file = "/path/to/participant.crt"
+      //
+      //   // private key of the server
+      //   private-key-file = "/path/to/participant.pem"
+      //
+      //   // trust collection, which means that all client certificates that will be verified using the trusted
+      //   // certificates in this store. If omitted, the JVM default trust store is used.
+      //   trust-collection-file = "/path/to/root-ca.crt"
+      //}
     }
 
 The Trigger Service can also be started using command line arguments as shown below. The command ``daml trigger-service --help`` lists all available parameters.


### PR DESCRIPTION
- [x] Add in TLS configuration block example to trigger service example config
- [x] Explain what default configuration is