### PR TITLE
Remove `libcrypt1` mention in the 'TLS Configuration' section

### DIFF
--- a/docs/2.8.0/docs/canton/usermanual/apis.rst
+++ b/docs/2.8.0/docs/canton/usermanual/apis.rst
@@ -41,8 +41,7 @@ TLS Configuration
 
 Both, the Ledger API and the admin API provide the same TLS capabilities and can be configured using
 the same configuration directives. TLS provides end-to-end channel encryption between the server and
-client, and depending on the settings, server or mutual authentication. Ensure that the required TLS
-system dependencies are installed, e.g., `libcrypt1` on Ubuntu.
+client, and depending on the settings, server or mutual authentication.
 
 A full configuration example is given by
 


### PR DESCRIPTION
The issue triggering the mention of `libcrypt` [1] has been resolved with the issue [2] for the Canton 2.8 release.

[1] https://github.com/DACH-NY/canton/issues/11866
[2] https://github.com/DACH-NY/canton/issues/15301