### PR TITLE
fix deploy links

### DIFF
--- a/docs/2.6.5/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/use-cases.rst
+++ b/docs/2.6.5/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/use-cases.rst
@@ -133,7 +133,7 @@ Monitoring normally consists of the following activities:
 * Parse out trace IDs from the log files.
 * Keep logs for audit.
 
-Check the documentation for more information on :dod:`monitoring </canton/usermanual/monitoring>`.
+Check the documentation for more information on :doc:`monitoring </canton/usermanual/monitoring>`.
 
 .. rubric:: Footnotes
 

--- a/docs/2.6.5/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/use-cases.rst
+++ b/docs/2.6.5/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/use-cases.rst
@@ -115,7 +115,7 @@ The simple configuration shown above, like that of the domain owner, can expand 
 Upload the distributed application DAR files
 ============================================
 
-Check the documentation for information on how to `upload DAR files <../../../deploy/generic_ledger.html>`__.
+Check the documentation for information on how to :doc:`upload DAR files </deploy/generic_ledger>`.
 
 
 Site Reliability Engineer (SRE)
@@ -133,7 +133,7 @@ Monitoring normally consists of the following activities:
 * Parse out trace IDs from the log files.
 * Keep logs for audit.
 
-Check the documentation for more information on `monitoring <../../../canton/usermanual/monitoring.html>`__.
+Check the documentation for more information on :dod:`monitoring </canton/usermanual/monitoring>`.
 
 .. rubric:: Footnotes
 

--- a/docs/2.7.1/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/use-cases.rst
+++ b/docs/2.7.1/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/use-cases.rst
@@ -115,7 +115,7 @@ The simple configuration shown above, like that of the domain owner, can expand 
 Upload the distributed application DAR files
 ============================================
 
-Check the documentation for information on how to `upload DAR files </deploy/generic_ledger.html>`__.
+Check the documentation for information on how to :doc:`upload DAR files </deploy/generic_ledger>`.
 
 
 Site Reliability Engineer (SRE)
@@ -133,7 +133,7 @@ Monitoring normally consists of the following activities:
 * Parse out trace IDs from the log files.
 * Keep logs for audit.
 
-Check the documentation for more information on `monitoring </canton/usermanual/monitoring.html>`__.
+Check the documentation for more information on :doc:`monitoring </canton/usermanual/monitoring>`.
 
 .. rubric:: Footnotes
 

--- a/docs/2.8.0/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/use-cases.rst
+++ b/docs/2.8.0/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/use-cases.rst
@@ -115,7 +115,7 @@ The simple configuration shown above, like that of the domain owner, can expand 
 Upload the distributed application DAR files
 ============================================
 
-Check the documentation for information on how to `upload DAR files </deploy/generic_ledger.html>`__.
+Check the documentation for information on how to :doc:`upload DAR files </deploy/generic_ledger>`.
 
 
 Site Reliability Engineer (SRE)
@@ -133,7 +133,7 @@ Monitoring normally consists of the following activities:
 * Parse out trace IDs from the log files.
 * Keep logs for audit.
 
-Check the documentation for more information on `monitoring </canton/usermanual/monitoring.html>`__.
+Check the documentation for more information on :doc:`monitoring </canton/usermanual/monitoring>`.
 
 .. rubric:: Footnotes
 


### PR DESCRIPTION
Similar to #460 but includes 2.6.5 (before that the issue is _probably_ present but the source is in Canton repo), and changing the URL format from external to internal so the vailidity of the link gets checked by Sphinx at build time. (So if we move these files around in the future we'll be notified that the links have broken.)