### PR TITLE
Changed repair section back to repair nodes

### DIFF
--- a/docs/2.5.5/docs/index/_toc.yml
+++ b/docs/2.5.5/docs/index/_toc.yml
@@ -370,7 +370,7 @@ subtrees:
       - file: canton/usermanual/connectivity
         title: "Sequencer Connections"
       - file: canton/usermanual/repairing
-        title: "Repair the Topology Information"
+        title: "Repair Nodes"
 
 - caption: "Daml Finance"
   titlesonly: True

--- a/docs/2.5.5/docs/index/operate-a-daml-ledger/common-tasks/index.rst
+++ b/docs/2.5.5/docs/index/operate-a-daml-ledger/common-tasks/index.rst
@@ -8,7 +8,7 @@ Common Operational Tasks
    :titlesonly:
 
    Add a Party <https://docs.daml.com/canton/usermanual/identity_management.html#adding-a-new-party-to-a-participant>
-   Repair the Topology Information </canton/usermanual/repairing>
+   Repair Nodes </canton/usermanual/repairing>
    Manage DARs and Packages </canton/usermanual/packagemanagement>
    Upgrade To a New Release </canton/usermanual/upgrading>
    Configure Auth0 Middleware (With Example Configuration) </tools/trigger-service/auth0_example>

--- a/docs/2.6.5/_toc.yml
+++ b/docs/2.6.5/_toc.yml
@@ -1012,7 +1012,7 @@ subtrees:
       - file: canton/usermanual/connectivity
         title: "Sequencer Connections"
       - file: canton/usermanual/repairing
-        title: "Repair the Topology Information"
+        title: "Repair Nodes"
   - file: canton/usermanual/troubleshooting_guide
 
 

--- a/docs/2.7.0/_toc.yml
+++ b/docs/2.7.0/_toc.yml
@@ -1202,7 +1202,7 @@ subtrees:
       - file: canton/usermanual/connectivity
         title: "Sequencer Connections"
       - file: canton/usermanual/repairing
-        title: "Repair the Topology Information"
+        title: "Repair Nodes"
   - file: canton/usermanual/troubleshooting_guide
 
 

--- a/docs/2.8.0/_toc.yml
+++ b/docs/2.8.0/_toc.yml
@@ -1222,7 +1222,7 @@ subtrees:
       - file: canton/usermanual/connectivity
         title: "Sequencer Connections"
       - file: canton/usermanual/repairing
-        title: "Repair the Topology Information"
+        title: "Repair Nodes"
   - file: canton/usermanual/troubleshooting_guide
 
 


### PR DESCRIPTION
Somebody previously renamed the section "Repair Nodes" to Repair Topology Information despite the fact that the section actually covers the repair service, which isn't about repairing topology, but repairing the contract state. This PR now reverts this change.