### PR TITLE
add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# https://help.github.com/articles/about-codeowners/
+# Note that accounts or teams mentioned must have WRITE access to the repository.
+
+* @digital-asset/daml-docs


### PR DESCRIPTION
The goal here is to ensure that the docs team has a chance to review all changes to the documentation, by reducing the risk that they might miss a PR.