### PR TITLE
snapshots: only look at first 2 numbers

### DIFF
--- a/bin/publish-snapshots
+++ b/bin/publish-snapshots
@@ -68,9 +68,10 @@ for version in $snapshots; do
   then echo " -> Skipping, known broken."
   else
     base=${version%-*}
-    if [ -d docs/$base ]; then
+    base=${base%.*}
+    if [ -d docs/${base}* ]; then
       (
-        cd docs/$base
+        cd docs/${base}*
         canton=$(curl -H "Authorization: bearer $GITHUB_TOKEN" \
                       --fail \
                       --silent \
@@ -111,7 +112,7 @@ NIX
         if [ "${CI:-}" = "true" ]; then
           echo " -> Pushing to S3..."
           upload=$(mktemp -d)
-          tar xf workdir/target/html-$base.tar.gz -C $upload --strip-components=1
+          tar xf workdir/target/html-${base}*.tar.gz -C $upload --strip-components=1
           aws s3 cp $upload s3://docs-daml-com/$version --recursive --acl public-read --region us-east-1 --no-progress
           aws cloudfront create-invalidation --distribution-id E1U753I56ERH55 --paths "/$version/*"
         else
@@ -120,7 +121,7 @@ NIX
         echo "-> Done."
       )
     else
-      echo " -> No base version $base found for $version, unable to proceed."
+      echo " -> No base version ${base} found for $version, unable to proceed."
       exit 1
     fi
   fi


### PR DESCRIPTION
Right now, in order to build a snapshot, the system looks at available versions for a matching "stable": in order to build `2.8.0-snapshot`, it would look for a `2.8.0` folder. That works for future stable versions that aren't published yet, like 2.8.0, but it doesn't work for, say, 2.7.2-rc1, which will exist before we are ready to make a 2.7.2 folder.

With this change, we're only trying to match the first two segments, i.e. the system would build `2.7.2-rc1` based on the `2.7.1` folder.