### PR TITLE
update from postgres 11 to postgres 14 in docker instructions

### DIFF
--- a/docs/2.4.3/docs/overwrite/canton/usermanual/installation.rst
+++ b/docs/2.4.3/docs/overwrite/canton/usermanual/installation.rst
@@ -123,8 +123,8 @@ First, pull Postgres and start it up.
 
 .. code-block:: bash
 
-    docker pull postgres:11
-    docker run --rm --name pg-docker -e POSTGRES_PASSWORD=docker -d -p 5432:5432 postgres:11
+    docker pull postgres:14.8-bullseye
+    docker run --rm --name pg-docker -e POSTGRES_PASSWORD=docker -d -p 5432:5432 postgres:14.8-bullseye
 
 Then, you can run ``psql`` using:
 

--- a/docs/2.5.5/docs/canton/usermanual/installation.rst
+++ b/docs/2.5.5/docs/canton/usermanual/installation.rst
@@ -123,8 +123,8 @@ First, pull Postgres and start it up.
 
 .. code-block:: bash
 
-    docker pull postgres:11
-    docker run --rm --name pg-docker -e POSTGRES_PASSWORD=docker -d -p 5432:5432 postgres:11
+    docker pull postgres:14.8-bullseye
+    docker run --rm --name pg-docker -e POSTGRES_PASSWORD=docker -d -p 5432:5432 postgres:14.8-bullseye
 
 Then, you can run ``psql`` using:
 

--- a/docs/2.6.5/docs/canton/usermanual/installation.rst
+++ b/docs/2.6.5/docs/canton/usermanual/installation.rst
@@ -123,8 +123,8 @@ First, pull Postgres and start it up.
 
 .. code-block:: bash
 
-    docker pull postgres:11
-    docker run --rm --name pg-docker -e POSTGRES_PASSWORD=docker -d -p 5432:5432 postgres:11
+    docker pull postgres:14.8-bullseye
+    docker run --rm --name pg-docker -e POSTGRES_PASSWORD=docker -d -p 5432:5432 postgres:14.8-bullseye
 
 Then, you can run ``psql`` using:
 

--- a/docs/2.7.1/docs/canton/usermanual/docker.rst
+++ b/docs/2.7.1/docs/canton/usermanual/docker.rst
@@ -97,7 +97,7 @@ container using the following, helpful command:
 .. code-block:: bash
 
     docker run -d --rm --name canton-postgres --shm-size=256mb --publish 5432:5432 -e POSTGRES_USER=test-user
-        -e POSTGRES_PASSWORD=test-password postgres:11 postgres -c max_connections=500
+        -e POSTGRES_PASSWORD=test-password postgres:14.8-bullseye postgres -c max_connections=500
 
 Please note that the ``--publish`` command allows us to pick the target port which we have to define in the
 Canton configuration file. The ``--rm`` will delete the data store once the docker container is killed. This is

--- a/docs/2.7.1/docs/canton/usermanual/example_monitoring_setup.rst
+++ b/docs/2.7.1/docs/canton/usermanual/example_monitoring_setup.rst
@@ -232,7 +232,7 @@ The Docker images need to be pulled down before starting the network:
 * docker.elastic.co/logstash/logstash:8.5.1
 * gcr.io/cadvisor/cadvisor:v0.45.0
 * grafana/grafana:9.3.1-ubuntu
-* postgres:11.18-bullseye
+* postgres:14.8-bullseye
 * prom/prometheus:v2.40.6
 
 Running Docker Compose

--- a/docs/2.7.1/docs/canton/usermanual/installation.rst
+++ b/docs/2.7.1/docs/canton/usermanual/installation.rst
@@ -121,8 +121,8 @@ First, pull Postgres and start it up.
 
 .. code-block:: bash
 
-    docker pull postgres:11
-    docker run --rm --name pg-docker -e POSTGRES_PASSWORD=docker -d -p 5432:5432 postgres:11
+    docker pull postgres:14.8-bullseye
+    docker run --rm --name pg-docker -e POSTGRES_PASSWORD=docker -d -p 5432:5432 postgres:14.8-bullseye
 
 Then, you can run ``psql`` using:
 

--- a/docs/2.7.1/docs/canton/usermanual/monitoring/etc/postgres-docker-compose.yml
+++ b/docs/2.7.1/docs/canton/usermanual/monitoring/etc/postgres-docker-compose.yml
@@ -1,7 +1,7 @@
 
 services:
   postgres:
-    image: postgres:11.18-bullseye
+    image: postgres:14.8-bullseye
     hostname: postgres
     container_name: postgres
     environment:

--- a/docs/2.8.0/docs/canton/usermanual/docker.rst
+++ b/docs/2.8.0/docs/canton/usermanual/docker.rst
@@ -97,7 +97,7 @@ container using the following, helpful command:
 .. code-block:: bash
 
     docker run -d --rm --name canton-postgres --shm-size=256mb --publish 5432:5432 -e POSTGRES_USER=test-user
-        -e POSTGRES_PASSWORD=test-password postgres:11 postgres -c max_connections=500
+        -e POSTGRES_PASSWORD=test-password postgres:14.8-bullseye postgres -c max_connections=500
 
 Please note that the ``--publish`` command allows us to pick the target port which we have to define in the
 Canton configuration file. The ``--rm`` will delete the data store once the docker container is killed. This is

--- a/docs/2.8.0/docs/canton/usermanual/example_monitoring_setup.rst
+++ b/docs/2.8.0/docs/canton/usermanual/example_monitoring_setup.rst
@@ -232,7 +232,7 @@ The Docker images need to be pulled down before starting the network:
 * docker.elastic.co/logstash/logstash:8.5.1
 * gcr.io/cadvisor/cadvisor:v0.45.0
 * grafana/grafana:9.3.1-ubuntu
-* postgres:11.18-bullseye
+* postgres:14.8-bullseye
 * prom/prometheus:v2.40.6
 
 Running Docker Compose

--- a/docs/2.8.0/docs/canton/usermanual/installation.rst
+++ b/docs/2.8.0/docs/canton/usermanual/installation.rst
@@ -123,8 +123,8 @@ First, pull Postgres and start it up.
 
 .. code-block:: bash
 
-    docker pull postgres:11
-    docker run --rm --name pg-docker -e POSTGRES_PASSWORD=docker -d -p 5432:5432 postgres:11
+    docker pull postgres:14.8-bullseye
+    docker run --rm --name pg-docker -e POSTGRES_PASSWORD=docker -d -p 5432:5432 postgres:14.8-bullseye
 
 Then, you can run ``psql`` using:
 

--- a/docs/2.8.0/docs/canton/usermanual/monitoring/etc/postgres-docker-compose.yml
+++ b/docs/2.8.0/docs/canton/usermanual/monitoring/etc/postgres-docker-compose.yml
@@ -1,7 +1,7 @@
 
 services:
   postgres:
-    image: postgres:11.18-bullseye
+    image: postgres:14.8-bullseye
     hostname: postgres
     container_name: postgres
     environment:


### PR DESCRIPTION
Since Canton and PQS both support postgres 14, update to this newer version in the examples and docs