### PR TITLE
bump daml and canton versions

### DIFF
--- a/docs/2.8.0/versions.json
+++ b/docs/2.8.0/versions.json
@@ -1,6 +1,6 @@
 {
-  "daml": "2.8.0-snapshot.20230913.12113.0.vf71b764f",
-  "canton": "2.8.0-snapshot.20230828.11069.0.v0819eb02",
+  "daml": "2.8.0-snapshot.20230919.12129.0.v37ffc7dd",
+  "canton": "2.8.0-snapshot.20230921.11203.0.v764ebf3e",
   "daml_finance": "1.3.2",
   "canton_drivers": "0.1.9"
 }


### PR DESCRIPTION
daml: 2.8.0-snapshot.20230919
canton: 2.8.0-snapshot.20230921