### PR TITLE
Document cache sizes and imfo size

### DIFF
--- a/docs/2.8.0/docs/canton/usermanual/apis.rst
+++ b/docs/2.8.0/docs/canton/usermanual/apis.rst
@@ -212,6 +212,31 @@ using the custom target audience configuration option:
 
 .. literalinclude:: /canton/includes/mirrored/community/app/src/test/resources/documentation-snippets/ledger-api-target-audience.conf
 
+Ledger API Caches
+^^^^^^^^^^^^^^^^^
+
+The ``max-contract-state-cache-size`` and ``max-contract-key-state-cache-size`` parameters control the sizes of the
+ledger api contract and contract key caches respectively. Modifying these parameters changes the likelihood that a
+transaction using a contract or a contract-key that was recently accessed (created or read) can still find it in the
+memory rather than need to query it from the database. Larger caches might be of interest when there is a big pool of
+ambient contracts that are consistently being fetched or used for non consuming exercises. It may also benefit those
+use cases where a big pool of contracts is being rotated through a create -> archive -> create-successor cycle.
+Consider adjusting these parameters explicitly if the performance of your specific workflow depends on large caches.
+
+.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/large-ledger-api-cache.conf
+
+Max Transactions in the In-Memory Fan-Out
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``max-transactions-in-memory-fan-out-buffer-size`` parameter controls the size of the in-memory fan-out buffer.
+This buffer allows serving the transaction streams from memory as they are finalized, rather than from the database.
+You should choose this buffer to be large enough such that the likelihood of applications having to stream transactions
+from the database is low. Generally, having a 10s buffer is sensible. Therefore, if you expect a throughput of 20 tx/s,
+then setting this number to 200 is sensible. The new default setting of 1000 assumes 100 tx/s.
+Consider adjusting this parameters explicitly if the performance of your workflow foresees transaction rates larger
+than 100 tx/s.
+
+.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/large-in-memory-fan-out.conf
 
 Domain Configurations
 ---------------------

--- a/docs/2.8.0/docs/canton/usermanual/apis.rst
+++ b/docs/2.8.0/docs/canton/usermanual/apis.rst
@@ -216,11 +216,11 @@ Ledger API Caches
 ^^^^^^^^^^^^^^^^^
 
 The ``max-contract-state-cache-size`` and ``max-contract-key-state-cache-size`` parameters control the sizes of the
-ledger api contract and contract key caches respectively. Modifying these parameters changes the likelihood that a
+ledger API contract and contract key caches, respectively. Modifying these parameters changes the likelihood that a
 transaction using a contract or a contract-key that was recently accessed (created or read) can still find it in the
-memory rather than need to query it from the database. Larger caches might be of interest when there is a big pool of
-ambient contracts that are consistently being fetched or used for non consuming exercises. It may also benefit those
-use cases where a big pool of contracts is being rotated through a create -> archive -> create-successor cycle.
+memory, rather than needing to query it from the database. Larger caches might be of interest when there is a big pool of
+ambient contracts that are consistently being fetched or used for non-consuming exercises. Larger caches can also benefit
+use cases where a big pool of contracts rotates through a create -> archive -> create-successor cycle.
 Consider adjusting these parameters explicitly if the performance of your specific workflow depends on large caches.
 
 .. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/large-ledger-api-cache.conf
@@ -230,10 +230,10 @@ Max Transactions in the In-Memory Fan-Out
 
 The ``max-transactions-in-memory-fan-out-buffer-size`` parameter controls the size of the in-memory fan-out buffer.
 This buffer allows serving the transaction streams from memory as they are finalized, rather than from the database.
-You should choose this buffer to be large enough such that the likelihood of applications having to stream transactions
-from the database is low. Generally, having a 10s buffer is sensible. Therefore, if you expect a throughput of 20 tx/s,
-then setting this number to 200 is sensible. The new default setting of 1000 assumes 100 tx/s.
-Consider adjusting this parameters explicitly if the performance of your workflow foresees transaction rates larger
+Make sure this buffer is large enough so applications are less likely to have to stream transactions
+from the database. In most cases, a 10s buffer works well. For example, if you expect a throughput of 20 tx/s,
+set this number to 200. The new default setting of 1000 assumes 100 tx/s.
+Consider adjusting these parameters explicitly if the performance of your workflow foresees transaction rates larger
 than 100 tx/s.
 
 .. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/large-in-memory-fan-out.conf

--- a/docs/2.8.0/versions.json
+++ b/docs/2.8.0/versions.json
@@ -1,6 +1,6 @@
 {
   "daml": "2.8.0-snapshot.20230919.12129.0.v37ffc7dd",
-  "canton": "2.8.0-snapshot.20230921.11203.0.v764ebf3e",
+  "canton": "2.8.0-snapshot.20230925.11215.0.v4f819507",
   "daml_finance": "1.3.3",
   "canton_drivers": "0.1.9"
 }


### PR DESCRIPTION
Document the parameters governing the sizing of the ledger api caches and the in-memory fan-out