### PR TITLE
remove the union operation when determining the fetch actors

### DIFF
--- a/docs/2.7.5/docs/concepts/ledger-model/ledger-daml.rst
+++ b/docs/2.7.5/docs/concepts/ledger-model/ledger-daml.rst
@@ -45,7 +45,7 @@ Intuitively, the allowed actions are:
    The actors must be a non-empty subset of the contract stakeholders.
    The actors are determined dynamically as follows: if the fetch appears in an update block of a choice
    `ch` on a contract `c1`, and the fetched contract ID resolves to a contract `c2`, then the actors are defined as the
-   intersection of (1) the signatories of `c1` union the controllers of `ch` with (2) the stakeholders of `c2`.
+   intersection of (1) the controllers of `ch` with (2) the stakeholders of `c2`.
 
    A :ref:`fetchbykey` statement also produces a **Fetch** action with the actors determined in the same way.
    A :ref:`lookupbykey` statement that finds a contract also translates into a **Fetch** action, but all maintainers of the key are the actors.


### PR DESCRIPTION
According to the discussion [here](https://discuss.daml.com/t/fetch-a-contract-as-a-non-stakeholder/6915/5?u=sai), I think DAML is not doing the union operation when determining the fetch actors. This PR is to correct the docs by removing the union operation.

It would be good if someone with the expertise and time can confirm that the union is not performed in DAML source code. The DAML template and script [here](https://discuss.daml.com/t/fetch-a-contract-as-a-non-stakeholder/6915?u=sai) can be considered as a blackbox test.