### PR TITLE
Fix snippets using PingPong for 2.8.0 and 3.0.0

### DIFF
--- a/docs/2.8.0/docs/canton/includes/snippet_data/tutorials/getting_started.json
+++ b/docs/2.8.0/docs/canton/includes/snippet_data/tutorials/getting_started.json
@@ -1,274 +1,274 @@
 {
-  "385" : {
-    "command" : "val bank = participant2.parties.enable(\"Bank\", waitForDomain = DomainChoice.All)",
-    "output" : "bank : PartyId = Bank::12207f6b1097..."
-  },
-  "489" : {
-    "command" : "val paintOffer = participant1.ledger_api.acs.find_generic(alice, _.templateId.isModuleEntity(\"Paint\", \"OfferToPaintHouseByPainter\"))",
-    "output" : "paintOffer : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#1220ab0b25094769ffd759d1e4c33fd2924212abe93c4f1f997ce3e619643ec63d42:0\",\n    contractId = \"0021ae8b91a08ed8f073d0331cb370b6ce0f61417478731ca6a4488cb248f21ba6ca01122016b5004bb68ae2e4bf42e79b6e67a469b6fbe090d34cf7d3400367ac3299381a\",\n    templateId = Some(\n      value = Identifier(\n.."
-  },
-  "343" : {
-    "command" : "nodes.local",
-    "output" : "res28: Seq[com.digitalasset.canton.console.LocalInstanceReferenceCommon] = ArraySeq(Participant 'participant1', Participant 'participant2', Domain 'mydomain')"
-  },
-  "259" : {
-    "command" : "val alice = participant1.parties.enable(\"Alice\")",
-    "output" : "alice : PartyId = Alice::1220e92602e9..."
-  },
-  "483" : {
-    "command" : "val createOfferCmd = ledger_api_utils.create(pkgPaint.packageId, \"Paint\", \"OfferToPaintHouseByPainter\", Map(\"bank\" -> bank, \"houseOwner\" -> alice, \"painter\" -> bob, \"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\")))",
-    "output" : "createOfferCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Create(\n    value = CreateCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n.."
-  },
-  "525" : {
-    "command" : "participant1.ledger_api.commands.submit_flat(Seq(alice), Seq(acceptOffer))",
-    "output" : "res48: com.daml.ledger.api.v1.transaction.Transaction = Transaction(\n  transactionId = \"1220ced37b240eefc96341fa42245989e4750f8b777121d445dfb3d2688ee625c08c\",\n  commandId = \"7b231bb3-aa08-4f6e-a4e4-d34160e893d0\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n.."
-  },
-  "68" : {
-    "command" : "Seq(1,2,3).map(_ * 2)",
-    "output" : "res1: Seq[Int] = List(2, 4, 6)"
-  },
-  "69" : {
-    "command" : "",
-    "output" : ""
-  },
-  "468" : {
-    "command" : "participant1.ledger_api.acs.of_party(alice).map(x => (x.templateId, x.arguments))",
-    "output" : "res38: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
-  },
-  "523" : {
-    "command" : "import com.digitalasset.canton.protocol.LfContractId",
-    "output" : ""
-  },
-  "308" : {
-    "command" : "participant1.health.ping(p2Id)",
-    "output" : "res22: Duration = 576 milliseconds"
-  },
-  "202" : {
-    "command" : "participant1.health.ping(participant2)",
-    "output" : "res11: Duration = 613 milliseconds"
-  },
-  "504" : {
-    "command" : "",
-    "output" : ""
-  },
-  "357" : {
-    "command" : "",
-    "output" : ""
-  },
-  "460" : {
-    "command" : "participant1.ledger_api.acs.of_party(alice)",
-    "output" : "res37: Seq[com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent] = List(\n  WrappedCreatedEvent(\n    event = CreatedEvent(\n      eventId = \"#122016dfb107997decae572917a0cca323f3d71a99d808c55c821fc84921bee57bbc:0\",\n      contractId = \"0064eace0d06c962a4141372442e1b64b4655383df07f1ea191a90094ed3df35dcca01122098f4a7f6a3945b66fc3ab524b2bb5731ace8c8fb5e429eae64db616bf8c89a53\",\n      templateId = Some(\n        value = Identifier(\n          packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n.."
-  },
-  "189" : {
-    "command" : "participant2.domains.connect_local(mydomain)",
-    "output" : ""
-  },
-  "93" : {
-    "command" : "help",
-    "output" : "Top-level Commands\n------------------\nexit - Leave the console\nhelp - Help with console commands; type help(\"<command>\") for detailed help for <command>\n\nGeneric Node References\n-----------------------\ndomainManagers - All domain manager nodes (.all, .local, .remote)\n.."
-  },
-  "261" : {
-    "command" : "val bob = participant2.parties.enable(\"Bob\")",
-    "output" : "bob : PartyId = Bob::12207f6b1097..."
-  },
-  "321" : {
-    "command" : "val p2UidString = participant2.id.uid.toProtoPrimitive",
-    "output" : "p2UidString : String = \"participant2::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\""
-  },
-  "348" : {
-    "command" : "participants.all",
-    "output" : "res29: Seq[com.digitalasset.canton.console.ParticipantReference] = List(Participant 'participant1', Participant 'participant2')"
+  "481" : {
+    "command" : "val pkgPaint = participant1.packages.find(\"Paint\").head",
+    "output" : "pkgPaint : com.digitalasset.canton.participant.admin.v0.PackageDescription = PackageDescription(\n  packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n  sourceDescription = \"CantonExamples\"\n)"
   },
   "280" : {
     "command" : "",
     "output" : ""
   },
-  "293" : {
-    "command" : "participant1.health.ping(participant2)",
-    "output" : ".."
+  "452" : {
+    "command" : "participant1.ledger_api.commands.submit(Seq(alice), Seq(createIouCmd))",
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcClientError: INVALID_ARGUMENT/DAML_AUTHORIZATION_ERROR(8,1efe0fcf): Interpretation error: Error: node NodeId(0) (6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680:Iou:Iou) requires authorizers Bank::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482, but only Alice::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9 were given\n  Request: SubmitAndWaitTransactionTree(\n  actAs = Alice::1220f4191f94...,\n.."
   },
-  "439" : {
-    "command" : "participant2.ledger_api.commands.submit(Seq(bank), Seq(createIouCmd))",
-    "output" : "res35: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"122016dfb107997decae572917a0cca323f3d71a99d808c55c821fc84921bee57bbc\",\n  commandId = \"66d0c0bd-5a2f-4a46-a933-31dbb65bb856\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1686572349L,\n      nanos = 575851000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n  ),\n  offset = \"000000000000000015\",\n.."
+  "392" : {
+    "command" : "val bank = participant2.parties.enable(\"Bank\", waitForDomain = DomainChoice.All)",
+    "output" : "bank : PartyId = Bank::1220a497955f..."
   },
-  "201" : {
+  "328" : {
+    "command" : "val p2UidString = participant2.id.uid.toProtoPrimitive",
+    "output" : "p2UidString : String = \"participant2::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\""
+  },
+  "286" : {
+    "command" : "mydomain.parties.list(\"Bob\")",
+    "output" : "res18: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Bob::1220a497955f...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant2::1220a497955f...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220440cf3c3..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
+  },
+  "208" : {
     "command" : "",
     "output" : ""
   },
-  "260" : {
-    "command" : "",
-    "output" : ""
+  "462" : {
+    "command" : "val aliceIou = participant1.ledger_api.acs.find_generic(alice, _.templateId.isModuleEntity(\"Iou\", \"Iou\"))",
+    "output" : "aliceIou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#1220451d0751815e7bf2618d13534f3779048a49c273ee7b7c7cfa9ae401161c1b23:0\",\n    contractId = \"0008a2a92f69282ca09f2f08fead9a332672e7fe1140d97d5ce14678f0be8c46b3ca021220edff6f7f2a5ae36e0c94c82398397d7972aa3a312a3b9854c95e051a6d72bdbc\",\n.."
   },
-  "429" : {
-    "command" : "val pkgIou = participant1.packages.find(\"Iou\").head",
-    "output" : "pkgIou : com.digitalasset.canton.participant.admin.v0.PackageDescription = PackageDescription(\n  packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n  sourceDescription = \"CantonExamples\"\n)"
+  "310" : {
+    "command" : "val p2Id = ParticipantId.tryFromProtoPrimitive(extractedId)",
+    "output" : "p2Id : ParticipantId = PAR::participant2::1220a497955f..."
   },
-  "229" : {
-    "command" : "mydomain.id",
-    "output" : "res12: DomainId = mydomain::1220b4e9b0f0..."
-  },
-  "484" : {
-    "command" : "participant2.ledger_api.commands.submit_flat(Seq(bob), Seq(createOfferCmd))",
-    "output" : "res41: com.daml.ledger.api.v1.transaction.Transaction = Transaction(\n  transactionId = \"1220ab0b25094769ffd759d1e4c33fd2924212abe93c4f1f997ce3e619643ec63d42\",\n  commandId = \"b63e26ee-7c29-4ea7-849c-79796a7b5e5b\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n.."
-  },
-  "188" : {
-    "command" : "",
-    "output" : ""
-  },
-  "356" : {
+  "363" : {
     "command" : "participant1.dars.list()",
-    "output" : "res30: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\",\n    name = \"CantonExamples\"\n  ),\n  DarDescription(\n    hash = \"122012a6f2b7c0b666e7541ce6f5d4273ab8d00da671b4d3bbb9bebb6a5120ec02c5\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  )\n)"
+    "output" : "res30: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220caf9b815c77d40b24801fc88acaa85bffac5cc315644c8242923d039d8df6d73\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  ),\n  DarDescription(\n    hash = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\",\n    name = \"CantonExamples\"\n  )\n)"
+  },
+  "517" : {
+    "command" : "",
+    "output" : ""
+  },
+  "369" : {
+    "command" : "participant2.dars.list()",
+    "output" : "res31: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220caf9b815c77d40b24801fc88acaa85bffac5cc315644c8242923d039d8df6d73\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  ),\n  DarDescription(\n    hash = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\",\n    name = \"CantonExamples\"\n  )\n)"
+  },
+  "511" : {
+    "command" : "",
+    "output" : ""
+  },
+  "269" : {
+    "command" : "",
+    "output" : ""
+  },
+  "202" : {
+    "command" : "health.status",
+    "output" : "res10: EnterpriseCantonStatus = Status for Domain 'mydomain':\nDomain id: mydomain::1220440cf3c3df32ba71a54aeea88aadbd859fe728311aef4fdfd365abfc987dbeb4\nUptime: 16.09241s\nPorts: \n\tadmin: 30769\n\tpublic: 30768\nConnected Participants: \n\tPAR::participant2::1220a497955f...\n\tPAR::participant1::1220f4191f94...\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()\n\n.."
+  },
+  "174" : {
+    "command" : "",
+    "output" : ""
+  },
+  "320" : {
+    "command" : "val aliceAsStr = alice.toProtoPrimitive",
+    "output" : "aliceAsStr : String = \"Alice::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\""
+  },
+  "436" : {
+    "command" : "val pkgIou = participant1.packages.find(\"Iou\").head",
+    "output" : "pkgIou : com.digitalasset.canton.participant.admin.v0.PackageDescription = PackageDescription(\n  packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n  sourceDescription = \"CantonExamples\"\n)"
+  },
+  "504" : {
+    "command" : "participant2.ledger_api.acs.of_party(bob).map(x => (x.templateId, x.arguments))",
+    "output" : "res43: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n      moduleName = \"Paint\",\n      entityName = \"OfferToPaintHouseByPainter\"\n    ),\n    HashMap(\n      \"painter\" -> \"Bob::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\",\n      \"houseOwner\" -> \"Alice::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\",\n      \"bank\" -> \"Bank::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
+  },
+  "344" : {
+    "command" : "participants.all.dars.upload(\"dars/CantonExamples.dar\")",
+    "output" : "res27: Map[com.digitalasset.canton.console.ParticipantReference, String] = Map(\n  Participant 'participant1' -> \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\",\n  Participant 'participant2' -> \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\"\n)"
+  },
+  "196" : {
+    "command" : "participant2.domains.connect_local(mydomain)",
+    "output" : ""
+  },
+  "475" : {
+    "command" : "participant1.ledger_api.acs.of_party(alice).map(x => (x.templateId, x.arguments))",
+    "output" : "res38: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
+  },
+  "179" : {
+    "command" : "mydomain.health.status",
+    "output" : "res7: com.digitalasset.canton.health.admin.data.NodeStatus[mydomain.Status] = Domain id: mydomain::1220440cf3c3df32ba71a54aeea88aadbd859fe728311aef4fdfd365abfc987dbeb4\nUptime: 12.336155s\nPorts: \n\tadmin: 30769\n\tpublic: 30768\nConnected Participants: None\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()"
+  },
+  "321" : {
+    "command" : "val aliceParsed = PartyId.tryFromProtoPrimitive(aliceAsStr)",
+    "output" : "aliceParsed : PartyId = Alice::1220f4191f94..."
+  },
+  "106" : {
+    "command" : "participant1.help(\"start\")",
+    "output" : "start\nStart the instance"
+  },
+  "238" : {
+    "command" : "participant2.id",
+    "output" : "res14: ParticipantId = PAR::participant2::1220a497955f..."
+  },
+  "467" : {
+    "command" : "participant1.ledger_api.acs.of_party(alice)",
+    "output" : "res37: Seq[com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent] = List(\n  WrappedCreatedEvent(\n    event = CreatedEvent(\n      eventId = \"#1220451d0751815e7bf2618d13534f3779048a49c273ee7b7c7cfa9ae401161c1b23:0\",\n      contractId = \"0008a2a92f69282ca09f2f08fead9a332672e7fe1140d97d5ce14678f0be8c46b3ca021220edff6f7f2a5ae36e0c94c82398397d7972aa3a312a3b9854c95e051a6d72bdbc\",\n      templateId = Some(\n        value = Identifier(\n          packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n.."
+  },
+  "197" : {
+    "command" : "",
+    "output" : ""
+  },
+  "329" : {
+    "command" : "val p2FromUid = ParticipantId(UniqueIdentifier.tryFromProtoPrimitive(p2UidString))",
+    "output" : "p2FromUid : ParticipantId = PAR::participant2::1220a497955f..."
+  },
+  "285" : {
+    "command" : "",
+    "output" : ""
+  },
+  "457" : {
+    "command" : "participant1.ledger_api.commands.submit(Seq(bank), Seq(createIouCmd))",
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: NOT_FOUND/NO_DOMAIN_ON_WHICH_ALL_SUBMITTERS_CAN_SUBMIT(11,05ea6bcf): This participant can not submit as the given submitter on any connected domain\n  Request: SubmitAndWaitTransactionTree(\n  actAs = Bank::1220a497955f...,\n.."
   },
   "173" : {
-    "command" : "",
-    "output" : ""
-  },
-  "503" : {
-    "command" : "participant2.ledger_api.acs.of_party(bank).map(x => (x.templateId, x.arguments))",
-    "output" : "res44: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
-  },
-  "298" : {
-    "command" : "val extractedId = participant2.id.toProtoPrimitive",
-    "output" : "extractedId : String = \"PAR::participant2::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\""
-  },
-  "166" : {
     "command" : "participant1.health.status",
-    "output" : "res6: com.digitalasset.canton.health.admin.data.NodeStatus[com.digitalasset.canton.health.admin.data.ParticipantStatus] = Participant id: PAR::participant1::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\nUptime: 5.349261s\nPorts: \n\tledger: 30098\n\tadmin: 30099\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized"
+    "output" : "res6: com.digitalasset.canton.health.admin.data.NodeStatus[com.digitalasset.canton.health.admin.data.ParticipantStatus] = Participant id: PAR::participant1::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\nUptime: 7.248153s\nPorts: \n\tledger: 30764\n\tadmin: 30765\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized"
   },
-  "161" : {
-    "command" : "health.status",
-    "output" : "res5: EnterpriseCantonStatus = Status for Domain 'mydomain':\nDomain id: mydomain::1220b4e9b0f09429d18bb4f197864468b713b28d5334e7581e82e6b9f129cf5c0e15\nUptime: 7.494604s\nPorts: \n\tadmin: 30103\n\tpublic: 30102\nConnected Participants: None\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()\n\nStatus for Participant 'participant1':\nParticipant id: PAR::participant1::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\nUptime: 5.181514s\nPorts: \n\tledger: 30098\n\tadmin: 30099\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized\n\nStatus for Participant 'participant2':\nParticipant id: PAR::participant2::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\nUptime: 3.406213s\nPorts: \n\tledger: 30100\n\tadmin: 30101\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized"
-  },
-  "279" : {
-    "command" : "mydomain.parties.list(\"Bob\")",
-    "output" : "res18: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Bob::12207f6b1097...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant2::12207f6b1097...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220b4e9b0f0..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
-  },
-  "445" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(alice), Seq(createIouCmd))",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcClientError: INVALID_ARGUMENT/DAML_AUTHORIZATION_ERROR(8,9d7c7884): Interpretation error: Error: node NodeId(0) (9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0:Iou:Iou) requires authorizers Bank::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e, but only Alice::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a were given\n  Request: SubmitAndWaitTransactionTree(actAs = Alice::1220e92602e9..., readAs = Seq(), commandId = '', workflowId = '', submissionId = '', deduplicationPeriod = None(), commands = ...)\n  CorrelationId: 9d7c7884-6e76-41c2-b70b-665c49bd097f\n.."
-  },
-  "313" : {
-    "command" : "val aliceAsStr = alice.toProtoPrimitive",
-    "output" : "aliceAsStr : String = \"Alice::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\""
-  },
-  "498" : {
-    "command" : "",
-    "output" : ""
-  },
-  "187" : {
-    "command" : "participant1.domains.connect_local(mydomain)",
-    "output" : ""
-  },
-  "172" : {
-    "command" : "mydomain.health.status",
-    "output" : "res7: com.digitalasset.canton.health.admin.data.NodeStatus[mydomain.Status] = Domain id: mydomain::1220b4e9b0f09429d18bb4f197864468b713b28d5334e7581e82e6b9f129cf5c0e15\nUptime: 7.854944s\nPorts: \n\tadmin: 30103\n\tpublic: 30102\nConnected Participants: None\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()"
-  },
-  "230" : {
+  "237" : {
     "command" : "participant1.id",
-    "output" : "res13: ParticipantId = PAR::participant1::1220e92602e9..."
+    "output" : "res13: ParticipantId = PAR::participant1::1220f4191f94..."
   },
-  "362" : {
-    "command" : "participant2.dars.list()",
-    "output" : "res31: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\",\n    name = \"CantonExamples\"\n  ),\n  DarDescription(\n    hash = \"122012a6f2b7c0b666e7541ce6f5d4273ab8d00da671b4d3bbb9bebb6a5120ec02c5\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  )\n)"
-  },
-  "271" : {
-    "command" : "",
-    "output" : ""
-  },
-  "509" : {
-    "command" : "participant1.ledger_api.acs.of_party(alice).map(x => (x.templateId, x.arguments))",
-    "output" : "res45: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  ),\n  (\n    TemplateId(\n      packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n      moduleName = \"Paint\",\n      entityName = \"OfferToPaintHouseByPainter\"\n    ),\n    HashMap(\n      \"painter\" -> \"Bob::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\",\n      \"houseOwner\" -> \"Alice::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\",\n      \"bank\" -> \"Bank::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
-  },
-  "434" : {
-    "command" : "val createIouCmd = ledger_api_utils.create(pkgIou.packageId,\"Iou\",\"Iou\",Map(\"payer\" -> bank,\"owner\" -> alice,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
-    "output" : "createIouCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Create(\n    value = CreateCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n.."
-  },
-  "98" : {
+  "105" : {
     "command" : "help(\"participant1\")",
     "output" : "participant1\nManage participant 'participant1'; type 'participant1 help' or 'participant1 help(\"<methodName>\")' for more help"
   },
-  "303" : {
-    "command" : "val p2Id = ParticipantId.tryFromProtoPrimitive(extractedId)",
-    "output" : "p2Id : ParticipantId = PAR::participant2::12207f6b1097..."
+  "266" : {
+    "command" : "val alice = participant1.parties.enable(\"Alice\")",
+    "output" : "alice : PartyId = Alice::1220f4191f94..."
+  },
+  "530" : {
+    "command" : "import com.digitalasset.canton.protocol.LfContractId",
+    "output" : ""
+  },
+  "279" : {
+    "command" : "mydomain.parties.list(\"Alice\")",
+    "output" : "res17: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Alice::1220f4191f94...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant1::1220f4191f94...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220440cf3c3..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
+  },
+  "180" : {
+    "command" : "",
+    "output" : ""
+  },
+  "71" : {
+    "command" : "Seq(1,2,3).map(_ * 2)",
+    "output" : "res1: Seq[Int] = List(2, 4, 6)"
+  },
+  "236" : {
+    "command" : "mydomain.id",
+    "output" : "res12: DomainId = mydomain::1220440cf3c3..."
+  },
+  "350" : {
+    "command" : "nodes.local",
+    "output" : "res28: Seq[com.digitalasset.canton.console.LocalInstanceReferenceCommon] = ArraySeq(Participant 'participant1', Participant 'participant2', Domain 'mydomain')"
   },
   "278" : {
     "command" : "",
     "output" : ""
   },
-  "455" : {
-    "command" : "val aliceIou = participant1.ledger_api.acs.find_generic(alice, _.templateId.isModuleEntity(\"Iou\", \"Iou\"))",
-    "output" : "aliceIou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#122016dfb107997decae572917a0cca323f3d71a99d808c55c821fc84921bee57bbc:0\",\n    contractId = \"0064eace0d06c962a4141372442e1b64b4655383df07f1ea191a90094ed3df35dcca01122098f4a7f6a3945b66fc3ab524b2bb5731ace8c8fb5e429eae64db616bf8c89a53\",\n.."
-  },
-  "167" : {
+  "267" : {
     "command" : "",
     "output" : ""
   },
-  "314" : {
-    "command" : "val aliceParsed = PartyId.tryFromProtoPrimitive(aliceAsStr)",
-    "output" : "aliceParsed : PartyId = Alice::1220e92602e9..."
-  },
-  "497" : {
-    "command" : "participant2.ledger_api.acs.of_party(bob).map(x => (x.templateId, x.arguments))",
-    "output" : "res43: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n      moduleName = \"Paint\",\n      entityName = \"OfferToPaintHouseByPainter\"\n    ),\n    HashMap(\n      \"painter\" -> \"Bob::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\",\n      \"houseOwner\" -> \"Alice::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\",\n      \"bank\" -> \"Bank::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
-  },
-  "231" : {
-    "command" : "participant2.id",
-    "output" : "res14: ParticipantId = PAR::participant2::12207f6b1097..."
-  },
-  "450" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(bank), Seq(createIouCmd))",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: NOT_FOUND/NO_DOMAIN_ON_WHICH_ALL_SUBMITTERS_CAN_SUBMIT(11,89c4dc65): This participant can not submit as the given submitter on any connected domain\n  Request: SubmitAndWaitTransactionTree(actAs = Bank::12207f6b1097..., readAs = Seq(), commandId = '', workflowId = '', submissionId = '', deduplicationPeriod = None(), commands = ...)\n  CorrelationId: 89c4dc654bf60571a516aa17b36abeb8\n.."
-  },
-  "99" : {
-    "command" : "participant1.help(\"start\")",
-    "output" : "start\nStart the instance"
-  },
-  "363" : {
+  "505" : {
     "command" : "",
     "output" : ""
   },
-  "524" : {
+  "490" : {
+    "command" : "val createOfferCmd = ledger_api_utils.create(pkgPaint.packageId, \"Paint\", \"OfferToPaintHouseByPainter\", Map(\"bank\" -> bank, \"houseOwner\" -> alice, \"painter\" -> bob, \"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\")))",
+    "output" : "createOfferCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Create(\n    value = CreateCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n.."
+  },
+  "531" : {
     "command" : "val acceptOffer = ledger_api_utils.exercise(\"AcceptByOwner\", Map(\"iouId\" -> LfContractId.assertFromString(aliceIou.event.contractId)),paintOffer.event)",
-    "output" : "acceptOffer : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Exercise(\n    value = ExerciseCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n.."
+    "output" : "acceptOffer : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Exercise(\n    value = ExerciseCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n.."
+  },
+  "209" : {
+    "command" : "participant1.health.ping(participant2)",
+    "output" : "res11: Duration = 573 milliseconds"
+  },
+  "516" : {
+    "command" : "participant1.ledger_api.acs.of_party(alice).map(x => (x.templateId, x.arguments))",
+    "output" : "res45: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  ),\n  (\n    TemplateId(\n      packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n      moduleName = \"Paint\",\n      entityName = \"OfferToPaintHouseByPainter\"\n    ),\n    HashMap(\n      \"painter\" -> \"Bob::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\",\n      \"houseOwner\" -> \"Alice::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\",\n      \"bank\" -> \"Bank::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
+  },
+  "355" : {
+    "command" : "participants.all",
+    "output" : "res29: Seq[com.digitalasset.canton.console.ParticipantReference] = List(Participant 'participant1', Participant 'participant2')"
+  },
+  "194" : {
+    "command" : "participant1.domains.connect_local(mydomain)",
+    "output" : ""
+  },
+  "441" : {
+    "command" : "val createIouCmd = ledger_api_utils.create(pkgIou.packageId,\"Iou\",\"Iou\",Map(\"payer\" -> bank,\"owner\" -> alice,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
+    "output" : "createIouCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Create(\n    value = CreateCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n.."
+  },
+  "370" : {
+    "command" : "",
+    "output" : ""
+  },
+  "72" : {
+    "command" : "",
+    "output" : ""
+  },
+  "446" : {
+    "command" : "participant2.ledger_api.commands.submit(Seq(bank), Seq(createIouCmd))",
+    "output" : "res35: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220451d0751815e7bf2618d13534f3779048a49c273ee7b7c7cfa9ae401161c1b23\",\n  commandId = \"eda539cd-fb2f-44a9-bb62-03b962b04a39\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1700582453L,\n      nanos = 135011000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n  ),\n  offset = \"000000000000000015\",\n.."
   },
   "510" : {
+    "command" : "participant2.ledger_api.acs.of_party(bank).map(x => (x.templateId, x.arguments))",
+    "output" : "res44: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
+  },
+  "287" : {
     "command" : "",
     "output" : ""
   },
-  "272" : {
-    "command" : "mydomain.parties.list(\"Alice\")",
-    "output" : "res17: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Alice::1220e92602e9...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant1::1220e92602e9...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220b4e9b0f0..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
+  "300" : {
+    "command" : "participant1.health.ping(participant2)",
+    "output" : ".."
   },
   "315" : {
-    "command" : "",
-    "output" : ""
+    "command" : "participant1.health.ping(p2Id)",
+    "output" : "res22: Duration = 309 milliseconds"
   },
-  "262" : {
-    "command" : "",
-    "output" : ""
+  "168" : {
+    "command" : "health.status",
+    "output" : "res5: EnterpriseCantonStatus = Status for Domain 'mydomain':\nDomain id: mydomain::1220440cf3c3df32ba71a54aeea88aadbd859fe728311aef4fdfd365abfc987dbeb4\nUptime: 12.047341s\nPorts: \n\tadmin: 30769\n\tpublic: 30768\nConnected Participants: None\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()\n\nStatus for Participant 'participant1':\nParticipant id: PAR::participant1::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\nUptime: 7.149419s\nPorts: \n\tledger: 30764\n\tadmin: 30765\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized\n\nStatus for Participant 'participant2':\nParticipant id: PAR::participant2::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\nUptime: 7.165978s\nPorts: \n\tledger: 30766\n\tadmin: 30767\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized"
   },
-  "190" : {
-    "command" : "",
-    "output" : ""
+  "305" : {
+    "command" : "val extractedId = participant2.id.toProtoPrimitive",
+    "output" : "extractedId : String = \"PAR::participant2::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\""
   },
-  "273" : {
-    "command" : "",
-    "output" : ""
+  "268" : {
+    "command" : "val bob = participant2.parties.enable(\"Bob\")",
+    "output" : "bob : PartyId = Bob::1220a497955f..."
   },
   "195" : {
-    "command" : "health.status",
-    "output" : "res10: EnterpriseCantonStatus = Status for Domain 'mydomain':\nDomain id: mydomain::1220b4e9b0f09429d18bb4f197864468b713b28d5334e7581e82e6b9f129cf5c0e15\nUptime: 10.87264s\nPorts: \n\tadmin: 30103\n\tpublic: 30102\nConnected Participants: \n\tPAR::participant1::1220e92602e9...\n\tPAR::participant2::12207f6b1097...\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()\n\n.."
+    "command" : "",
+    "output" : ""
   },
-  "474" : {
-    "command" : "val pkgPaint = participant1.packages.find(\"Paint\").head",
-    "output" : "pkgPaint : com.digitalasset.canton.participant.admin.v0.PackageDescription = PackageDescription(\n  packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n  sourceDescription = \"CantonExamples\"\n)"
+  "532" : {
+    "command" : "participant1.ledger_api.commands.submit_flat(Seq(alice), Seq(acceptOffer))",
+    "output" : "res48: com.daml.ledger.api.v1.transaction.Transaction = Transaction(\n  transactionId = \"12201a27a5c76be0588cde35110ac25e20ba0cf6c8c783dc0277c38f42714661332e\",\n  commandId = \"3063bcaf-4182-4283-9358-de053938185e\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n.."
   },
   "322" : {
-    "command" : "val p2FromUid = ParticipantId(UniqueIdentifier.tryFromProtoPrimitive(p2UidString))",
-    "output" : "p2FromUid : ParticipantId = PAR::participant2::12207f6b1097..."
+    "command" : "",
+    "output" : ""
   },
-  "337" : {
-    "command" : "participants.all.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "res27: Map[com.digitalasset.canton.console.ParticipantReference, String] = Map(\n  Participant 'participant1' -> \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\",\n  Participant 'participant2' -> \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\"\n)"
+  "491" : {
+    "command" : "participant2.ledger_api.commands.submit_flat(Seq(bob), Seq(createOfferCmd))",
+    "output" : "res41: com.daml.ledger.api.v1.transaction.Transaction = Transaction(\n  transactionId = \"122082871e91589dfb77000cd8e992aa691c6a2f829596ef097c4233ddcd62c65a21\",\n  commandId = \"0e8dccc2-ae89-4889-b731-09583074c77a\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n.."
+  },
+  "496" : {
+    "command" : "val paintOffer = participant1.ledger_api.acs.find_generic(alice, _.templateId.isModuleEntity(\"Paint\", \"OfferToPaintHouseByPainter\"))",
+    "output" : "paintOffer : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#122082871e91589dfb77000cd8e992aa691c6a2f829596ef097c4233ddcd62c65a21:0\",\n    contractId = \"009b7335c3f6a9fc65916f95ec1a77cf030a873f128ca4dfc3b0763f99e782a7e8ca021220088a8a3f3c898ceec52449f67e282eaa29722769e8f01494e48848c0fdf84678\",\n    templateId = Some(\n      value = Identifier(\n.."
+  },
+  "364" : {
+    "command" : "",
+    "output" : ""
+  },
+  "100" : {
+    "command" : "help",
+    "output" : "Top-level Commands\n------------------\nexit - Leave the console\nhelp - Help with console commands; type help(\"<command>\") for detailed help for <command>\n\nGeneric Node References\n-----------------------\ndomainManagers - All domain manager nodes (.all, .local, .remote)\n.."
   }
 }

--- a/docs/2.8.0/docs/canton/includes/snippet_data/usermanual/connectivity.json
+++ b/docs/2.8.0/docs/canton/includes/snippet_data/usermanual/connectivity.json
@@ -5,7 +5,7 @@
   },
   "202" : {
     "command" : "val config = DomainConnectionConfig(domain = \"mydomain\", sequencerConnection, manualConnect, domainId, priority)",
-    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = Seq(http://127.0.0.1:30123, http://127.0.0.1:30121),\n    transportSecurity = false,\n    customTrustCertificates = None()\n  ),\n  manualConnect = false,\n  domainId = Some(domainManager1::1220b9035a1f...),\n  priority = 10,\n  initialRetryDelay = None(),\n  maxRetryDelay = None()\n)"
+    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = Seq(http://127.0.0.1:30811, http://127.0.0.1:30809),\n    transportSecurity = false,\n    customTrustCertificates = None()\n  ),\n  manualConnect = false,\n  domainId = Some(domainManager1::1220366f0b65...),\n  priority = 10,\n  initialRetryDelay = None(),\n  maxRetryDelay = None()\n)"
   },
   "189" : {
     "command" : "participant3.domains.reconnect(\"mydomain\")",
@@ -21,7 +21,7 @@
   },
   "86" : {
     "command" : "val port = sequencer3.config.publicApi.port",
-    "output" : "port : Port = Port(n = 30119)"
+    "output" : "port : Port = Port(n = 30807)"
   },
   "67" : {
     "command" : "",
@@ -37,7 +37,7 @@
   },
   "100" : {
     "command" : "participant2.domains.connect(\"mydomain\", connection = url, certificatesPath = certificatesPath)",
-    "output" : "res8: DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = https://127.0.0.1:30119,\n    transportSecurity = true,\n    customTrustCertificates = Some(2d2d2d2d2d42)\n  ),\n  manualConnect = false,\n  domainId = None(),\n  priority = 0,\n  initialRetryDelay = None(),\n  maxRetryDelay = None()\n)"
+    "output" : "res8: DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = https://127.0.0.1:30807,\n    transportSecurity = true,\n    customTrustCertificates = Some(2d2d2d2d2d42)\n  ),\n  manualConnect = false,\n  domainId = None(),\n  priority = 0,\n  initialRetryDelay = None(),\n  maxRetryDelay = None()\n)"
   },
   "174" : {
     "command" : "val priority = 10 // default is 0 if not set",
@@ -49,11 +49,11 @@
   },
   "61" : {
     "command" : "sequencer1.config.publicApi.port",
-    "output" : "res2: Port = Port(n = 30123)"
+    "output" : "res2: Port = Port(n = 30811)"
   },
   "312" : {
     "command" : "mediator1.mediator.help(\"initialize\")",
-    "output" : "initialize(domainId: com.digitalasset.canton.topology.DomainId, mediatorId: com.digitalasset.canton.topology.MediatorId, domainParameters: com.digitalasset.canton.admin.api.client.data.StaticDomainParameters, sequencerConnection: com.digitalasset.canton.sequencing.SequencerConnection, topologySnapshot: Option[com.digitalasset.canton.topology.store.StoredTopologyTransactions[com.digitalasset.canton.topology.transaction.TopologyChangeOp.Positive]]): com.digitalasset.canton.crypto.PublicKey\nInitialize a mediator\ninitialize(domainId: com.digitalasset.canton.topology.DomainId, mediatorId: com.digitalasset.canton.topology.MediatorId, domainParameters: com.digitalasset.canton.admin.api.client.data.StaticDomainParameters, sequencerConnections: com.digitalasset.canton.sequencing.SequencerConnections, topologySnapshot: Option[com.digitalasset.canton.topology.store.StoredTopologyTransactions[com.digitalasset.canton.topology.transaction.TopologyChangeOp.Positive]]): com.digitalasset.canton.crypto.PublicKey\nInitialize a mediator"
+    "output" : "initialize(domainId: com.digitalasset.canton.topology.DomainId, mediatorId: com.digitalasset.canton.topology.MediatorId, domainParameters: com.digitalasset.canton.admin.api.client.data.StaticDomainParameters, sequencerConnection: com.digitalasset.canton.sequencing.SequencerConnection, topologySnapshot: Option[com.digitalasset.canton.topology.store.StoredTopologyTransactions[com.digitalasset.canton.topology.transaction.TopologyChangeOp.Positive]], signingKeyFingerprint: Option[com.digitalasset.canton.crypto.Fingerprint]): com.digitalasset.canton.crypto.PublicKey\nInitialize a mediator\ninitialize(domainId: com.digitalasset.canton.topology.DomainId, mediatorId: com.digitalasset.canton.topology.MediatorId, domainParameters: com.digitalasset.canton.admin.api.client.data.StaticDomainParameters, sequencerConnections: com.digitalasset.canton.sequencing.SequencerConnections, topologySnapshot: Option[com.digitalasset.canton.topology.store.StoredTopologyTransactions[com.digitalasset.canton.topology.transaction.TopologyChangeOp.Positive]], signingKeyFingerprint: Option[com.digitalasset.canton.crypto.Fingerprint]): com.digitalasset.canton.crypto.PublicKey\nInitialize a mediator"
   },
   "292" : {
     "command" : "",
@@ -61,7 +61,7 @@
   },
   "117" : {
     "command" : "participant3.domains.connect_multi(\"mydomain\", Seq(sequencer1, sequencer2))",
-    "output" : "res9: DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = Seq(http://0.0.0.0:30123, http://127.0.0.1:30121),\n    transportSecurity = false,\n    customTrustCertificates = None()\n  ),\n  manualConnect = false,\n  domainId = None(),\n  priority = 0,\n  initialRetryDelay = None(),\n  maxRetryDelay = None()\n)"
+    "output" : "res9: DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = Seq(http://0.0.0.0:30811, http://127.0.0.1:30809),\n    transportSecurity = false,\n    customTrustCertificates = None()\n  ),\n  manualConnect = false,\n  domainId = None(),\n  priority = 0,\n  initialRetryDelay = None(),\n  maxRetryDelay = None()\n)"
   },
   "302" : {
     "command" : "participant2.domains.reconnect_all()",
@@ -69,7 +69,7 @@
   },
   "160" : {
     "command" : "val sequencerConnection = sequencerConnectionWithoutHighAvailability.addEndpoints(urls(1))",
-    "output" : "sequencerConnection : SequencerConnection = GrpcSequencerConnection(\n  endpoints = Seq(http://127.0.0.1:30123, http://127.0.0.1:30121),\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
+    "output" : "sequencerConnection : SequencerConnection = GrpcSequencerConnection(\n  endpoints = Seq(http://127.0.0.1:30811, http://127.0.0.1:30809),\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
   },
   "297" : {
     "command" : "participant2.domains.reconnect(\"mydomain\")",
@@ -81,7 +81,7 @@
   },
   "197" : {
     "command" : "val domainId = Some(domainManager1.id)",
-    "output" : "domainId : Some[DomainId] = Some(value = domainManager1::1220b9035a1f...)"
+    "output" : "domainId : Some[DomainId] = Some(value = domainManager1::1220366f0b65...)"
   },
   "329" : {
     "command" : "",
@@ -89,11 +89,11 @@
   },
   "224" : {
     "command" : "participant2.domains.list_connected()",
-    "output" : "res23: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'mydomain',\n    domainId = domainManager1::1220b9035a1f...,\n    healthy = true\n  )\n)"
+    "output" : "res23: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'mydomain',\n    domainId = domainManager1::1220366f0b65...,\n    healthy = true\n  )\n)"
   },
   "317" : {
     "command" : "mediator1.sequencer_connection.get()",
-    "output" : "res35: Option[SequencerConnections] = Some(\n  value = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://0.0.0.0:30123,\n    transportSecurity = false,\n    customTrustCertificates = None()\n  )\n)"
+    "output" : "res35: Option[SequencerConnections] = Some(\n  value = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://0.0.0.0:30811,\n    transportSecurity = false,\n    customTrustCertificates = None()\n  )\n)"
   },
   "169" : {
     "command" : "val connectionWithTLS = com.digitalasset.canton.sequencing.GrpcSequencerConnection.tryCreate(\"https://daml.com\", customTrustCertificates = Some(certificate))",
@@ -133,7 +133,7 @@
   },
   "230" : {
     "command" : "participant2.domains.config(\"mydomain\")",
-    "output" : "res24: Option[DomainConnectionConfig] = Some(\n  value = DomainConnectionConfig(\n    domain = Domain 'mydomain',\n    sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n      endpoints = https://127.0.0.1:30119,\n      transportSecurity = true,\n      customTrustCertificates = Some(2d2d2d2d2d42)\n    ),\n    manualConnect = false,\n    domainId = None(),\n    priority = 0,\n    initialRetryDelay = None(),\n    maxRetryDelay = None()\n  )\n)"
+    "output" : "res24: Option[DomainConnectionConfig] = Some(\n  value = DomainConnectionConfig(\n    domain = Domain 'mydomain',\n    sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n      endpoints = https://127.0.0.1:30807,\n      transportSecurity = true,\n      customTrustCertificates = Some(2d2d2d2d2d42)\n    ),\n    manualConnect = false,\n    domainId = None(),\n    priority = 0,\n    initialRetryDelay = None(),\n    maxRetryDelay = None()\n  )\n)"
   },
   "208" : {
     "command" : "participant4.domains.register(config)",
@@ -153,7 +153,7 @@
   },
   "155" : {
     "command" : "val sequencerConnectionWithoutHighAvailability = com.digitalasset.canton.sequencing.GrpcSequencerConnection.tryCreate(urls(0))",
-    "output" : "sequencerConnectionWithoutHighAvailability : GrpcSequencerConnection = GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:30123,\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
+    "output" : "sequencerConnectionWithoutHighAvailability : GrpcSequencerConnection = GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:30811,\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
   },
   "278" : {
     "command" : "participant2.domains.modify(\"mydomain\", _.copy(sequencerConnections=SequencerConnections.single(connection)))",
@@ -161,7 +161,7 @@
   },
   "267" : {
     "command" : "val certificate = com.digitalasset.canton.util.BinaryFileUtil.tryReadByteStringFromFile(\"tls/root-ca.crt\")",
-    "output" : "certificate : com.google.protobuf.ByteString = <ByteString@6f432dcb size=1960 contents=\"-----BEGIN CERTIFICATE-----\\nMIIFeTCCA2GgAwIBAgI...\">"
+    "output" : "certificate : com.google.protobuf.ByteString = <ByteString@57da4a78 size=1960 contents=\"-----BEGIN CERTIFICATE-----\\nMIIFeTCCA2GgAwIBAgI...\">"
   },
   "80" : {
     "command" : "sequencer3.config.publicApi.tls",
@@ -169,7 +169,7 @@
   },
   "150" : {
     "command" : "val urls = Seq(sequencer1, sequencer2).map(_.config.publicApi.port).map(port => s\"http://127.0.0.1:${port}\")",
-    "output" : "urls : Seq[String] = List(\"http://127.0.0.1:30123\", \"http://127.0.0.1:30121\")"
+    "output" : "urls : Seq[String] = List(\"http://127.0.0.1:30811\", \"http://127.0.0.1:30809\")"
   },
   "95" : {
     "command" : "val certificatesPath = \"tls/root-ca.crt\"",
@@ -177,15 +177,15 @@
   },
   "87" : {
     "command" : "val url = s\"https://127.0.0.1:${port}\"",
-    "output" : "url : String = \"https://127.0.0.1:30119\""
+    "output" : "url : String = \"https://127.0.0.1:30807\""
   },
   "218" : {
     "command" : "participant2.domains.list_registered()",
-    "output" : "res22: Seq[(DomainConnectionConfig, Boolean)] = Vector(\n  (\n    DomainConnectionConfig(\n      domain = Domain 'mydomain',\n      sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n        endpoints = https://127.0.0.1:30119,\n        transportSecurity = true,\n        customTrustCertificates = Some(2d2d2d2d2d42)\n      ),\n      manualConnect = false,\n      domainId = None(),\n      priority = 0,\n      initialRetryDelay = None(),\n      maxRetryDelay = None()\n    ),\n    true\n  )\n)"
+    "output" : "res22: Seq[(DomainConnectionConfig, Boolean)] = Vector(\n  (\n    DomainConnectionConfig(\n      domain = Domain 'mydomain',\n      sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n        endpoints = https://127.0.0.1:30807,\n        transportSecurity = true,\n        customTrustCertificates = Some(2d2d2d2d2d42)\n      ),\n      manualConnect = false,\n      domainId = None(),\n      priority = 0,\n      initialRetryDelay = None(),\n      maxRetryDelay = None()\n    ),\n    true\n  )\n)"
   },
   "168" : {
     "command" : "val certificate = com.digitalasset.canton.util.BinaryFileUtil.tryReadByteStringFromFile(\"tls/root-ca.crt\")",
-    "output" : "certificate : com.google.protobuf.ByteString = <ByteString@5ca338e4 size=1960 contents=\"-----BEGIN CERTIFICATE-----\\nMIIFeTCCA2GgAwIBAgI...\">"
+    "output" : "certificate : com.google.protobuf.ByteString = <ByteString@6c6397ad size=1960 contents=\"-----BEGIN CERTIFICATE-----\\nMIIFeTCCA2GgAwIBAgI...\">"
   },
   "183" : {
     "command" : "val manualConnect = false",
@@ -193,6 +193,6 @@
   },
   "273" : {
     "command" : "val connection = com.digitalasset.canton.sequencing.GrpcSequencerConnection.tryCreate(url, customTrustCertificates = Some(certificate))",
-    "output" : "connection : GrpcSequencerConnection = GrpcSequencerConnection(\n  endpoints = https://127.0.0.1:30119,\n  transportSecurity = true,\n  customTrustCertificates = Some(2d2d2d2d2d42)\n)"
+    "output" : "connection : GrpcSequencerConnection = GrpcSequencerConnection(\n  endpoints = https://127.0.0.1:30807,\n  transportSecurity = true,\n  customTrustCertificates = Some(2d2d2d2d2d42)\n)"
   }
 }

--- a/docs/2.8.0/docs/canton/includes/snippet_data/usermanual/identity_management.json
+++ b/docs/2.8.0/docs/canton/includes/snippet_data/usermanual/identity_management.json
@@ -1,5 +1,9 @@
 {
-  "565" : {
+  "629" : {
+    "command" : "participant2.topology.party_to_participant_mappings.authorize(TopologyChangeOp.Add, alice, participant2.id, RequestSide.To, ParticipantPermission.Submission)",
+    "output" : "res2: com.google.protobuf.ByteString = <ByteString@6204cdaa size=556 contents=\"\\n\\251\\004\\n\\327\\001\\n\\322\\001\\n\\317\\001\\022 pOTqf8KfSAziaKfKCrYwpW7o2sEyCfTt2...\">"
+  },
+  "550" : {
     "command" : "",
     "output" : ""
   },
@@ -7,85 +11,57 @@
     "command" : "participant1.ledger_api.users.get(user.id)",
     "output" : "res9: User = User(\n  id = \"myuser\",\n  primaryParty = None,\n  isActive = true,\n  annotations = Map(\"baz\" -> \"bar\", \"description\" -> \"This is a new description\"),\n  identityProviderId = \"\"\n)"
   },
-  "591" : {
+  "623" : {
     "command" : "",
     "output" : ""
   },
   "428" : {
     "command" : "participant1.ledger_api.users.rights.grant(id = user.id, actAs = Set(alice, bob), readAs = Set(eve), participantAdmin = true)",
-    "output" : "res11: UserRights = UserRights(\n  actAs = Set(bob::12207af325a3...),\n  readAs = Set(eve::12207af325a3...),\n  participantAdmin = true,\n  identityProviderAdmin = false\n)"
+    "output" : "res11: UserRights = UserRights(\n  actAs = Set(bob::1220ef4417b7...),\n  readAs = Set(eve::1220ef4417b7...),\n  participantAdmin = true,\n  identityProviderAdmin = false\n)"
+  },
+  "439" : {
+    "command" : "participant1.ledger_api.users.rights.list(user.id)",
+    "output" : "res13: UserRights = UserRights(\n  actAs = Set(alice::1220ef4417b7...),\n  readAs = Set(bob::1220ef4417b7..., eve::1220ef4417b7...),\n  participantAdmin = false,\n  identityProviderAdmin = false\n)"
   },
   "590" : {
     "command" : "",
     "output" : ""
   },
-  "393" : {
+  "573" : {
+    "command" : "participant2.domains.disconnect(\"mydomain\")",
+    "output" : ""
+  },
+  "621" : {
+    "command" : "val alice = participant1.parties.enable(\"Alice\")",
+    "output" : "alice : PartyId = Alice::12201637ff6c..."
+  },
+  "705" : {
     "command" : "",
     "output" : ""
   },
-  "618" : {
-    "command" : "participant2.domains.disconnect_all()",
-    "output" : ""
-  },
-  "402" : {
-    "command" : "participant1.ledger_api.users.get(\"myuser\", identityProviderId=\"idp-id1\")",
-    "output" : "res6: User = User(\n  id = \"myuser\",\n  primaryParty = None,\n  isActive = true,\n  annotations = Map(\"baz\" -> \"bar\", \"description\" -> \"This is a new description\"),\n  identityProviderId = \"idp-id1\"\n)"
-  },
-  "557" : {
-    "command" : "repair.party_migration.step3_enable_on_target(alice, participant2)",
-    "output" : ""
-  },
-  "673" : {
-    "command" : "",
-    "output" : ""
-  },
-  "446" : {
-    "command" : "participant1.ledger_api.users.list(filterUser = \"my\")",
-    "output" : "res15: UsersPage = UsersPage(\n  users = Vector(\n    User(\n      id = \"myotheruser\",\n      primaryParty = None,\n      isActive = true,\n      annotations = Map(),\n      identityProviderId = \"\"\n    ),\n    User(\n      id = \"myuser\",\n      primaryParty = None,\n      isActive = true,\n      annotations = Map(\"baz\" -> \"bar\", \"description\" -> \"This is a new description\"),\n      identityProviderId = \"\"\n    )\n  ),\n  nextPageToken = \"\"\n)"
-  },
-  "667" : {
-    "command" : "repair.party_migration.step2_import_acs(participant2, \"alice.acs.gz\")",
-    "output" : ""
-  },
-  "659" : {
-    "command" : "participant1.repair.download(Set(alice), \"alice.acs.gz\", filterDomainId=\"mydomain\", timestamp = Some(timestamp))",
-    "output" : ""
-  },
-  "645" : {
-    "command" : "participant1.health.ping(participant1.id)",
-    "output" : "res6: Duration = 635 milliseconds"
-  },
-  "518" : {
-    "command" : "",
-    "output" : ""
+  "549" : {
+    "command" : "val alice = participant1.parties.enable(\"Alice\")",
+    "output" : "alice : PartyId = Alice::12206a1457fd..."
   },
   "408" : {
     "command" : "participant1.ledger_api.users.get(\"myuser\", identityProviderId=\"\")",
     "output" : "res8: User = User(\n  id = \"myuser\",\n  primaryParty = None,\n  isActive = true,\n  annotations = Map(\"baz\" -> \"bar\", \"description\" -> \"This is a new description\"),\n  identityProviderId = \"\"\n)"
   },
+  "677" : {
+    "command" : "participant1.health.ping(participant1.id)",
+    "output" : "res6: Duration = 355 milliseconds"
+  },
   "597" : {
-    "command" : "participant2.topology.party_to_participant_mappings.authorize(TopologyChangeOp.Add, alice, participant2.id, RequestSide.To, ParticipantPermission.Submission)",
-    "output" : "res2: com.google.protobuf.ByteString = <ByteString@f166652 size=554 contents=\"\\n\\247\\004\\n\\327\\001\\n\\322\\001\\n\\317\\001\\022 065F3gyr8JKybE1s2NaUZw37lRbPTwaw2...\">"
+    "command" : "",
+    "output" : ""
   },
   "372" : {
     "command" : "val user = participant1.ledger_api.users.create(id = \"myuser\", actAs = Set(alice), readAs = Set(bob), primaryParty = Some(alice), participantAdmin = false, isActive = true, annotations = Map(\"foo\" -> \"bar\", \"description\" -> \"This is a description\"))",
-    "output" : "user : User = User(\n  id = \"myuser\",\n  primaryParty = Some(value = alice::12207af325a3...),\n  isActive = true,\n  annotations = Map(\"foo\" -> \"bar\", \"description\" -> \"This is a description\"),\n  identityProviderId = \"\"\n)"
+    "output" : "user : User = User(\n  id = \"myuser\",\n  primaryParty = Some(value = alice::1220ef4417b7...),\n  isActive = true,\n  annotations = Map(\"foo\" -> \"bar\", \"description\" -> \"This is a description\"),\n  identityProviderId = \"\"\n)"
   },
   "460" : {
     "command" : "participant1.ledger_api.users.list(\"myotheruser\")",
     "output" : "res17: UsersPage = UsersPage(users = Vector(), nextPageToken = \"\")"
-  },
-  "439" : {
-    "command" : "participant1.ledger_api.users.rights.list(user.id)",
-    "output" : "res13: UserRights = UserRights(\n  actAs = Set(alice::12207af325a3...),\n  readAs = Set(bob::12207af325a3..., eve::12207af325a3...),\n  participantAdmin = false,\n  identityProviderAdmin = false\n)"
-  },
-  "678" : {
-    "command" : "",
-    "output" : ""
-  },
-  "546" : {
-    "command" : "repair.party_migration.step2_import_acs(participant2, \"alice.acs.gz\")",
-    "output" : ""
   },
   "598" : {
     "command" : "",
@@ -99,25 +75,45 @@
     "command" : "participant1.ledger_api.users.update_idp(\"myuser\", sourceIdentityProviderId=\"idp-id1\", targetIdentityProviderId=\"\")",
     "output" : ""
   },
-  "566" : {
+  "630" : {
     "command" : "",
     "output" : ""
   },
-  "551" : {
+  "583" : {
     "command" : "participant2.domains.reconnect(\"mydomain\")",
     "output" : "res6: Boolean = true"
   },
-  "541" : {
-    "command" : "participant2.domains.disconnect(\"mydomain\")",
-    "output" : ""
-  },
-  "558" : {
+  "710" : {
     "command" : "",
     "output" : ""
   },
-  "530" : {
+  "578" : {
+    "command" : "repair.party_migration.step2_import_acs(participant2, \"alice.acs.gz\")",
+    "output" : ""
+  },
+  "650" : {
+    "command" : "participant2.domains.disconnect_all()",
+    "output" : ""
+  },
+  "622" : {
+    "command" : "",
+    "output" : ""
+  },
+  "393" : {
+    "command" : "",
+    "output" : ""
+  },
+  "584" : {
+    "command" : "",
+    "output" : ""
+  },
+  "562" : {
     "command" : "repair.party_migration.step1_hold_and_store_acs(alice, participant1, targetParticipantId, \"alice.acs.gz\")",
-    "output" : "res3: Map[DomainId, Long] = Map()"
+    "output" : ""
+  },
+  "402" : {
+    "command" : "participant1.ledger_api.users.get(\"myuser\", identityProviderId=\"idp-id1\")",
+    "output" : "res6: User = User(\n  id = \"myuser\",\n  primaryParty = None,\n  isActive = true,\n  annotations = Map(\"baz\" -> \"bar\", \"description\" -> \"This is a new description\"),\n  identityProviderId = \"idp-id1\"\n)"
   },
   "391" : {
     "command" : "val updatedUser = participant1.ledger_api.users.update(id = user.id, modifier = user => { user.copy(primaryParty = None, annotations = user.annotations.updated(\"description\", \"This is a new description\").removed(\"foo\").updated(\"baz\", \"bar\")) })",
@@ -127,7 +123,7 @@
     "command" : "participant1.ledger_api.users.create(id = \"myotheruser\")",
     "output" : "res14: User = User(\n  id = \"myotheruser\",\n  primaryParty = None,\n  isActive = true,\n  annotations = Map(),\n  identityProviderId = \"\"\n)"
   },
-  "672" : {
+  "704" : {
     "command" : "participant2.domains.reconnect_all()",
     "output" : ""
   },
@@ -137,42 +133,42 @@
   },
   "434" : {
     "command" : "participant1.ledger_api.users.rights.revoke(id = user.id, actAs = Set(bob), readAs = Set(alice), participantAdmin = true)",
-    "output" : "res12: UserRights = UserRights(\n  actAs = Set(bob::12207af325a3...),\n  readAs = Set(),\n  participantAdmin = true,\n  identityProviderAdmin = false\n)"
+    "output" : "res12: UserRights = UserRights(\n  actAs = Set(bob::1220ef4417b7...),\n  readAs = Set(),\n  participantAdmin = true,\n  identityProviderAdmin = false\n)"
   },
-  "631" : {
-    "command" : "participant1.parties.list(\"Alice\")",
-    "output" : "res5: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Alice::1220df7d96ce...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant2::1220a532b115...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220a35ef9f4..., permission = Submission)\n        )\n      ),\n      ParticipantDomains(\n        participant = PAR::participant1::1220df7d96ce...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220a35ef9f4..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
-  },
-  "552" : {
-    "command" : "",
-    "output" : ""
-  },
-  "626" : {
-    "command" : "participant1.topology.party_to_participant_mappings.authorize(TopologyChangeOp.Add, alice, participant2.id, RequestSide.From, ParticipantPermission.Submission)",
-    "output" : "res4: com.google.protobuf.ByteString = <ByteString@56f89b1b size=556 contents=\"\\n\\251\\004\\n\\327\\001\\n\\322\\001\\n\\317\\001\\022 LJCGYk1KGUI0bPaSEJHCulUglzsQ3lIr2...\">"
+  "685" : {
+    "command" : "val timestamp = participant1.topology.party_to_participant_mappings.list(filterStore=\"mydomain\", filterParty=\"Alice\").map(_.context.validFrom).max",
+    "output" : "timestamp : Instant = 2023-11-21T16:01:23.395676Z"
   },
   "455" : {
     "command" : "participant1.ledger_api.users.delete(\"myotheruser\")",
     "output" : ""
   },
   "563" : {
-    "command" : "participant1.domains.disconnect(\"mydomain\")",
+    "command" : "",
     "output" : ""
   },
-  "653" : {
-    "command" : "val timestamp = participant1.topology.party_to_participant_mappings.list(filterStore=\"mydomain\", filterParty=\"Alice\").map(_.context.validFrom).max",
-    "output" : "timestamp : Instant = 2023-06-22T12:42:10.034684Z"
+  "658" : {
+    "command" : "participant1.topology.party_to_participant_mappings.authorize(TopologyChangeOp.Add, alice, participant2.id, RequestSide.From, ParticipantPermission.Submission)",
+    "output" : "res4: com.google.protobuf.ByteString = <ByteString@31af0592 size=556 contents=\"\\n\\251\\004\\n\\327\\001\\n\\322\\001\\n\\317\\001\\022 FHyvQGL5laKYdqg2LdTeXP4VpMewcVlv2...\">"
   },
   "589" : {
-    "command" : "val alice = participant1.parties.enable(\"Alice\")",
-    "output" : "alice : PartyId = Alice::1220df7d96ce..."
+    "command" : "repair.party_migration.step3_enable_on_target(alice, participant2)",
+    "output" : ""
   },
-  "531" : {
+  "663" : {
+    "command" : "participant1.parties.list(\"Alice\")",
+    "output" : "res5: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Alice::12201637ff6c...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant2::1220b163d599...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220719ba79b..., permission = Submission)\n        )\n      ),\n      ParticipantDomains(\n        participant = PAR::participant1::12201637ff6c...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220719ba79b..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
+  },
+  "548" : {
     "command" : "",
     "output" : ""
   },
-  "516" : {
-    "command" : "",
+  "446" : {
+    "command" : "participant1.ledger_api.users.list(filterUser = \"my\")",
+    "output" : "res15: UsersPage = UsersPage(\n  users = Vector(\n    User(\n      id = \"myotheruser\",\n      primaryParty = None,\n      isActive = true,\n      annotations = Map(),\n      identityProviderId = \"\"\n    ),\n    User(\n      id = \"myuser\",\n      primaryParty = None,\n      isActive = true,\n      annotations = Map(\"baz\" -> \"bar\", \"description\" -> \"This is a new description\"),\n      identityProviderId = \"\"\n    )\n  ),\n  nextPageToken = \"\"\n)"
+  },
+  "595" : {
+    "command" : "participant1.domains.disconnect(\"mydomain\")",
     "output" : ""
   },
   "465" : {
@@ -181,42 +177,46 @@
   },
   "363" : {
     "command" : "val Seq(alice, bob, eve) = Seq(\"alice\", \"bob\", \"eve\").map(p => participant1.parties.enable(name = p, waitForDomain = DomainChoice.All))",
-    "output" : "Seq(alice, bob, eve) : Seq[PartyId] = List(alice::12207af325a3..., bob::12207af325a3..., eve::12207af325a3...)"
+    "output" : "Seq(alice, bob, eve) : Seq[PartyId] = List(alice::1220ef4417b7..., bob::1220ef4417b7..., eve::1220ef4417b7...)"
   },
-  "524" : {
+  "556" : {
     "command" : "val targetParticipantId = participant2.id",
-    "output" : "targetParticipantId : ParticipantId = PAR::participant2::12207334a68d..."
+    "output" : "targetParticipantId : ParticipantId = PAR::participant2::1220b05c458a..."
   },
-  "588" : {
-    "command" : "",
-    "output" : ""
-  },
-  "517" : {
-    "command" : "val alice = participant1.parties.enable(\"Alice\")",
-    "output" : "alice : PartyId = Alice::12204dc1e4c4..."
-  },
-  "632" : {
-    "command" : "",
+  "699" : {
+    "command" : "repair.party_migration.step2_import_acs(participant2, \"alice.acs.gz\")",
     "output" : ""
   },
   "401" : {
     "command" : "participant1.ledger_api.users.update_idp(\"myuser\", sourceIdentityProviderId=\"\", targetIdentityProviderId=\"idp-id1\")",
     "output" : ""
   },
+  "620" : {
+    "command" : "",
+    "output" : ""
+  },
   "422" : {
     "command" : "participant1.ledger_api.users.rights.list(user.id)",
-    "output" : "res10: UserRights = UserRights(\n  actAs = Set(alice::12207af325a3...),\n  readAs = Set(bob::12207af325a3...),\n  participantAdmin = false,\n  identityProviderAdmin = false\n)"
+    "output" : "res10: UserRights = UserRights(\n  actAs = Set(alice::1220ef4417b7...),\n  readAs = Set(bob::1220ef4417b7...),\n  participantAdmin = false,\n  identityProviderAdmin = false\n)"
   },
   "373" : {
     "command" : "",
     "output" : ""
   },
-  "564" : {
-    "command" : "repair.party_migration.step4_clean_up_source(alice, participant1, \"alice.acs.gz\")",
+  "664" : {
+    "command" : "",
     "output" : ""
   },
   "400" : {
     "command" : "participant1.ledger_api.identity_provider_config.create(\"idp-id1\", isDeactivated = false, jwksUrl = \"http://someurl\", issuer = \"issuer1\", audience = None)",
     "output" : "res4: com.digitalasset.canton.ledger.api.domain.IdentityProviderConfig = IdentityProviderConfig(\n  identityProviderId = Id(value = \"idp-id1\"),\n  isDeactivated = false,\n  jwksUrl = JwksUrl(value = \"http://someurl\"),\n  issuer = \"issuer1\",\n  audience = None\n)"
+  },
+  "596" : {
+    "command" : "repair.party_migration.step4_clean_up_source(alice, participant1, \"alice.acs.gz\")",
+    "output" : ""
+  },
+  "691" : {
+    "command" : "participant1.repair.download(Set(alice), \"alice.acs.gz\", filterDomainId=\"mydomain\", timestamp = Some(timestamp))",
+    "output" : ""
   }
 }

--- a/docs/2.8.0/docs/canton/includes/snippet_data/usermanual/manage_domain_entities.json
+++ b/docs/2.8.0/docs/canton/includes/snippet_data/usermanual/manage_domain_entities.json
@@ -1,7 +1,7 @@
 {
   "138" : {
     "command" : "mediator1.mediator.initialize(domainId, MediatorId(domainId), domainParameters, sequencerConnections, None)",
-    "output" : "res20: PublicKey = SigningPublicKey(id = 1220189c84ae..., format = Tink, scheme = Ed25519)"
+    "output" : "res20: PublicKey = SigningPublicKey(id = 12207a13f7a1..., format = Tink, scheme = Ed25519)"
   },
   "120" : {
     "command" : "domainManager1.topology.all.list().collectOfType[TopologyChangeOp.Positive].writeToFile(\"tmp/domain-bootstrapping-files/topology-transactions.proto\")",
@@ -9,11 +9,11 @@
   },
   "84" : {
     "command" : "val domainIdString = domainManager1.id.toProtoPrimitive",
-    "output" : "domainIdString : String = \"domainManager1::1220be641b8b69c9e56c6548ac78437f05e2fdc0be96df9a70dfe2e403d28da0de9b\""
+    "output" : "domainIdString : String = \"domainManager1::12205a5398acf9970bb74a45d1940155e501ad374f1789ee3d7703bd7796fee73d8e\""
   },
   "92" : {
     "command" : "val domainId = DomainId.tryFromString(domainIdString)",
-    "output" : "domainId : DomainId = domainManager1::1220be641b8b..."
+    "output" : "domainId : DomainId = domainManager1::12205a5398ac..."
   },
   "129" : {
     "command" : "sequencer1.initialization.bootstrap_topology(initialTopology)",
@@ -25,7 +25,7 @@
   },
   "144" : {
     "command" : "val sequencerConnection = SequencerConnections.tryReadFromFile(\"tmp/domain-bootstrapping-files/sequencer-connection.proto\")",
-    "output" : "sequencerConnection : SequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:30141,\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
+    "output" : "sequencerConnection : SequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:30829,\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
   },
   "113" : {
     "command" : "domainManager1.setup.helper.authorizeKey(mediatorKey, \"mediator1\", MediatorId(domainId))",
@@ -33,7 +33,7 @@
   },
   "91" : {
     "command" : "val domainParameters = com.digitalasset.canton.admin.api.client.data.StaticDomainParameters.tryReadFromFile(\"tmp/domain-bootstrapping-files/params.proto\")",
-    "output" : "domainParameters : StaticDomainParameters = StaticDomainParametersV1(\n  uniqueContractKeys = true,\n  requiredSigningKeySchemes = Set(Ed25519, ECDSA-P256, ECDSA-P384),\n  requiredEncryptionKeySchemes = Set(ECIES-P256_HMAC256_AES128-GCM),\n  requiredSymmetricKeySchemes = Set(AES128-GCM),\n  requiredHashAlgorithms = Set(Sha256),\n  requiredCryptoKeyFormats = Set(Tink),\n  protocolVersion = 4\n)"
+    "output" : "domainParameters : StaticDomainParameters = StaticDomainParametersV1(\n  uniqueContractKeys = true,\n  requiredSigningKeySchemes = Set(Ed25519, ECDSA-P256, ECDSA-P384),\n  requiredEncryptionKeySchemes = Set(ECIES-P256_HMAC256_AES128-GCM),\n  requiredSymmetricKeySchemes = Set(AES128-GCM),\n  requiredHashAlgorithms = Set(Sha256),\n  requiredCryptoKeyFormats = Set(Tink, Raw, DER),\n  protocolVersion = 5\n)"
   },
   "130" : {
     "command" : "SequencerConnections.single(sequencer1.sequencerConnection).writeToFile(\"tmp/domain-bootstrapping-files/sequencer-connection.proto\")",
@@ -45,7 +45,7 @@
   },
   "99" : {
     "command" : "val sequencerPublicKey = SigningPublicKey.tryReadFromFile(\"tmp/domain-bootstrapping-files/seq1-key.proto\")",
-    "output" : "sequencerPublicKey : SigningPublicKey = SigningPublicKey(id = 122050ae909a..., format = Tink, scheme = Ed25519)"
+    "output" : "sequencerPublicKey : SigningPublicKey = SigningPublicKey(id = 1220cbedd319..., format = Tink, scheme = Ed25519)"
   },
   "42" : {
     "command" : "domainManager1.setup.bootstrap_domain(Seq(sequencer1), Seq(mediator1))",
@@ -61,11 +61,11 @@
   },
   "93" : {
     "command" : "val initResponse = sequencer1.initialization.initialize_from_beginning(domainId, domainParameters)",
-    "output" : "initResponse : com.digitalasset.canton.domain.sequencing.admin.grpc.InitializeSequencerResponse = InitializeSequencerResponse(\n  keyId = \"sequencer-id\",\n  publicKey = SigningPublicKey(id = 122050ae909a..., format = Tink, scheme = Ed25519),\n  replicated = false\n)"
+    "output" : "initResponse : com.digitalasset.canton.domain.sequencing.admin.grpc.InitializeSequencerResponse = InitializeSequencerResponse(\n  keyId = \"sequencer-id\",\n  publicKey = SigningPublicKey(id = 1220cbedd319..., format = Tink, scheme = Ed25519),\n  replicated = false\n)"
   },
   "152" : {
     "command" : "participant1.health.ping(participant1)",
-    "output" : "res26: Duration = 948 milliseconds"
+    "output" : "res26: Duration = 361 milliseconds"
   },
   "28" : {
     "command" : "",
@@ -73,7 +73,7 @@
   },
   "137" : {
     "command" : "val domainParameters = com.digitalasset.canton.admin.api.client.data.StaticDomainParameters.tryReadFromFile(\"tmp/domain-bootstrapping-files/params.proto\")",
-    "output" : "domainParameters : StaticDomainParameters = StaticDomainParametersV1(\n  uniqueContractKeys = true,\n  requiredSigningKeySchemes = Set(Ed25519, ECDSA-P256, ECDSA-P384),\n  requiredEncryptionKeySchemes = Set(ECIES-P256_HMAC256_AES128-GCM),\n  requiredSymmetricKeySchemes = Set(AES128-GCM),\n  requiredHashAlgorithms = Set(Sha256),\n  requiredCryptoKeyFormats = Set(Tink),\n  protocolVersion = 4\n)"
+    "output" : "domainParameters : StaticDomainParameters = StaticDomainParametersV1(\n  uniqueContractKeys = true,\n  requiredSigningKeySchemes = Set(Ed25519, ECDSA-P256, ECDSA-P384),\n  requiredEncryptionKeySchemes = Set(ECIES-P256_HMAC256_AES128-GCM),\n  requiredSymmetricKeySchemes = Set(AES128-GCM),\n  requiredHashAlgorithms = Set(Sha256),\n  requiredCryptoKeyFormats = Set(Tink, Raw, DER),\n  protocolVersion = 5\n)"
   },
   "33" : {
     "command" : "domainManager1.health.wait_for_identity()",
@@ -97,7 +97,7 @@
   },
   "112" : {
     "command" : "val domainId = DomainId.tryFromString(domainIdString)",
-    "output" : "domainId : DomainId = domainManager1::1220be641b8b..."
+    "output" : "domainId : DomainId = domainManager1::12205a5398ac..."
   },
   "145" : {
     "command" : "domainManager1.setup.init(sequencerConnection)",
@@ -109,7 +109,7 @@
   },
   "127" : {
     "command" : "val initialTopology = com.digitalasset.canton.topology.store.StoredTopologyTransactions.tryReadFromFile(\"tmp/domain-bootstrapping-files/topology-transactions.proto\").collectOfType[TopologyChangeOp.Positive]",
-    "output" : "initialTopology : store.StoredTopologyTransactions[TopologyChangeOp.Positive] = Seq(\n  StoredTopologyTransaction(\n    sequenced = 2023-06-12T12:19:31.150925Z,\n    validFrom = 2023-06-12T12:19:31.150925Z,\n    validUntil = 2023-06-12T12:19:31.150925Z,\n    op = Add,\n.."
+    "output" : "initialTopology : store.StoredTopologyTransactions[TopologyChangeOp.Positive] = Seq(\n  StoredTopologyTransaction(\n    sequenced = 2023-11-21T16:01:05.580750Z,\n    validFrom = 2023-11-21T16:01:05.580750Z,\n    validUntil = 2023-11-21T16:01:05.580750Z,\n    op = Add,\n.."
   },
   "26" : {
     "command" : "",
@@ -117,7 +117,7 @@
   },
   "114" : {
     "command" : "domainManager1.topology.mediator_domain_states.authorize(TopologyChangeOp.Add, domainId, MediatorId(domainId), RequestSide.Both)",
-    "output" : "res13: com.google.protobuf.ByteString = <ByteString@227271fd size=560 contents=\"\\n\\255\\004\\n\\333\\001\\n\\326\\001\\n\\323\\001\\022 TJu4dWv2cpqPUOi2StZtQyuEE2BjPM0UR...\">"
+    "output" : "res13: com.google.protobuf.ByteString = <ByteString@3de2507a size=560 contents=\"\\n\\255\\004\\n\\333\\001\\n\\326\\001\\n\\323\\001\\022 gq1gqFyqx99AOvBQRufV5aTRlQc2Fw5xR...\">"
   },
   "139" : {
     "command" : "mediator1.health.wait_for_initialized()",
@@ -137,11 +137,11 @@
   },
   "51" : {
     "command" : "participant1.health.ping(participant1)",
-    "output" : "res7: Duration = 5514 milliseconds"
+    "output" : "res7: Duration = 411 milliseconds"
   },
   "136" : {
     "command" : "val sequencerConnections = SequencerConnections.tryReadFromFile(\"tmp/domain-bootstrapping-files/sequencer-connection.proto\")",
-    "output" : "sequencerConnections : SequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:30141,\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
+    "output" : "sequencerConnections : SequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:30829,\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
   },
   "94" : {
     "command" : "initResponse.publicKey.writeToFile(\"tmp/domain-bootstrapping-files/seq1-key.proto\")",
@@ -149,7 +149,7 @@
   },
   "111" : {
     "command" : "val mediatorKey = SigningPublicKey.tryReadFromFile(\"tmp/domain-bootstrapping-files/med1-key.proto\")",
-    "output" : "mediatorKey : SigningPublicKey = SigningPublicKey(id = 122097079077..., format = Tink, scheme = Ed25519)"
+    "output" : "mediatorKey : SigningPublicKey = SigningPublicKey(id = 1220117ddd66..., format = Tink, scheme = Ed25519)"
   },
   "83" : {
     "command" : "domainManager1.service.get_static_domain_parameters.writeToFile(\"tmp/domain-bootstrapping-files/params.proto\")",

--- a/docs/2.8.0/docs/canton/includes/snippet_data/usermanual/manage_domains.json
+++ b/docs/2.8.0/docs/canton/includes/snippet_data/usermanual/manage_domains.json
@@ -1,7 +1,7 @@
 {
   "101" : {
     "command" : "participant1.health.ping(participant1)",
-    "output" : "res10: Duration = 2646 milliseconds"
+    "output" : "res10: Duration = 2822 milliseconds"
   },
   "84" : {
     "command" : "",
@@ -21,7 +21,7 @@
   },
   "73" : {
     "command" : "domainManager1.topology.participant_domain_states.list(filterStore=\"Authorized\").map(_.item)",
-    "output" : "res6: Seq[ParticipantState] = Vector(\n  ParticipantState(\n    From,\n    domainManager1::1220ce9a486a...,\n    PAR::participant1::12201c55b3f9...,\n    Submission,\n    Ordinary\n  )\n)"
+    "output" : "res6: Seq[ParticipantState] = Vector(\n  ParticipantState(\n    From,\n    domainManager1::1220d2ee4eb7...,\n    PAR::participant1::122004e7fb4e...,\n    Submission,\n    Ordinary\n  )\n)"
   },
   "66" : {
     "command" : "",
@@ -29,11 +29,11 @@
   },
   "95" : {
     "command" : "domainManager1.topology.participant_domain_states.list(filterStore=\"Authorized\").map(_.item)",
-    "output" : "res9: Seq[ParticipantState] = Vector(\n  ParticipantState(\n    From,\n    domainManager1::1220ce9a486a...,\n    PAR::participant1::12201c55b3f9...,\n    Submission,\n    Ordinary\n  ),\n  ParticipantState(\n    To,\n    domainManager1::1220ce9a486a...,\n    PAR::participant1::12201c55b3f9...,\n    Submission,\n    Ordinary\n  )\n)"
+    "output" : "res9: Seq[ParticipantState] = Vector(\n  ParticipantState(\n    From,\n    domainManager1::1220d2ee4eb7...,\n    PAR::participant1::122004e7fb4e...,\n    Submission,\n    Ordinary\n  ),\n  ParticipantState(\n    To,\n    domainManager1::1220d2ee4eb7...,\n    PAR::participant1::122004e7fb4e...,\n    Submission,\n    Ordinary\n  )\n)"
   },
   "50" : {
     "command" : "val participantAsString = participant1.id.toProtoPrimitive",
-    "output" : "participantAsString : String = \"PAR::participant1::12201c55b3f9bd2090569099ed1a2eb60a872cad7170cb286a5e09b01bf32d856037\""
+    "output" : "participantAsString : String = \"PAR::participant1::122004e7fb4e6490729681a35ddc903cdd9d1783e440bbff67fcc50ccce910ae0ae2\""
   },
   "43" : {
     "command" : "",
@@ -41,7 +41,7 @@
   },
   "55" : {
     "command" : "val participantIdFromString = ParticipantId.tryFromProtoPrimitive(participantAsString)",
-    "output" : "participantIdFromString : ParticipantId = PAR::participant1::12201c55b3f9..."
+    "output" : "participantIdFromString : ParticipantId = PAR::participant1::122004e7fb4e..."
   },
   "36" : {
     "command" : "",
@@ -49,11 +49,11 @@
   },
   "42" : {
     "command" : "participant1.domains.register(config)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PARTICIPANT_IS_NOT_ACTIVE(9,20d5cc73): The participant is not yet active\n  Request: RegisterDomain(DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(endpoints = http://127.0.0.1:30078, transportSecurity = false, customTrustCertificates = None()),\n   ...\n  CorrelationId: 20d5cc7385cb9dc0895e47ef8fc0495f\n  Context: HashMap(participant -> participant1, test -> ManagePermissionedDomainsDocumentationManual, serverResponse -> Domain Domain 'mydomain' has rejected our on-boarding attempt, domain -> mydomain, tid -> 20d5cc7385cb9dc0895e47ef8fc0495f)\n  Command ParticipantAdministration$domains$.register invoked from cmd10000006.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PARTICIPANT_IS_NOT_ACTIVE(9,a7de072c): The participant is not yet active\n  Request: RegisterDomain(DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(endpoints = http://127.0.0.1:30755, transportSecurity = false, customTrustCertificates = None()),\n   ...\n  CorrelationId: a7de072ca88d4d52dc747af45c19032d\n  Context: HashMap(participant -> participant1, test -> ManagePermissionedDomainsDocumentationManual, serverResponse -> Domain Domain 'mydomain' has rejected our on-boarding attempt, domain -> mydomain, tid -> a7de072ca88d4d52dc747af45c19032d)\n  Command ParticipantAdministration$domains$.register invoked from cmd10000006.sc:1"
   },
   "37" : {
     "command" : "val config = DomainConnectionConfig(\"mydomain\", sequencer1.sequencerConnection)",
-    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://127.0.0.1:30078,\n    transportSecurity = false,\n.."
+    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://127.0.0.1:30755,\n    transportSecurity = false,\n.."
   },
   "89" : {
     "command" : "domainManager1.participants.active(participantIdFromString)",

--- a/docs/2.8.0/docs/canton/includes/snippet_data/usermanual/packagemanagement.json
+++ b/docs/2.8.0/docs/canton/includes/snippet_data/usermanual/packagemanagement.json
@@ -5,15 +5,15 @@
   },
   "124" : {
     "command" : "val darHash_ = participant1.dars.list().filter(_.name == \"CantonExamples\").head.hash",
-    "output" : "darHash_ : String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "darHash_ : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "173" : {
     "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(archiveIouCmd))",
-    "output" : "res24: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220e94572b389df0216fefdbbd67933938779a64c789fa2a2fd01a9ad19ea34125d\",\n  commandId = \"a638b802-02b4-4fdb-a4f6-a3d59a6777f5\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
+    "output" : "res24: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220eb5d82ae2925552306be22fcf86e501377e8b4a2b17254f8acf7b0ce69bd881f\",\n  commandId = \"88a6e285-9826-4386-994f-172cfd772ebe\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
   },
   "118" : {
     "command" : "val packagesBefore = participant1.packages.list().map(_.packageId).toSet",
-    "output" : "packagesBefore : Set[String] = HashSet(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"5921708ce82f4255deb1b26d2c05358b548720938a5a325718dc69f381ba47ff\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"bef3d1e9c2f8be31f80c032e930c85e336da27b64ebb1e3a31c9072e9df3a14b\",\n  \"6839a6d3d430c569b2425e9391717b44ca324b88ba621d597778811b2d05031d\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"e22bce619ae24ca3b8e6519281cb5a33b64b3190cc763248b4c3f9ad5087a92c\",\n  \"d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97\",\n  \"6c2c0667393c5f92f1885163068cd31800d2264eb088eb6fc740e11241b2bf06\",\n.."
+    "output" : "packagesBefore : Set[String] = HashSet(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"5921708ce82f4255deb1b26d2c05358b548720938a5a325718dc69f381ba47ff\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"6839a6d3d430c569b2425e9391717b44ca324b88ba621d597778811b2d05031d\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"e22bce619ae24ca3b8e6519281cb5a33b64b3190cc763248b4c3f9ad5087a92c\",\n  \"d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97\",\n  \"6c2c0667393c5f92f1885163068cd31800d2264eb088eb6fc740e11241b2bf06\",\n  \"fdd56e2ece40d67781248bc47663c9112122e35eec580b7e93ee7cfa83cda2cc\",\n.."
   },
   "159" : {
     "command" : "participant1.domains.connect_local(mydomain)",
@@ -21,11 +21,11 @@
   },
   "263" : {
     "command" : "val iou = participant1.ledger_api.acs.find_generic(participant1.adminParty, _.templateId.isModuleEntity(\"Iou\", \"Iou\"))",
-    "output" : "iou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#12204b37add31c559ac455ef8b81c5b2b4b4a9fc582aa8af26312b9fdcff5f8f0722:0\",\n    contractId = \"00f83a2f1d08029ba57a7d094db04e384e65ca77db569936e4b4ead52805993eb4ca0112209b309891c946638a730ced565114bd0a976b5df45f3a12d4f2d78d5c2fc2ce4d\",\n    templateId = Some(\n      value = Identifier(\n        packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n        moduleName = \"Iou\",\n        entityName = \"Iou\"\n      )\n.."
+    "output" : "iou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#12206a583221a67e432ba7a7ed6097cf3e9216ed2b2bf76874b24d3e01d3d3760b75:0\",\n    contractId = \"0089706b2eecd481436897fe503f438458539b6e8c41f270e38516a92b31032109ca021220e9f0db900b810a0ac8409559f7f146d89ab25cd892be3d2c950f8af66f192614\",\n    templateId = Some(\n      value = Identifier(\n        packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n        moduleName = \"Iou\",\n        entityName = \"Iou\"\n      )\n.."
   },
   "195" : {
     "command" : "participant1.dars.remove(darHash)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,6d26d83c): An error was encountered whilst trying to unvet the DAR DarDescriptor(SHA-256:c783022e36ad...,CantonExamples) with main package 9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0 for DAR removal. Details: IdentityManagerParentError(Mapping(VettedPackages(\n  participant = participant1::12203c8338b7...,\n  packages = Seq(\n    9d65f326a67a...,\n    bef3d1e9c2f8...,\n    cb0552debf21...,\n    3f4deaf145a1...,\n    86828b984346...,\n    f20de1e4e37b...,\n    76bf0fd12bd9...,\n    38e6274601b2...,\n    d58cf...\n  Request: RemoveDar(1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476)\n  CorrelationId: 6d26d83cdf69a4e4f41f56f2d3f1e28c\n  Context: Map(participant -> participant1, tid -> 6d26d83cdf69a4e4f41f56f2d3f1e28c, test -> PackageDarManagementDocumentationIntegrationTest)\n  Command ParticipantAdministration$dars$.remove invoked from cmd10000076.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,44730a8c): An error was encountered whilst trying to unvet the DAR DarDescriptor(SHA-256:cf7693f5858d...,CantonExamples) with main package 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680 for DAR removal. Details: IdentityManagerParentError(Mapping(VettedPackages(\n  participant = participant1::122042762b7b...,\n  packages = Seq(\n    6087107abcaa...,\n    a566728bb2d4...,\n    cb0552debf21...,\n    3f4deaf145a1...,\n    86828b984346...,\n    f20de1e4e37b...,\n    76bf0fd12bd9...,\n    38e6274601b2...,\n    d58cf...\n  Request: RemoveDar(1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c)\n  CorrelationId: 44730a8c36a5f1142283fa4cfab20bdc\n  Context: Map(participant -> participant1, tid -> 44730a8c36a5f1142283fa4cfab20bdc, test -> PackageDarManagementDocumentationIntegrationTest)\n  Command ParticipantAdministration$dars$.remove invoked from cmd10000076.sc:1"
   },
   "276" : {
     "command" : "participant1.packages.remove(packageId)",
@@ -33,15 +33,15 @@
   },
   "247" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "darHash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "42" : {
     "command" : "val darContent = participant2.dars.list_contents(hash)",
-    "output" : "darContent : DarMetadata = DarMetadata(\n  name = \"CantonExamples\",\n  main = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n  packages = Vector(\n    \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n    \"bef3d1e9c2f8be31f80c032e930c85e336da27b64ebb1e3a31c9072e9df3a14b\",\n    \"cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a\",\n    \"3f4deaf145a15cdcfa762c058005e2edb9baa75bb7f95a4f8f6f937378e86415\",\n.."
+    "output" : "darContent : DarMetadata = DarMetadata(\n  name = \"CantonExamples\",\n  main = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n  packages = Vector(\n    \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n    \"a566728bb2d4ad0103eb11ff8140296f4cea4fc94f1f95ddc6c3e4f983d107f1\",\n    \"cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a\",\n    \"3f4deaf145a15cdcfa762c058005e2edb9baa75bb7f95a4f8f6f937378e86415\",\n.."
   },
   "37" : {
     "command" : "val hash = dars.head.hash",
-    "output" : "hash : String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "hash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "125" : {
     "command" : "",
@@ -49,7 +49,7 @@
   },
   "157" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "darHash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "189" : {
     "command" : "val packageIds = participant1.packages.list().filter(_.sourceDescription == \"CantonExamples\").map(_.packageId).map(PackageId.assertFromString)",
@@ -57,11 +57,11 @@
   },
   "20" : {
     "command" : "participant2.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "res1: String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "res1: String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "253" : {
     "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
-    "output" : "res39: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"12204b37add31c559ac455ef8b81c5b2b4b4a9fc582aa8af26312b9fdcff5f8f0722\",\n  commandId = \"9c107e7c-e63a-46af-bfbc-7dc36d0e6a31\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1686572343L,\n      nanos = 324270000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n.."
+    "output" : "res39: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"12206a583221a67e432ba7a7ed6097cf3e9216ed2b2bf76874b24d3e01d3d3760b75\",\n  commandId = \"acdf8522-5d80-4e06-b479-2174827b3afd\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1700582453L,\n      nanos = 82326000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n.."
   },
   "238" : {
     "command" : "participant1.packages.remove(packageId)",
@@ -73,11 +73,11 @@
   },
   "221" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "darHash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "265" : {
     "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(archiveIouCmd))",
-    "output" : "res42: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220fb7be1e400fe1f2d4506b8c5fa1c383e200150667e1feffbbe6b81f4b23695a1\",\n  commandId = \"9605fb99-b2f5-4483-aadf-82f9464041e3\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1686572344L,\n      nanos = 187726000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n  ),\n  offset = \"00000000000000000c\",\n.."
+    "output" : "res42: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"122032f35a1bca685ed4c8a42b7cf0c1029ae5155fa8a57d895f9eea319d640ab3d0\",\n  commandId = \"a47f3270-b3a7-40ab-9305-12b3bce8c7c0\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1700582453L,\n      nanos = 531855000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n  ),\n  offset = \"00000000000000000c\",\n.."
   },
   "292" : {
     "command" : "participant1.packages.remove(packageId, force = true)",
@@ -85,11 +85,11 @@
   },
   "233" : {
     "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove, participant1.id, packageIds, force = true)",
-    "output" : "res35: com.google.protobuf.ByteString = <ByteString@4fb290fb size=2384 contents=\"\\n\\315\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 mpi2lnnmh4OW4bQLCDbKw64QaIc9acP...\">"
+    "output" : "res35: com.google.protobuf.ByteString = <ByteString@78a09f12 size=2386 contents=\"\\n\\317\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 AA9hgdF6EdW1O3HrrGffNCi12iz5JfF...\">"
   },
   "270" : {
     "command" : "val packageIds = participant1.topology.vetted_packages.list().map(_.item.packageIds).filter(_.contains(packageId)).head",
-    "output" : "packageIds : Seq[com.digitalasset.canton.package.LfPackageId] = Vector(\n  \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n  \"bef3d1e9c2f8be31f80c032e930c85e336da27b64ebb1e3a31c9072e9df3a14b\",\n.."
+    "output" : "packageIds : Seq[com.digitalasset.canton.package.LfPackageId] = Vector(\n  \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n  \"a566728bb2d4ad0103eb11ff8140296f4cea4fc94f1f95ddc6c3e4f983d107f1\",\n.."
   },
   "201" : {
     "command" : "participant1.dars.remove(darHash)",
@@ -97,7 +97,7 @@
   },
   "28" : {
     "command" : "participant2.dars.list()",
-    "output" : "res2: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\",\n    name = \"CantonExamples\"\n  ),\n  DarDescription(\n    hash = \"122012a6f2b7c0b666e7541ce6f5d4273ab8d00da671b4d3bbb9bebb6a5120ec02c5\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  )\n)"
+    "output" : "res2: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220caf9b815c77d40b24801fc88acaa85bffac5cc315644c8242923d039d8df6d73\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  ),\n  DarDescription(\n    hash = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\",\n    name = \"CantonExamples\"\n  )\n)"
   },
   "160" : {
     "command" : "val createIouCmd = ledger_api_utils.create(packageId,\"Iou\",\"Iou\",Map(\"payer\" -> participant1.adminParty,\"owner\" -> participant1.adminParty,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
@@ -113,19 +113,19 @@
   },
   "166" : {
     "command" : "participant1.dars.remove(darHash)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,40ff158c): The DAR DarDescriptor(SHA-256:c783022e36ad...,CantonExamples) cannot be removed because its main package 9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0 is in-use by contract ContractId(005170f294b69a37a7ba0c30a8f0c6ea1ab81e142e74fb146f19104af801cac302ca0112203845e89891f897f3bbc66395732e4994ccd4b3e26ebc9a46ca0e272d4c284422)\non domain mydomain::1220bf7c580f....\n  Request: RemoveDar(1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476)\n  CorrelationId: 40ff158cd233c870d3dcba1e95b267bb\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, pkg -> 9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0, tid -> 40ff158cd233c870d3dcba1e95b267bb)\n  Command ParticipantAdministration$dars$.remove invoked from cmd10000056.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,0c6258f1): The DAR DarDescriptor(SHA-256:cf7693f5858d...,CantonExamples) cannot be removed because its main package 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680 is in-use by contract ContractId(002ac723b60cf62b827fa1fbfb4760fbf35b337d19519c30a56ba4df5b1ef7aec8ca0212207ed3d4db9505f19e9aa96a6dd1e7f51eeaa883bb6af3f559400d4ec814b7ffc8)\non domain mydomain::12208be8725d....\n  Request: RemoveDar(1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c)\n  CorrelationId: 0c6258f136abe1f759cadb551d35cfd4\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, pkg -> 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680, tid -> 0c6258f136abe1f759cadb551d35cfd4)\n  Command ParticipantAdministration$dars$.remove invoked from cmd10000056.sc:1"
   },
   "264" : {
     "command" : "val archiveIouCmd = ledger_api_utils.exercise(\"Archive\", Map.empty, iou.event)",
-    "output" : "archiveIouCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Exercise(\n    value = ExerciseCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n          moduleName = \"Iou\",\n          entityName = \"Iou\"\n        )\n      ),\n.."
+    "output" : "archiveIouCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Exercise(\n    value = ExerciseCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n          moduleName = \"Iou\",\n          entityName = \"Iou\"\n        )\n      ),\n.."
   },
   "161" : {
     "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
-    "output" : "res21: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220140615c40a381f9b867ceb78961bb1fbaceb82c8c52259ce4c5e83940bd4fc4e\",\n  commandId = \"09fd6428-b7a8-49eb-9972-85f1f3dd9376\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
+    "output" : "res21: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220f85c004ec07426ad8085d75d9be6055375b59a4d25f88dcd4f8917c2cb7c32f1\",\n  commandId = \"05db6b8f-cbd6-4420-baa9-16288075383a\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
   },
   "187" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\", vetAllPackages = false)",
-    "output" : "darHash : String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "darHash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "172" : {
     "command" : "val archiveIouCmd = ledger_api_utils.exercise(\"Archive\", Map.empty, iou.event)",
@@ -133,7 +133,7 @@
   },
   "271" : {
     "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove, participant1.id, packageIds, force = true)",
-    "output" : "res44: com.google.protobuf.ByteString = <ByteString@6328d67d size=2384 contents=\"\\n\\315\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 LJkyooFPhwkMj4HzoHpmsrxdXvEDWsP...\">"
+    "output" : "res44: com.google.protobuf.ByteString = <ByteString@7c1f16ea size=2386 contents=\"\\n\\317\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 2aXrz9G79rgWdmaV06VuNHedCk2vgyl...\">"
   },
   "130" : {
     "command" : "participant1.dars.remove(darHash)",
@@ -141,15 +141,15 @@
   },
   "135" : {
     "command" : "val packageIds = participant1.packages.list().filter(_.sourceDescription == \"CantonExamples\").map(_.packageId)",
-    "output" : "packageIds : Seq[String] = Vector(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"e491352788e56ca4603acc411ffe1a49fefd76ed8b163af86cf5ee5f4c38645b\",\n  \"cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a\",\n  \"38e6274601b21d7202bb995bc5ec147decda5a01b68d57dda422425038772af7\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"f20de1e4e37b92280264c08bf15eca0be0bc5babd7a7b5e574997f154c00cb78\",\n  \"283fdcf3bbbc04db4ee15ba5760dbe459aee1087f358b7e6cd4d7da2ff36e776\",\n  \"8a7806365bbd98d88b4c13832ebfa305f6abaeaf32cfa2b7dd25c4fa489b79fb\",\n.."
+    "output" : "packageIds : Seq[String] = Vector(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"e491352788e56ca4603acc411ffe1a49fefd76ed8b163af86cf5ee5f4c38645b\",\n  \"55aeefaf7bfb7f275f52b402f419f71c8e529b6ec625812d2a4e80f280fd86d4\",\n  \"cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a\",\n  \"38e6274601b21d7202bb995bc5ec147decda5a01b68d57dda422425038772af7\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"a566728bb2d4ad0103eb11ff8140296f4cea4fc94f1f95ddc6c3e4f983d107f1\",\n  \"f20de1e4e37b92280264c08bf15eca0be0bc5babd7a7b5e574997f154c00cb78\",\n.."
   },
   "258" : {
     "command" : "participant1.packages.remove(packageId)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,7f16ca92): Package 9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0 is currently in-use by contract ContractId(00f83a2f1d08029ba57a7d094db04e384e65ca77db569936e4b4ead52805993eb4ca0112209b309891c946638a730ced565114bd0a976b5df45f3a12d4f2d78d5c2fc2ce4d) on domain mydomain::1220bf7c580f.... It may also be in-use by other contracts.\n  Request: RemovePackage(9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0,false)\n  CorrelationId: 7f16ca92dea13a8d2e27e2a68d3ed5fe\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, domain -> mydomain::1220bf7c580f..., pkg -> 9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0, tid -> 7f16ca92dea13a8d2e27e2a68d3ed5fe, contract -> ContractId(00f83a2f1d08029ba57a7d094db04e384e65ca77db569936e4b4ead52805993eb4ca0112209b309891c946638a730ced565114bd0a976b5df45f3a12d4f2d78d5c2fc2ce4d))\n  Command ParticipantAdministration$packages$.remove invoked from cmd10000103.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,67ecba2f): Package 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680 is currently in-use by contract ContractId(0089706b2eecd481436897fe503f438458539b6e8c41f270e38516a92b31032109ca021220e9f0db900b810a0ac8409559f7f146d89ab25cd892be3d2c950f8af66f192614) on domain mydomain::12208be8725d.... It may also be in-use by other contracts.\n  Request: RemovePackage(6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680,false)\n  CorrelationId: 67ecba2f154fa15ff11c2d601d34d37b\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, domain -> mydomain::12208be8725d..., pkg -> 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680, tid -> 67ecba2f154fa15ff11c2d601d34d37b, contract -> ContractId(0089706b2eecd481436897fe503f438458539b6e8c41f270e38516a92b31032109ca021220e9f0db900b810a0ac8409559f7f146d89ab25cd892be3d2c950f8af66f192614))\n  Command ParticipantAdministration$packages$.remove invoked from cmd10000103.sc:1"
   },
   "158" : {
     "command" : "val packageId = participant1.packages.find(\"Iou\").head.packageId",
-    "output" : "packageId : String = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\""
+    "output" : "packageId : String = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\""
   },
   "55" : {
     "command" : "participant2.packages.list_contents(darContent.main)",
@@ -157,31 +157,31 @@
   },
   "171" : {
     "command" : "val iou = participant1.ledger_api.acs.find_generic(participant1.adminParty, _.templateId.isModuleEntity(\"Iou\", \"Iou\"))",
-    "output" : "iou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#1220140615c40a381f9b867ceb78961bb1fbaceb82c8c52259ce4c5e83940bd4fc4e:0\",\n    contractId = \"005170f294b69a37a7ba0c30a8f0c6ea1ab81e142e74fb146f19104af801cac302ca0112203845e89891f897f3bbc66395732e4994ccd4b3e26ebc9a46ca0e272d4c284422\",\n    templateId = Some(\n      value = Identifier(\n        packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n        moduleName = \"Iou\",\n        entityName = \"Iou\"\n      )\n.."
+    "output" : "iou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#1220f85c004ec07426ad8085d75d9be6055375b59a4d25f88dcd4f8917c2cb7c32f1:0\",\n    contractId = \"002ac723b60cf62b827fa1fbfb4760fbf35b337d19519c30a56ba4df5b1ef7aec8ca0212207ed3d4db9505f19e9aa96a6dd1e7f51eeaa883bb6af3f559400d4ec814b7ffc8\",\n    templateId = Some(\n      value = Identifier(\n        packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n        moduleName = \"Iou\",\n        entityName = \"Iou\"\n      )\n.."
   },
   "75" : {
     "command" : "participant2.topology.vetted_packages.list()",
-    "output" : "res8: Seq[ListVettedPackagesResult] = Vector(\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2023-06-12T12:18:42.142697Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@110816a5 size=2582 contents=\"\\n\\223\\024\\n\\301\\021\\n\\274\\021\\n\\271\\021\\022 QJVnZH6yMsV48KljIgN1QyQ53uSqnNBtJ...\">,\n.."
+    "output" : "res8: Seq[ListVettedPackagesResult] = Vector(\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2023-11-21T16:00:41.982758Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@502a94b6 size=2582 contents=\"\\n\\223\\024\\n\\301\\021\\n\\274\\021\\n\\271\\021\\022 8xi7SfjelEqmNg2t3i9OGbbEhhJR6Vm2J...\">,\n.."
   },
   "119" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "darHash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "287" : {
     "command" : "participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "res46: String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "res46: String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "36" : {
     "command" : "val dars = participant2.dars.list(filterName = \"CantonExamples\")",
-    "output" : "dars : Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\",\n    name = \"CantonExamples\"\n  )\n)"
+    "output" : "dars : Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\",\n    name = \"CantonExamples\"\n  )\n)"
   },
   "146" : {
     "command" : "val packages = participant1.packages.list().map(_.packageId).toSet",
-    "output" : "packages : Set[String] = HashSet(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"5921708ce82f4255deb1b26d2c05358b548720938a5a325718dc69f381ba47ff\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"bef3d1e9c2f8be31f80c032e930c85e336da27b64ebb1e3a31c9072e9df3a14b\",\n  \"6839a6d3d430c569b2425e9391717b44ca324b88ba621d597778811b2d05031d\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"e22bce619ae24ca3b8e6519281cb5a33b64b3190cc763248b4c3f9ad5087a92c\",\n  \"d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97\",\n  \"6c2c0667393c5f92f1885163068cd31800d2264eb088eb6fc740e11241b2bf06\",\n.."
+    "output" : "packages : Set[String] = HashSet(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"5921708ce82f4255deb1b26d2c05358b548720938a5a325718dc69f381ba47ff\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"6839a6d3d430c569b2425e9391717b44ca324b88ba621d597778811b2d05031d\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"e22bce619ae24ca3b8e6519281cb5a33b64b3190cc763248b4c3f9ad5087a92c\",\n  \"d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97\",\n  \"6c2c0667393c5f92f1885163068cd31800d2264eb088eb6fc740e11241b2bf06\",\n  \"fdd56e2ece40d67781248bc47663c9112122e35eec580b7e93ee7cfa83cda2cc\",\n.."
   },
   "190" : {
     "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Add, participant1.id, packageIds)",
-    "output" : "res29: com.google.protobuf.ByteString = <ByteString@27db41fd size=2382 contents=\"\\n\\313\\022\\n\\373\\017\\n\\366\\017\\n\\363\\017\\022 0SDxlEAROOtxd441yH4iwrMCwtqn7ZB2J...\">"
+    "output" : "res29: com.google.protobuf.ByteString = <ByteString@460615d5 size=2384 contents=\"\\n\\315\\022\\n\\373\\017\\n\\366\\017\\n\\363\\017\\022 BNKfe1wxqqwhoi4q3SXf6hz6rPVg5438J...\">"
   },
   "47" : {
     "command" : "participant2.packages.list()",
@@ -189,7 +189,7 @@
   },
   "200" : {
     "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove, participant1.id, packageIds, force = true)",
-    "output" : "res30: com.google.protobuf.ByteString = <ByteString@237238b1 size=2384 contents=\"\\n\\315\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 0SDxlEAROOtxd441yH4iwrMCwtqn7ZB...\">"
+    "output" : "res30: com.google.protobuf.ByteString = <ByteString@6239c893 size=2386 contents=\"\\n\\317\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 BNKfe1wxqqwhoi4q3SXf6hz6rPVg543...\">"
   },
   "178" : {
     "command" : "participant1.dars.remove(darHash)",
@@ -197,14 +197,14 @@
   },
   "227" : {
     "command" : "participant1.packages.remove(packageId)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,a10cdd12): Package 9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0 is currently vetted and available to use.\n  Request: RemovePackage(9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0,false)\n  CorrelationId: a10cdd12ceeefbc4a17c2bc21b469371\n  Context: Map(participant -> participant1, tid -> a10cdd12ceeefbc4a17c2bc21b469371, test -> PackageDarManagementDocumentationIntegrationTest)\n  Command ParticipantAdministration$packages$.remove invoked from cmd10000087.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,98b8b97e): Package 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680 is currently vetted and available to use.\n  Request: RemovePackage(6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680,false)\n  CorrelationId: 98b8b97e9275a9112cd8f04a83f1d170\n  Context: Map(participant -> participant1, tid -> 98b8b97e9275a9112cd8f04a83f1d170, test -> PackageDarManagementDocumentationIntegrationTest)\n  Command ParticipantAdministration$packages$.remove invoked from cmd10000087.sc:1"
   },
   "222" : {
     "command" : "val packageId = participant1.packages.find(\"Iou\").head.packageId",
-    "output" : "packageId : String = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\""
+    "output" : "packageId : String = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\""
   },
   "232" : {
     "command" : "val packageIds = participant1.topology.vetted_packages.list().map(_.item.packageIds).filter(_.contains(packageId)).head",
-    "output" : "packageIds : Seq[com.digitalasset.canton.package.LfPackageId] = Vector(\n  \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n  \"bef3d1e9c2f8be31f80c032e930c85e336da27b64ebb1e3a31c9072e9df3a14b\",\n.."
+    "output" : "packageIds : Seq[com.digitalasset.canton.package.LfPackageId] = Vector(\n  \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n  \"a566728bb2d4ad0103eb11ff8140296f4cea4fc94f1f95ddc6c3e4f983d107f1\",\n.."
   }
 }

--- a/docs/2.8.0/docs/canton/includes/snippet_data/usermanual/upgrading.json
+++ b/docs/2.8.0/docs/canton/includes/snippet_data/usermanual/upgrading.json
@@ -1,126 +1,126 @@
 {
-  "416" : {
+  "481" : {
     "command" : "",
     "output" : ""
   },
-  "147" : {
+  "440" : {
+    "command" : "",
+    "output" : ""
+  },
+  "538" : {
+    "command" : "",
+    "output" : ""
+  },
+  "184" : {
+    "command" : "",
+    "output" : ""
+  },
+  "189" : {
+    "command" : "participant.health.ping(participant)",
+    "output" : "res7: Duration = 568 milliseconds"
+  },
+  "132" : {
     "command" : "participant.start()",
-    "output" : ""
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - failed to initialize participant: There are 6 pending migrations to get to database schema version 7. Currently on version 1.1. Please run `participant.db.migrate` to apply pending migrations\n  Command LocalParticipantReference.start invoked from cmd10000002.sc:1"
   },
-  "160" : {
-    "command" : "participant.domains.connect_local(testdomain)",
-    "output" : ""
-  },
-  "361" : {
+  "424" : {
     "command" : "",
     "output" : ""
   },
-  "420" : {
-    "command" : "",
-    "output" : ""
-  },
-  "371" : {
-    "command" : "participant.health.ping(participant)",
-    "output" : "res10: Duration = 890 milliseconds"
-  },
-  "360" : {
-    "command" : "participant.domains.list_connected()",
-    "output" : "res8: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'newdomain',\n    domainId = newdomain::1220b732056e...,\n    healthy = true\n  )\n)"
-  },
-  "166" : {
-    "command" : "participant.domains.reconnect_all()",
-    "output" : ""
-  },
-  "177" : {
-    "command" : "participant.health.ping(participant)",
-    "output" : "res7: Duration = 987 milliseconds"
-  },
-  "314" : {
-    "command" : "participant.domains.disconnect(\"olddomain\")",
-    "output" : ""
-  },
-  "305" : {
-    "command" : "",
-    "output" : ""
-  },
-  "138" : {
+  "141" : {
     "command" : "participant.db.migrate()",
     "output" : ""
   },
-  "347" : {
-    "command" : "participant.repair.migrate_domain(\"olddomain\", config)",
-    "output" : ""
-  },
-  "417" : {
+  "537" : {
     "command" : "",
     "output" : ""
   },
-  "320" : {
+  "425" : {
     "command" : "",
     "output" : ""
   },
-  "307" : {
-    "command" : "participant.resources.set_resource_limits(ResourceLimits(Some(0), Some(0)))",
-    "output" : ""
+  "462" : {
+    "command" : "val config = DomainConnectionConfig(\"newdomain\", newdomain.sequencerConnection)",
+    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'newdomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://127.0.0.1:30848,\n    transportSecurity = false,\n.."
   },
-  "366" : {
-    "command" : "participant.resources.set_resource_limits(ResourceLimits(None, None))",
-    "output" : ""
-  },
-  "335" : {
+  "455" : {
     "command" : "val config = DomainConnectionConfig(\"newdomain\", GrpcSequencerConnection.tryCreate(\"https://127.0.0.1:5018\"))",
     "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'newdomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = https://127.0.0.1:5018,\n    transportSecurity = true,\n.."
   },
-  "159" : {
-    "command" : "testdomain.start()",
-    "output" : ""
-  },
-  "172" : {
+  "426" : {
     "command" : "",
     "output" : ""
   },
-  "419" : {
+  "539" : {
     "command" : "participant.domains.connect_local(newdomain)",
     "output" : ""
   },
-  "130" : {
-    "command" : "participant.start()",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - failed to initialize participant: There are 5 pending migrations to get to database schema version 6. Currently on version 1.1. Please run `participant.db.migrate` to apply pending migrations\n  Command LocalParticipantReference.start invoked from cmd10000002.sc:1"
+  "171" : {
+    "command" : "testdomain.start()",
+    "output" : ""
   },
-  "306" : {
+  "536" : {
     "command" : "",
     "output" : ""
   },
-  "431" : {
-    "command" : "participant.domains.list_registered().map { case (c,_) => (c.domain, c.priority) }",
-    "output" : "res3: Seq[(com.digitalasset.canton.DomainAlias, Int)] = Vector((Domain 'newdomain', 10), (Domain 'olddomain', 0))"
+  "183" : {
+    "command" : "participant.domains.list_connected()",
+    "output" : "res6: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'testdomain',\n    domainId = testdomain::122078500722...,\n    healthy = true\n  )\n)"
   },
-  "426" : {
-    "command" : "participant.domains.modify(\"newdomain\", _.copy(priority=10))",
-    "output" : ""
-  },
-  "342" : {
-    "command" : "val config = DomainConnectionConfig(\"newdomain\", newdomain.sequencerConnection)",
-    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'newdomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://127.0.0.1:30154,\n    transportSecurity = false,\n.."
-  },
-  "355" : {
+  "475" : {
     "command" : "participant.domains.reconnect_all()",
     "output" : ""
   },
-  "319" : {
+  "480" : {
+    "command" : "participant.domains.list_connected()",
+    "output" : "res8: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'newdomain',\n    domainId = newdomain::1220ea53572c...,\n    healthy = true\n  )\n)"
+  },
+  "439" : {
     "command" : "participant.domains.list_connected()",
     "output" : "res3: Seq[ListConnectedDomainsResult] = Vector()"
   },
-  "304" : {
+  "546" : {
+    "command" : "participant.domains.modify(\"newdomain\", _.copy(priority=10))",
+    "output" : ""
+  },
+  "467" : {
+    "command" : "participant.repair.migrate_domain(\"olddomain\", config)",
+    "output" : ""
+  },
+  "551" : {
+    "command" : "participant.domains.list_registered().map { case (c,_) => (c.domain, c.priority) }",
+    "output" : "res3: Seq[(com.digitalasset.canton.DomainAlias, Int)] = Vector((Domain 'newdomain', 10), (Domain 'olddomain', 0))"
+  },
+  "540" : {
     "command" : "",
     "output" : ""
   },
-  "171" : {
-    "command" : "participant.domains.list_connected()",
-    "output" : "res6: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'testdomain',\n    domainId = testdomain::122056e307f0...,\n    healthy = true\n  )\n)"
-  },
-  "418" : {
-    "command" : "",
+  "159" : {
+    "command" : "participant.start()",
     "output" : ""
+  },
+  "172" : {
+    "command" : "participant.domains.connect_local(testdomain)",
+    "output" : ""
+  },
+  "434" : {
+    "command" : "participant.domains.disconnect(\"olddomain\")",
+    "output" : ""
+  },
+  "427" : {
+    "command" : "participant.resources.set_resource_limits(ResourceLimits(Some(0), Some(0)))",
+    "output" : ""
+  },
+  "178" : {
+    "command" : "participant.domains.reconnect_all()",
+    "output" : ""
+  },
+  "486" : {
+    "command" : "participant.resources.set_resource_limits(ResourceLimits(None, None))",
+    "output" : ""
+  },
+  "491" : {
+    "command" : "participant.health.ping(participant)",
+    "output" : "res10: Duration = 681 milliseconds"
   }
 }

--- a/docs/2.8.0/docs/canton/usermanual/identity_management.rst
+++ b/docs/2.8.0/docs/canton/usermanual/identity_management.rst
@@ -621,7 +621,7 @@ Starting with a party being allocated on participant1:
     .. assert:: { participants.all.domains.connect_local(mydomain); true }
     .. success:: val alice = participant1.parties.enable("Alice")
     .. assert:: { utils.synchronize_topology(); true }
-    .. assert:: { participant1.ledger_api.commands.submit_flat(Seq(alice), Seq(com.digitalasset.canton.participant.admin.workflows.PingPong.Cycle("hello", alice.toPrim).create.command)); true }
+    .. assert:: { import scala.jdk.CollectionConverters._; participant1.ledger_api.javaapi.commands.submit_flat(Seq(alice), new com.digitalasset.canton.participant.admin.workflows.java.pingpong.Cycle("hello", alice.toProtoPrimitive).create.commands.asScala.toSeq); true }
 
 To add this party to participant2, participant2 must first agree to host the party. This
 is done by authorizing the ``RequestSide.To`` of the party to participant mapping on the target participant:
@@ -708,7 +708,7 @@ Once the entire active contract store has been imported, the target participant 
 Now, both participant host the party and can act on behalf of it.
 
 .. snippet:: party_on_two_nodes
-    .. assert:: { val cycle = participant2.ledger_api.acs.await(alice, com.digitalasset.canton.participant.admin.workflows.PingPong.Cycle); participant2.ledger_api.commands.submit_flat(Seq(alice), Seq(cycle.contractId.exerciseRepeat().command)); true }
+    .. assert:: { import scala.jdk.CollectionConverters._; val cycle = participant2.ledger_api.javaapi.acs.await(com.digitalasset.canton.participant.admin.workflows.java.pingpong.Cycle.COMPANION)(alice); participant2.ledger_api.javaapi.commands.submit_flat(Seq(alice), cycle.id.exerciseRepeat().commands.asScala.toSeq); true }
 
 .. _manually_initializing_node:
 

--- a/docs/3.0.0/docs/canton/includes/snippet_data/tutorials/getting_started.json
+++ b/docs/3.0.0/docs/canton/includes/snippet_data/tutorials/getting_started.json
@@ -1,274 +1,274 @@
 {
-  "385" : {
-    "command" : "val bank = participant2.parties.enable(\"Bank\", waitForDomain = DomainChoice.All)",
-    "output" : "bank : PartyId = Bank::12207f6b1097..."
-  },
-  "489" : {
-    "command" : "val paintOffer = participant1.ledger_api.acs.find_generic(alice, _.templateId.isModuleEntity(\"Paint\", \"OfferToPaintHouseByPainter\"))",
-    "output" : "paintOffer : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#1220ab0b25094769ffd759d1e4c33fd2924212abe93c4f1f997ce3e619643ec63d42:0\",\n    contractId = \"0021ae8b91a08ed8f073d0331cb370b6ce0f61417478731ca6a4488cb248f21ba6ca01122016b5004bb68ae2e4bf42e79b6e67a469b6fbe090d34cf7d3400367ac3299381a\",\n    templateId = Some(\n      value = Identifier(\n.."
-  },
-  "343" : {
-    "command" : "nodes.local",
-    "output" : "res28: Seq[com.digitalasset.canton.console.LocalInstanceReferenceCommon] = ArraySeq(Participant 'participant1', Participant 'participant2', Domain 'mydomain')"
-  },
-  "259" : {
-    "command" : "val alice = participant1.parties.enable(\"Alice\")",
-    "output" : "alice : PartyId = Alice::1220e92602e9..."
-  },
-  "483" : {
-    "command" : "val createOfferCmd = ledger_api_utils.create(pkgPaint.packageId, \"Paint\", \"OfferToPaintHouseByPainter\", Map(\"bank\" -> bank, \"houseOwner\" -> alice, \"painter\" -> bob, \"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\")))",
-    "output" : "createOfferCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Create(\n    value = CreateCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n.."
-  },
-  "525" : {
-    "command" : "participant1.ledger_api.commands.submit_flat(Seq(alice), Seq(acceptOffer))",
-    "output" : "res48: com.daml.ledger.api.v1.transaction.Transaction = Transaction(\n  transactionId = \"1220ced37b240eefc96341fa42245989e4750f8b777121d445dfb3d2688ee625c08c\",\n  commandId = \"7b231bb3-aa08-4f6e-a4e4-d34160e893d0\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n.."
-  },
-  "68" : {
-    "command" : "Seq(1,2,3).map(_ * 2)",
-    "output" : "res1: Seq[Int] = List(2, 4, 6)"
-  },
-  "69" : {
-    "command" : "",
-    "output" : ""
-  },
-  "468" : {
-    "command" : "participant1.ledger_api.acs.of_party(alice).map(x => (x.templateId, x.arguments))",
-    "output" : "res38: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
-  },
-  "523" : {
-    "command" : "import com.digitalasset.canton.protocol.LfContractId",
-    "output" : ""
-  },
-  "308" : {
-    "command" : "participant1.health.ping(p2Id)",
-    "output" : "res22: Duration = 576 milliseconds"
-  },
-  "202" : {
-    "command" : "participant1.health.ping(participant2)",
-    "output" : "res11: Duration = 613 milliseconds"
-  },
-  "504" : {
-    "command" : "",
-    "output" : ""
-  },
-  "357" : {
-    "command" : "",
-    "output" : ""
-  },
-  "460" : {
-    "command" : "participant1.ledger_api.acs.of_party(alice)",
-    "output" : "res37: Seq[com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent] = List(\n  WrappedCreatedEvent(\n    event = CreatedEvent(\n      eventId = \"#122016dfb107997decae572917a0cca323f3d71a99d808c55c821fc84921bee57bbc:0\",\n      contractId = \"0064eace0d06c962a4141372442e1b64b4655383df07f1ea191a90094ed3df35dcca01122098f4a7f6a3945b66fc3ab524b2bb5731ace8c8fb5e429eae64db616bf8c89a53\",\n      templateId = Some(\n        value = Identifier(\n          packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n.."
-  },
-  "189" : {
-    "command" : "participant2.domains.connect_local(mydomain)",
-    "output" : ""
-  },
-  "93" : {
-    "command" : "help",
-    "output" : "Top-level Commands\n------------------\nexit - Leave the console\nhelp - Help with console commands; type help(\"<command>\") for detailed help for <command>\n\nGeneric Node References\n-----------------------\ndomainManagers - All domain manager nodes (.all, .local, .remote)\n.."
-  },
-  "261" : {
-    "command" : "val bob = participant2.parties.enable(\"Bob\")",
-    "output" : "bob : PartyId = Bob::12207f6b1097..."
-  },
-  "321" : {
-    "command" : "val p2UidString = participant2.id.uid.toProtoPrimitive",
-    "output" : "p2UidString : String = \"participant2::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\""
-  },
-  "348" : {
-    "command" : "participants.all",
-    "output" : "res29: Seq[com.digitalasset.canton.console.ParticipantReference] = List(Participant 'participant1', Participant 'participant2')"
+  "481" : {
+    "command" : "val pkgPaint = participant1.packages.find(\"Paint\").head",
+    "output" : "pkgPaint : com.digitalasset.canton.participant.admin.v0.PackageDescription = PackageDescription(\n  packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n  sourceDescription = \"CantonExamples\"\n)"
   },
   "280" : {
     "command" : "",
     "output" : ""
   },
-  "293" : {
-    "command" : "participant1.health.ping(participant2)",
-    "output" : ".."
+  "452" : {
+    "command" : "participant1.ledger_api.commands.submit(Seq(alice), Seq(createIouCmd))",
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcClientError: INVALID_ARGUMENT/DAML_AUTHORIZATION_ERROR(8,e2d7ff55): Interpretation error: Error: node NodeId(0) (6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680:Iou:Iou) requires authorizers Bank::122067528ee7d7271f04bba3f5c2280bcf99b1312d630ef34c8f3ce5946ac098d70d, but only Alice::1220c5bed95d162cd1464fce5726cc46a539b31c6607ebf212ebb27e6a782e7504fd were given\n  Request: SubmitAndWaitTransactionTree(\n  actAs = Alice::1220c5bed95d...,\n.."
   },
-  "439" : {
-    "command" : "participant2.ledger_api.commands.submit(Seq(bank), Seq(createIouCmd))",
-    "output" : "res35: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"122016dfb107997decae572917a0cca323f3d71a99d808c55c821fc84921bee57bbc\",\n  commandId = \"66d0c0bd-5a2f-4a46-a933-31dbb65bb856\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1686572349L,\n      nanos = 575851000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n  ),\n  offset = \"000000000000000015\",\n.."
+  "392" : {
+    "command" : "val bank = participant2.parties.enable(\"Bank\", waitForDomain = DomainChoice.All)",
+    "output" : "bank : PartyId = Bank::122067528ee7..."
   },
-  "201" : {
+  "328" : {
+    "command" : "val p2UidString = participant2.id.uid.toProtoPrimitive",
+    "output" : "p2UidString : String = \"participant2::122067528ee7d7271f04bba3f5c2280bcf99b1312d630ef34c8f3ce5946ac098d70d\""
+  },
+  "286" : {
+    "command" : "mydomain.parties.list(\"Bob\")",
+    "output" : "res18: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Bob::122067528ee7...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant2::122067528ee7...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::122002fd1b8a..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
+  },
+  "208" : {
     "command" : "",
     "output" : ""
   },
-  "260" : {
-    "command" : "",
-    "output" : ""
+  "462" : {
+    "command" : "val aliceIou = participant1.ledger_api.acs.find_generic(alice, _.templateId.isModuleEntity(\"Iou\", \"Iou\"))",
+    "output" : "aliceIou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#12201a48f189a536e79e85cc7802181d96dfa312c9ae2b7aef46428d362b7d1522cb:0\",\n    contractId = \"00f157ee45391f10fb89fd9d706cc49e8a5081cbad141ff85070e928f3d3315199ca0212201c073486e3287e009e650f744f84af859ca10ccc7745a3084c336e9141ce7759\",\n.."
   },
-  "429" : {
-    "command" : "val pkgIou = participant1.packages.find(\"Iou\").head",
-    "output" : "pkgIou : com.digitalasset.canton.participant.admin.v0.PackageDescription = PackageDescription(\n  packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n  sourceDescription = \"CantonExamples\"\n)"
+  "310" : {
+    "command" : "val p2Id = ParticipantId.tryFromProtoPrimitive(extractedId)",
+    "output" : "p2Id : ParticipantId = PAR::participant2::122067528ee7..."
   },
-  "229" : {
-    "command" : "mydomain.id",
-    "output" : "res12: DomainId = mydomain::1220b4e9b0f0..."
-  },
-  "484" : {
-    "command" : "participant2.ledger_api.commands.submit_flat(Seq(bob), Seq(createOfferCmd))",
-    "output" : "res41: com.daml.ledger.api.v1.transaction.Transaction = Transaction(\n  transactionId = \"1220ab0b25094769ffd759d1e4c33fd2924212abe93c4f1f997ce3e619643ec63d42\",\n  commandId = \"b63e26ee-7c29-4ea7-849c-79796a7b5e5b\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n.."
-  },
-  "188" : {
-    "command" : "",
-    "output" : ""
-  },
-  "356" : {
+  "363" : {
     "command" : "participant1.dars.list()",
-    "output" : "res30: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\",\n    name = \"CantonExamples\"\n  ),\n  DarDescription(\n    hash = \"122012a6f2b7c0b666e7541ce6f5d4273ab8d00da671b4d3bbb9bebb6a5120ec02c5\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  )\n)"
+    "output" : "res30: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220caf9b815c77d40b24801fc88acaa85bffac5cc315644c8242923d039d8df6d73\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  ),\n  DarDescription(\n    hash = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\",\n    name = \"CantonExamples\"\n  )\n)"
+  },
+  "517" : {
+    "command" : "",
+    "output" : ""
+  },
+  "369" : {
+    "command" : "participant2.dars.list()",
+    "output" : "res31: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220caf9b815c77d40b24801fc88acaa85bffac5cc315644c8242923d039d8df6d73\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  ),\n  DarDescription(\n    hash = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\",\n    name = \"CantonExamples\"\n  )\n)"
+  },
+  "511" : {
+    "command" : "",
+    "output" : ""
+  },
+  "269" : {
+    "command" : "",
+    "output" : ""
+  },
+  "202" : {
+    "command" : "health.status",
+    "output" : "res10: EnterpriseCantonStatus = Status for Domain 'mydomain':\nDomain id: mydomain::122002fd1b8a5e390c3dd6c9ba0daca4f7b01a15154e19838d3caf367834421debd6\nUptime: 5.257037s\nPorts: \n\tadmin: 31051\n\tpublic: 31050\nConnected Participants: \n\tPAR::participant2::122067528ee7...\n\tPAR::participant1::1220c5bed95d...\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()\n\n.."
+  },
+  "174" : {
+    "command" : "",
+    "output" : ""
+  },
+  "320" : {
+    "command" : "val aliceAsStr = alice.toProtoPrimitive",
+    "output" : "aliceAsStr : String = \"Alice::1220c5bed95d162cd1464fce5726cc46a539b31c6607ebf212ebb27e6a782e7504fd\""
+  },
+  "436" : {
+    "command" : "val pkgIou = participant1.packages.find(\"Iou\").head",
+    "output" : "pkgIou : com.digitalasset.canton.participant.admin.v0.PackageDescription = PackageDescription(\n  packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n  sourceDescription = \"CantonExamples\"\n)"
+  },
+  "504" : {
+    "command" : "participant2.ledger_api.acs.of_party(bob).map(x => (x.templateId, x.arguments))",
+    "output" : "res43: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n      moduleName = \"Paint\",\n      entityName = \"OfferToPaintHouseByPainter\"\n    ),\n    HashMap(\n      \"painter\" -> \"Bob::122067528ee7d7271f04bba3f5c2280bcf99b1312d630ef34c8f3ce5946ac098d70d\",\n      \"houseOwner\" -> \"Alice::1220c5bed95d162cd1464fce5726cc46a539b31c6607ebf212ebb27e6a782e7504fd\",\n      \"bank\" -> \"Bank::122067528ee7d7271f04bba3f5c2280bcf99b1312d630ef34c8f3ce5946ac098d70d\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
+  },
+  "344" : {
+    "command" : "participants.all.dars.upload(\"dars/CantonExamples.dar\")",
+    "output" : "res27: Map[com.digitalasset.canton.console.ParticipantReference, String] = Map(\n  Participant 'participant1' -> \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\",\n  Participant 'participant2' -> \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\"\n)"
+  },
+  "196" : {
+    "command" : "participant2.domains.connect_local(mydomain)",
+    "output" : ""
+  },
+  "475" : {
+    "command" : "participant1.ledger_api.acs.of_party(alice).map(x => (x.templateId, x.arguments))",
+    "output" : "res38: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::122067528ee7d7271f04bba3f5c2280bcf99b1312d630ef34c8f3ce5946ac098d70d\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::1220c5bed95d162cd1464fce5726cc46a539b31c6607ebf212ebb27e6a782e7504fd\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
+  },
+  "179" : {
+    "command" : "mydomain.health.status",
+    "output" : "res7: com.digitalasset.canton.health.admin.data.NodeStatus[mydomain.Status] = Domain id: mydomain::122002fd1b8a5e390c3dd6c9ba0daca4f7b01a15154e19838d3caf367834421debd6\nUptime: 2.78438s\nPorts: \n\tadmin: 31051\n\tpublic: 31050\nConnected Participants: None\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()"
+  },
+  "321" : {
+    "command" : "val aliceParsed = PartyId.tryFromProtoPrimitive(aliceAsStr)",
+    "output" : "aliceParsed : PartyId = Alice::1220c5bed95d..."
+  },
+  "106" : {
+    "command" : "participant1.help(\"start\")",
+    "output" : "start\nStart the instance"
+  },
+  "238" : {
+    "command" : "participant2.id",
+    "output" : "res14: ParticipantId = PAR::participant2::122067528ee7..."
+  },
+  "467" : {
+    "command" : "participant1.ledger_api.acs.of_party(alice)",
+    "output" : "res37: Seq[com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent] = List(\n  WrappedCreatedEvent(\n    event = CreatedEvent(\n      eventId = \"#12201a48f189a536e79e85cc7802181d96dfa312c9ae2b7aef46428d362b7d1522cb:0\",\n      contractId = \"00f157ee45391f10fb89fd9d706cc49e8a5081cbad141ff85070e928f3d3315199ca0212201c073486e3287e009e650f744f84af859ca10ccc7745a3084c336e9141ce7759\",\n      templateId = Some(\n        value = Identifier(\n          packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n.."
+  },
+  "197" : {
+    "command" : "",
+    "output" : ""
+  },
+  "329" : {
+    "command" : "val p2FromUid = ParticipantId(UniqueIdentifier.tryFromProtoPrimitive(p2UidString))",
+    "output" : "p2FromUid : ParticipantId = PAR::participant2::122067528ee7..."
+  },
+  "285" : {
+    "command" : "",
+    "output" : ""
+  },
+  "457" : {
+    "command" : "participant1.ledger_api.commands.submit(Seq(bank), Seq(createIouCmd))",
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: NOT_FOUND/NO_DOMAIN_ON_WHICH_ALL_SUBMITTERS_CAN_SUBMIT(11,b55e2421): This participant can not submit as the given submitter on any connected domain\n  Request: SubmitAndWaitTransactionTree(\n  actAs = Bank::122067528ee7...,\n.."
   },
   "173" : {
-    "command" : "",
-    "output" : ""
-  },
-  "503" : {
-    "command" : "participant2.ledger_api.acs.of_party(bank).map(x => (x.templateId, x.arguments))",
-    "output" : "res44: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
-  },
-  "298" : {
-    "command" : "val extractedId = participant2.id.toProtoPrimitive",
-    "output" : "extractedId : String = \"PAR::participant2::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\""
-  },
-  "166" : {
     "command" : "participant1.health.status",
-    "output" : "res6: com.digitalasset.canton.health.admin.data.NodeStatus[com.digitalasset.canton.health.admin.data.ParticipantStatus] = Participant id: PAR::participant1::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\nUptime: 5.349261s\nPorts: \n\tledger: 30098\n\tadmin: 30099\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized"
+    "output" : "res6: com.digitalasset.canton.health.admin.data.NodeStatus[com.digitalasset.canton.health.admin.data.ParticipantStatus] = Participant id: PAR::participant1::1220c5bed95d162cd1464fce5726cc46a539b31c6607ebf212ebb27e6a782e7504fd\nUptime: 1.7519s\nPorts: \n\tledger: 31046\n\tadmin: 31047\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized"
   },
-  "161" : {
-    "command" : "health.status",
-    "output" : "res5: EnterpriseCantonStatus = Status for Domain 'mydomain':\nDomain id: mydomain::1220b4e9b0f09429d18bb4f197864468b713b28d5334e7581e82e6b9f129cf5c0e15\nUptime: 7.494604s\nPorts: \n\tadmin: 30103\n\tpublic: 30102\nConnected Participants: None\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()\n\nStatus for Participant 'participant1':\nParticipant id: PAR::participant1::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\nUptime: 5.181514s\nPorts: \n\tledger: 30098\n\tadmin: 30099\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized\n\nStatus for Participant 'participant2':\nParticipant id: PAR::participant2::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\nUptime: 3.406213s\nPorts: \n\tledger: 30100\n\tadmin: 30101\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized"
-  },
-  "279" : {
-    "command" : "mydomain.parties.list(\"Bob\")",
-    "output" : "res18: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Bob::12207f6b1097...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant2::12207f6b1097...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220b4e9b0f0..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
-  },
-  "445" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(alice), Seq(createIouCmd))",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcClientError: INVALID_ARGUMENT/DAML_AUTHORIZATION_ERROR(8,9d7c7884): Interpretation error: Error: node NodeId(0) (9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0:Iou:Iou) requires authorizers Bank::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e, but only Alice::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a were given\n  Request: SubmitAndWaitTransactionTree(actAs = Alice::1220e92602e9..., readAs = Seq(), commandId = '', workflowId = '', submissionId = '', deduplicationPeriod = None(), commands = ...)\n  CorrelationId: 9d7c7884-6e76-41c2-b70b-665c49bd097f\n.."
-  },
-  "313" : {
-    "command" : "val aliceAsStr = alice.toProtoPrimitive",
-    "output" : "aliceAsStr : String = \"Alice::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\""
-  },
-  "498" : {
-    "command" : "",
-    "output" : ""
-  },
-  "187" : {
-    "command" : "participant1.domains.connect_local(mydomain)",
-    "output" : ""
-  },
-  "172" : {
-    "command" : "mydomain.health.status",
-    "output" : "res7: com.digitalasset.canton.health.admin.data.NodeStatus[mydomain.Status] = Domain id: mydomain::1220b4e9b0f09429d18bb4f197864468b713b28d5334e7581e82e6b9f129cf5c0e15\nUptime: 7.854944s\nPorts: \n\tadmin: 30103\n\tpublic: 30102\nConnected Participants: None\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()"
-  },
-  "230" : {
+  "237" : {
     "command" : "participant1.id",
-    "output" : "res13: ParticipantId = PAR::participant1::1220e92602e9..."
+    "output" : "res13: ParticipantId = PAR::participant1::1220c5bed95d..."
   },
-  "362" : {
-    "command" : "participant2.dars.list()",
-    "output" : "res31: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\",\n    name = \"CantonExamples\"\n  ),\n  DarDescription(\n    hash = \"122012a6f2b7c0b666e7541ce6f5d4273ab8d00da671b4d3bbb9bebb6a5120ec02c5\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  )\n)"
-  },
-  "271" : {
-    "command" : "",
-    "output" : ""
-  },
-  "509" : {
-    "command" : "participant1.ledger_api.acs.of_party(alice).map(x => (x.templateId, x.arguments))",
-    "output" : "res45: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  ),\n  (\n    TemplateId(\n      packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n      moduleName = \"Paint\",\n      entityName = \"OfferToPaintHouseByPainter\"\n    ),\n    HashMap(\n      \"painter\" -> \"Bob::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\",\n      \"houseOwner\" -> \"Alice::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\",\n      \"bank\" -> \"Bank::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
-  },
-  "434" : {
-    "command" : "val createIouCmd = ledger_api_utils.create(pkgIou.packageId,\"Iou\",\"Iou\",Map(\"payer\" -> bank,\"owner\" -> alice,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
-    "output" : "createIouCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Create(\n    value = CreateCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n.."
-  },
-  "98" : {
+  "105" : {
     "command" : "help(\"participant1\")",
     "output" : "participant1\nManage participant 'participant1'; type 'participant1 help' or 'participant1 help(\"<methodName>\")' for more help"
   },
-  "303" : {
-    "command" : "val p2Id = ParticipantId.tryFromProtoPrimitive(extractedId)",
-    "output" : "p2Id : ParticipantId = PAR::participant2::12207f6b1097..."
+  "266" : {
+    "command" : "val alice = participant1.parties.enable(\"Alice\")",
+    "output" : "alice : PartyId = Alice::1220c5bed95d..."
+  },
+  "530" : {
+    "command" : "import com.digitalasset.canton.protocol.LfContractId",
+    "output" : ""
+  },
+  "279" : {
+    "command" : "mydomain.parties.list(\"Alice\")",
+    "output" : "res17: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Alice::1220c5bed95d...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant1::1220c5bed95d...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::122002fd1b8a..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
+  },
+  "180" : {
+    "command" : "",
+    "output" : ""
+  },
+  "71" : {
+    "command" : "Seq(1,2,3).map(_ * 2)",
+    "output" : "res1: Seq[Int] = List(2, 4, 6)"
+  },
+  "236" : {
+    "command" : "mydomain.id",
+    "output" : "res12: DomainId = mydomain::122002fd1b8a..."
+  },
+  "350" : {
+    "command" : "nodes.local",
+    "output" : "res28: Seq[com.digitalasset.canton.console.LocalInstanceReferenceCommon] = ArraySeq(Participant 'participant1', Participant 'participant2', Domain 'mydomain')"
   },
   "278" : {
     "command" : "",
     "output" : ""
   },
-  "455" : {
-    "command" : "val aliceIou = participant1.ledger_api.acs.find_generic(alice, _.templateId.isModuleEntity(\"Iou\", \"Iou\"))",
-    "output" : "aliceIou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#122016dfb107997decae572917a0cca323f3d71a99d808c55c821fc84921bee57bbc:0\",\n    contractId = \"0064eace0d06c962a4141372442e1b64b4655383df07f1ea191a90094ed3df35dcca01122098f4a7f6a3945b66fc3ab524b2bb5731ace8c8fb5e429eae64db616bf8c89a53\",\n.."
-  },
-  "167" : {
+  "267" : {
     "command" : "",
     "output" : ""
   },
-  "314" : {
-    "command" : "val aliceParsed = PartyId.tryFromProtoPrimitive(aliceAsStr)",
-    "output" : "aliceParsed : PartyId = Alice::1220e92602e9..."
-  },
-  "497" : {
-    "command" : "participant2.ledger_api.acs.of_party(bob).map(x => (x.templateId, x.arguments))",
-    "output" : "res43: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n      moduleName = \"Paint\",\n      entityName = \"OfferToPaintHouseByPainter\"\n    ),\n    HashMap(\n      \"painter\" -> \"Bob::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\",\n      \"houseOwner\" -> \"Alice::1220e92602e979f678f3b64664f2599a03ebccdd3e914d24c3695d7e4bcfdc77734a\",\n      \"bank\" -> \"Bank::12207f6b1097871943e7f365a3f57d388d635561284143441aed3d1abda119c7b57e\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
-  },
-  "231" : {
-    "command" : "participant2.id",
-    "output" : "res14: ParticipantId = PAR::participant2::12207f6b1097..."
-  },
-  "450" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(bank), Seq(createIouCmd))",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: NOT_FOUND/NO_DOMAIN_ON_WHICH_ALL_SUBMITTERS_CAN_SUBMIT(11,89c4dc65): This participant can not submit as the given submitter on any connected domain\n  Request: SubmitAndWaitTransactionTree(actAs = Bank::12207f6b1097..., readAs = Seq(), commandId = '', workflowId = '', submissionId = '', deduplicationPeriod = None(), commands = ...)\n  CorrelationId: 89c4dc654bf60571a516aa17b36abeb8\n.."
-  },
-  "99" : {
-    "command" : "participant1.help(\"start\")",
-    "output" : "start\nStart the instance"
-  },
-  "363" : {
+  "505" : {
     "command" : "",
     "output" : ""
   },
-  "524" : {
+  "490" : {
+    "command" : "val createOfferCmd = ledger_api_utils.create(pkgPaint.packageId, \"Paint\", \"OfferToPaintHouseByPainter\", Map(\"bank\" -> bank, \"houseOwner\" -> alice, \"painter\" -> bob, \"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\")))",
+    "output" : "createOfferCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Create(\n    value = CreateCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n.."
+  },
+  "531" : {
     "command" : "val acceptOffer = ledger_api_utils.exercise(\"AcceptByOwner\", Map(\"iouId\" -> LfContractId.assertFromString(aliceIou.event.contractId)),paintOffer.event)",
-    "output" : "acceptOffer : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Exercise(\n    value = ExerciseCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n.."
+    "output" : "acceptOffer : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Exercise(\n    value = ExerciseCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n.."
+  },
+  "209" : {
+    "command" : "participant1.health.ping(participant2)",
+    "output" : "res11: Duration = 317 milliseconds"
+  },
+  "516" : {
+    "command" : "participant1.ledger_api.acs.of_party(alice).map(x => (x.templateId, x.arguments))",
+    "output" : "res45: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::122067528ee7d7271f04bba3f5c2280bcf99b1312d630ef34c8f3ce5946ac098d70d\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::1220c5bed95d162cd1464fce5726cc46a539b31c6607ebf212ebb27e6a782e7504fd\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  ),\n  (\n    TemplateId(\n      packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n      moduleName = \"Paint\",\n      entityName = \"OfferToPaintHouseByPainter\"\n    ),\n    HashMap(\n      \"painter\" -> \"Bob::122067528ee7d7271f04bba3f5c2280bcf99b1312d630ef34c8f3ce5946ac098d70d\",\n      \"houseOwner\" -> \"Alice::1220c5bed95d162cd1464fce5726cc46a539b31c6607ebf212ebb27e6a782e7504fd\",\n      \"bank\" -> \"Bank::122067528ee7d7271f04bba3f5c2280bcf99b1312d630ef34c8f3ce5946ac098d70d\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
+  },
+  "355" : {
+    "command" : "participants.all",
+    "output" : "res29: Seq[com.digitalasset.canton.console.ParticipantReference] = List(Participant 'participant1', Participant 'participant2')"
+  },
+  "194" : {
+    "command" : "participant1.domains.connect_local(mydomain)",
+    "output" : ""
+  },
+  "441" : {
+    "command" : "val createIouCmd = ledger_api_utils.create(pkgIou.packageId,\"Iou\",\"Iou\",Map(\"payer\" -> bank,\"owner\" -> alice,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
+    "output" : "createIouCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Create(\n    value = CreateCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n.."
+  },
+  "370" : {
+    "command" : "",
+    "output" : ""
+  },
+  "72" : {
+    "command" : "",
+    "output" : ""
+  },
+  "446" : {
+    "command" : "participant2.ledger_api.commands.submit(Seq(bank), Seq(createIouCmd))",
+    "output" : "res35: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"12201a48f189a536e79e85cc7802181d96dfa312c9ae2b7aef46428d362b7d1522cb\",\n  commandId = \"16b1eece-26b5-42ae-9d6e-2902ebd4de97\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1700584420L,\n      nanos = 468542000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n  ),\n  offset = \"000000000000000015\",\n.."
   },
   "510" : {
+    "command" : "participant2.ledger_api.acs.of_party(bank).map(x => (x.templateId, x.arguments))",
+    "output" : "res44: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::122067528ee7d7271f04bba3f5c2280bcf99b1312d630ef34c8f3ce5946ac098d70d\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::1220c5bed95d162cd1464fce5726cc46a539b31c6607ebf212ebb27e6a782e7504fd\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
+  },
+  "287" : {
     "command" : "",
     "output" : ""
   },
-  "272" : {
-    "command" : "mydomain.parties.list(\"Alice\")",
-    "output" : "res17: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Alice::1220e92602e9...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant1::1220e92602e9...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220b4e9b0f0..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
+  "300" : {
+    "command" : "participant1.health.ping(participant2)",
+    "output" : ".."
   },
   "315" : {
-    "command" : "",
-    "output" : ""
+    "command" : "participant1.health.ping(p2Id)",
+    "output" : "res22: Duration = 274 milliseconds"
   },
-  "262" : {
-    "command" : "",
-    "output" : ""
+  "168" : {
+    "command" : "health.status",
+    "output" : "res5: EnterpriseCantonStatus = Status for Domain 'mydomain':\nDomain id: mydomain::122002fd1b8a5e390c3dd6c9ba0daca4f7b01a15154e19838d3caf367834421debd6\nUptime: 2.562341s\nPorts: \n\tadmin: 31051\n\tpublic: 31050\nConnected Participants: None\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()\n\nStatus for Participant 'participant1':\nParticipant id: PAR::participant1::1220c5bed95d162cd1464fce5726cc46a539b31c6607ebf212ebb27e6a782e7504fd\nUptime: 1.6609s\nPorts: \n\tledger: 31046\n\tadmin: 31047\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized\n\nStatus for Participant 'participant2':\nParticipant id: PAR::participant2::122067528ee7d7271f04bba3f5c2280bcf99b1312d630ef34c8f3ce5946ac098d70d\nUptime: 1.669422s\nPorts: \n\tledger: 31048\n\tadmin: 31049\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized"
   },
-  "190" : {
-    "command" : "",
-    "output" : ""
+  "305" : {
+    "command" : "val extractedId = participant2.id.toProtoPrimitive",
+    "output" : "extractedId : String = \"PAR::participant2::122067528ee7d7271f04bba3f5c2280bcf99b1312d630ef34c8f3ce5946ac098d70d\""
   },
-  "273" : {
-    "command" : "",
-    "output" : ""
+  "268" : {
+    "command" : "val bob = participant2.parties.enable(\"Bob\")",
+    "output" : "bob : PartyId = Bob::122067528ee7..."
   },
   "195" : {
-    "command" : "health.status",
-    "output" : "res10: EnterpriseCantonStatus = Status for Domain 'mydomain':\nDomain id: mydomain::1220b4e9b0f09429d18bb4f197864468b713b28d5334e7581e82e6b9f129cf5c0e15\nUptime: 10.87264s\nPorts: \n\tadmin: 30103\n\tpublic: 30102\nConnected Participants: \n\tPAR::participant1::1220e92602e9...\n\tPAR::participant2::12207f6b1097...\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()\n\n.."
+    "command" : "",
+    "output" : ""
   },
-  "474" : {
-    "command" : "val pkgPaint = participant1.packages.find(\"Paint\").head",
-    "output" : "pkgPaint : com.digitalasset.canton.participant.admin.v0.PackageDescription = PackageDescription(\n  packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n  sourceDescription = \"CantonExamples\"\n)"
+  "532" : {
+    "command" : "participant1.ledger_api.commands.submit_flat(Seq(alice), Seq(acceptOffer))",
+    "output" : "res48: com.daml.ledger.api.v1.transaction.Transaction = Transaction(\n  transactionId = \"122041dd868473e425ddcc933e815055cbf14cf1bfab72df1d70f219c3582759a202\",\n  commandId = \"57661e87-8229-4980-bde1-02047af779c2\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n.."
   },
   "322" : {
-    "command" : "val p2FromUid = ParticipantId(UniqueIdentifier.tryFromProtoPrimitive(p2UidString))",
-    "output" : "p2FromUid : ParticipantId = PAR::participant2::12207f6b1097..."
+    "command" : "",
+    "output" : ""
   },
-  "337" : {
-    "command" : "participants.all.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "res27: Map[com.digitalasset.canton.console.ParticipantReference, String] = Map(\n  Participant 'participant1' -> \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\",\n  Participant 'participant2' -> \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\"\n)"
+  "491" : {
+    "command" : "participant2.ledger_api.commands.submit_flat(Seq(bob), Seq(createOfferCmd))",
+    "output" : "res41: com.daml.ledger.api.v1.transaction.Transaction = Transaction(\n  transactionId = \"1220aa850d5ad3ac6f0e011f3d7b4e7fdcd3eed8cb9f5d47b3c32cbc7888649a2225\",\n  commandId = \"7600cc00-8dd9-4d55-9629-b7c9b25d5ba3\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n.."
+  },
+  "496" : {
+    "command" : "val paintOffer = participant1.ledger_api.acs.find_generic(alice, _.templateId.isModuleEntity(\"Paint\", \"OfferToPaintHouseByPainter\"))",
+    "output" : "paintOffer : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#1220aa850d5ad3ac6f0e011f3d7b4e7fdcd3eed8cb9f5d47b3c32cbc7888649a2225:0\",\n    contractId = \"009bbeaf2a9c7af0e2accf2380cf03537ae440b9d901e5083e9655f6bb6552b69cca021220e7ac270d714a8840d47d025359c1f48254633efb7025c211aed60f2cdc920f2d\",\n    templateId = Some(\n      value = Identifier(\n.."
+  },
+  "364" : {
+    "command" : "",
+    "output" : ""
+  },
+  "100" : {
+    "command" : "help",
+    "output" : "Top-level Commands\n------------------\nexit - Leave the console\nhelp - Help with console commands; type help(\"<command>\") for detailed help for <command>\n\nGeneric Node References\n-----------------------\ndomainManagers - All domain manager nodes (.all, .local, .remote)\n.."
   }
 }

--- a/docs/3.0.0/docs/canton/includes/snippet_data/usermanual/connectivity.json
+++ b/docs/3.0.0/docs/canton/includes/snippet_data/usermanual/connectivity.json
@@ -5,7 +5,7 @@
   },
   "202" : {
     "command" : "val config = DomainConnectionConfig(domain = \"mydomain\", sequencerConnection, manualConnect, domainId, priority)",
-    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = Seq(http://127.0.0.1:30123, http://127.0.0.1:30121),\n    transportSecurity = false,\n    customTrustCertificates = None()\n  ),\n  manualConnect = false,\n  domainId = Some(domainManager1::1220b9035a1f...),\n  priority = 10,\n  initialRetryDelay = None(),\n  maxRetryDelay = None()\n)"
+    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = Seq(http://127.0.0.1:31071, http://127.0.0.1:31069),\n    transportSecurity = false,\n    customTrustCertificates = None()\n  ),\n  manualConnect = false,\n  domainId = Some(domainManager1::1220108ca15f...),\n  priority = 10,\n  initialRetryDelay = None(),\n  maxRetryDelay = None()\n)"
   },
   "189" : {
     "command" : "participant3.domains.reconnect(\"mydomain\")",
@@ -21,7 +21,7 @@
   },
   "86" : {
     "command" : "val port = sequencer3.config.publicApi.port",
-    "output" : "port : Port = Port(n = 30119)"
+    "output" : "port : Port = Port(n = 31067)"
   },
   "67" : {
     "command" : "",
@@ -37,7 +37,7 @@
   },
   "100" : {
     "command" : "participant2.domains.connect(\"mydomain\", connection = url, certificatesPath = certificatesPath)",
-    "output" : "res8: DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = https://127.0.0.1:30119,\n    transportSecurity = true,\n    customTrustCertificates = Some(2d2d2d2d2d42)\n  ),\n  manualConnect = false,\n  domainId = None(),\n  priority = 0,\n  initialRetryDelay = None(),\n  maxRetryDelay = None()\n)"
+    "output" : "res8: DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = https://127.0.0.1:31067,\n    transportSecurity = true,\n    customTrustCertificates = Some(2d2d2d2d2d42)\n  ),\n  manualConnect = false,\n  domainId = None(),\n  priority = 0,\n  initialRetryDelay = None(),\n  maxRetryDelay = None()\n)"
   },
   "174" : {
     "command" : "val priority = 10 // default is 0 if not set",
@@ -49,11 +49,11 @@
   },
   "61" : {
     "command" : "sequencer1.config.publicApi.port",
-    "output" : "res2: Port = Port(n = 30123)"
+    "output" : "res2: Port = Port(n = 31071)"
   },
   "312" : {
     "command" : "mediator1.mediator.help(\"initialize\")",
-    "output" : "initialize(domainId: com.digitalasset.canton.topology.DomainId, mediatorId: com.digitalasset.canton.topology.MediatorId, domainParameters: com.digitalasset.canton.admin.api.client.data.StaticDomainParameters, sequencerConnection: com.digitalasset.canton.sequencing.SequencerConnection, topologySnapshot: Option[com.digitalasset.canton.topology.store.StoredTopologyTransactions[com.digitalasset.canton.topology.transaction.TopologyChangeOp.Positive]]): com.digitalasset.canton.crypto.PublicKey\nInitialize a mediator\ninitialize(domainId: com.digitalasset.canton.topology.DomainId, mediatorId: com.digitalasset.canton.topology.MediatorId, domainParameters: com.digitalasset.canton.admin.api.client.data.StaticDomainParameters, sequencerConnections: com.digitalasset.canton.sequencing.SequencerConnections, topologySnapshot: Option[com.digitalasset.canton.topology.store.StoredTopologyTransactions[com.digitalasset.canton.topology.transaction.TopologyChangeOp.Positive]]): com.digitalasset.canton.crypto.PublicKey\nInitialize a mediator"
+    "output" : "initialize(domainId: com.digitalasset.canton.topology.DomainId, mediatorId: com.digitalasset.canton.topology.MediatorId, domainParameters: com.digitalasset.canton.admin.api.client.data.StaticDomainParameters, sequencerConnection: com.digitalasset.canton.sequencing.SequencerConnection, topologySnapshot: Option[com.digitalasset.canton.topology.store.StoredTopologyTransactions[com.digitalasset.canton.topology.transaction.TopologyChangeOp.Positive]], signingKeyFingerprint: Option[com.digitalasset.canton.crypto.Fingerprint]): com.digitalasset.canton.crypto.PublicKey\nInitialize a mediator\ninitialize(domainId: com.digitalasset.canton.topology.DomainId, mediatorId: com.digitalasset.canton.topology.MediatorId, domainParameters: com.digitalasset.canton.admin.api.client.data.StaticDomainParameters, sequencerConnections: com.digitalasset.canton.sequencing.SequencerConnections, topologySnapshot: Option[com.digitalasset.canton.topology.store.StoredTopologyTransactions[com.digitalasset.canton.topology.transaction.TopologyChangeOp.Positive]], signingKeyFingerprint: Option[com.digitalasset.canton.crypto.Fingerprint]): com.digitalasset.canton.crypto.PublicKey\nInitialize a mediator"
   },
   "292" : {
     "command" : "",
@@ -61,7 +61,7 @@
   },
   "117" : {
     "command" : "participant3.domains.connect_multi(\"mydomain\", Seq(sequencer1, sequencer2))",
-    "output" : "res9: DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = Seq(http://0.0.0.0:30123, http://127.0.0.1:30121),\n    transportSecurity = false,\n    customTrustCertificates = None()\n  ),\n  manualConnect = false,\n  domainId = None(),\n  priority = 0,\n  initialRetryDelay = None(),\n  maxRetryDelay = None()\n)"
+    "output" : "res9: DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = Seq(http://0.0.0.0:31071, http://127.0.0.1:31069),\n    transportSecurity = false,\n    customTrustCertificates = None()\n  ),\n  manualConnect = false,\n  domainId = None(),\n  priority = 0,\n  initialRetryDelay = None(),\n  maxRetryDelay = None()\n)"
   },
   "302" : {
     "command" : "participant2.domains.reconnect_all()",
@@ -69,7 +69,7 @@
   },
   "160" : {
     "command" : "val sequencerConnection = sequencerConnectionWithoutHighAvailability.addEndpoints(urls(1))",
-    "output" : "sequencerConnection : SequencerConnection = GrpcSequencerConnection(\n  endpoints = Seq(http://127.0.0.1:30123, http://127.0.0.1:30121),\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
+    "output" : "sequencerConnection : SequencerConnection = GrpcSequencerConnection(\n  endpoints = Seq(http://127.0.0.1:31071, http://127.0.0.1:31069),\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
   },
   "297" : {
     "command" : "participant2.domains.reconnect(\"mydomain\")",
@@ -81,7 +81,7 @@
   },
   "197" : {
     "command" : "val domainId = Some(domainManager1.id)",
-    "output" : "domainId : Some[DomainId] = Some(value = domainManager1::1220b9035a1f...)"
+    "output" : "domainId : Some[DomainId] = Some(value = domainManager1::1220108ca15f...)"
   },
   "329" : {
     "command" : "",
@@ -89,11 +89,11 @@
   },
   "224" : {
     "command" : "participant2.domains.list_connected()",
-    "output" : "res23: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'mydomain',\n    domainId = domainManager1::1220b9035a1f...,\n    healthy = true\n  )\n)"
+    "output" : "res23: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'mydomain',\n    domainId = domainManager1::1220108ca15f...,\n    healthy = true\n  )\n)"
   },
   "317" : {
     "command" : "mediator1.sequencer_connection.get()",
-    "output" : "res35: Option[SequencerConnections] = Some(\n  value = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://0.0.0.0:30123,\n    transportSecurity = false,\n    customTrustCertificates = None()\n  )\n)"
+    "output" : "res35: Option[SequencerConnections] = Some(\n  value = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://0.0.0.0:31071,\n    transportSecurity = false,\n    customTrustCertificates = None()\n  )\n)"
   },
   "169" : {
     "command" : "val connectionWithTLS = com.digitalasset.canton.sequencing.GrpcSequencerConnection.tryCreate(\"https://daml.com\", customTrustCertificates = Some(certificate))",
@@ -133,7 +133,7 @@
   },
   "230" : {
     "command" : "participant2.domains.config(\"mydomain\")",
-    "output" : "res24: Option[DomainConnectionConfig] = Some(\n  value = DomainConnectionConfig(\n    domain = Domain 'mydomain',\n    sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n      endpoints = https://127.0.0.1:30119,\n      transportSecurity = true,\n      customTrustCertificates = Some(2d2d2d2d2d42)\n    ),\n    manualConnect = false,\n    domainId = None(),\n    priority = 0,\n    initialRetryDelay = None(),\n    maxRetryDelay = None()\n  )\n)"
+    "output" : "res24: Option[DomainConnectionConfig] = Some(\n  value = DomainConnectionConfig(\n    domain = Domain 'mydomain',\n    sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n      endpoints = https://127.0.0.1:31067,\n      transportSecurity = true,\n      customTrustCertificates = Some(2d2d2d2d2d42)\n    ),\n    manualConnect = false,\n    domainId = None(),\n    priority = 0,\n    initialRetryDelay = None(),\n    maxRetryDelay = None()\n  )\n)"
   },
   "208" : {
     "command" : "participant4.domains.register(config)",
@@ -153,7 +153,7 @@
   },
   "155" : {
     "command" : "val sequencerConnectionWithoutHighAvailability = com.digitalasset.canton.sequencing.GrpcSequencerConnection.tryCreate(urls(0))",
-    "output" : "sequencerConnectionWithoutHighAvailability : GrpcSequencerConnection = GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:30123,\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
+    "output" : "sequencerConnectionWithoutHighAvailability : GrpcSequencerConnection = GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:31071,\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
   },
   "278" : {
     "command" : "participant2.domains.modify(\"mydomain\", _.copy(sequencerConnections=SequencerConnections.single(connection)))",
@@ -161,7 +161,7 @@
   },
   "267" : {
     "command" : "val certificate = com.digitalasset.canton.util.BinaryFileUtil.tryReadByteStringFromFile(\"tls/root-ca.crt\")",
-    "output" : "certificate : com.google.protobuf.ByteString = <ByteString@6f432dcb size=1960 contents=\"-----BEGIN CERTIFICATE-----\\nMIIFeTCCA2GgAwIBAgI...\">"
+    "output" : "certificate : com.google.protobuf.ByteString = <ByteString@1c69e9a8 size=1960 contents=\"-----BEGIN CERTIFICATE-----\\nMIIFeTCCA2GgAwIBAgI...\">"
   },
   "80" : {
     "command" : "sequencer3.config.publicApi.tls",
@@ -169,7 +169,7 @@
   },
   "150" : {
     "command" : "val urls = Seq(sequencer1, sequencer2).map(_.config.publicApi.port).map(port => s\"http://127.0.0.1:${port}\")",
-    "output" : "urls : Seq[String] = List(\"http://127.0.0.1:30123\", \"http://127.0.0.1:30121\")"
+    "output" : "urls : Seq[String] = List(\"http://127.0.0.1:31071\", \"http://127.0.0.1:31069\")"
   },
   "95" : {
     "command" : "val certificatesPath = \"tls/root-ca.crt\"",
@@ -177,15 +177,15 @@
   },
   "87" : {
     "command" : "val url = s\"https://127.0.0.1:${port}\"",
-    "output" : "url : String = \"https://127.0.0.1:30119\""
+    "output" : "url : String = \"https://127.0.0.1:31067\""
   },
   "218" : {
     "command" : "participant2.domains.list_registered()",
-    "output" : "res22: Seq[(DomainConnectionConfig, Boolean)] = Vector(\n  (\n    DomainConnectionConfig(\n      domain = Domain 'mydomain',\n      sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n        endpoints = https://127.0.0.1:30119,\n        transportSecurity = true,\n        customTrustCertificates = Some(2d2d2d2d2d42)\n      ),\n      manualConnect = false,\n      domainId = None(),\n      priority = 0,\n      initialRetryDelay = None(),\n      maxRetryDelay = None()\n    ),\n    true\n  )\n)"
+    "output" : "res22: Seq[(DomainConnectionConfig, Boolean)] = Vector(\n  (\n    DomainConnectionConfig(\n      domain = Domain 'mydomain',\n      sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n        endpoints = https://127.0.0.1:31067,\n        transportSecurity = true,\n        customTrustCertificates = Some(2d2d2d2d2d42)\n      ),\n      manualConnect = false,\n      domainId = None(),\n      priority = 0,\n      initialRetryDelay = None(),\n      maxRetryDelay = None()\n    ),\n    true\n  )\n)"
   },
   "168" : {
     "command" : "val certificate = com.digitalasset.canton.util.BinaryFileUtil.tryReadByteStringFromFile(\"tls/root-ca.crt\")",
-    "output" : "certificate : com.google.protobuf.ByteString = <ByteString@5ca338e4 size=1960 contents=\"-----BEGIN CERTIFICATE-----\\nMIIFeTCCA2GgAwIBAgI...\">"
+    "output" : "certificate : com.google.protobuf.ByteString = <ByteString@5d18610d size=1960 contents=\"-----BEGIN CERTIFICATE-----\\nMIIFeTCCA2GgAwIBAgI...\">"
   },
   "183" : {
     "command" : "val manualConnect = false",
@@ -193,6 +193,6 @@
   },
   "273" : {
     "command" : "val connection = com.digitalasset.canton.sequencing.GrpcSequencerConnection.tryCreate(url, customTrustCertificates = Some(certificate))",
-    "output" : "connection : GrpcSequencerConnection = GrpcSequencerConnection(\n  endpoints = https://127.0.0.1:30119,\n  transportSecurity = true,\n  customTrustCertificates = Some(2d2d2d2d2d42)\n)"
+    "output" : "connection : GrpcSequencerConnection = GrpcSequencerConnection(\n  endpoints = https://127.0.0.1:31067,\n  transportSecurity = true,\n  customTrustCertificates = Some(2d2d2d2d2d42)\n)"
   }
 }

--- a/docs/3.0.0/docs/canton/includes/snippet_data/usermanual/identity_management.json
+++ b/docs/3.0.0/docs/canton/includes/snippet_data/usermanual/identity_management.json
@@ -1,5 +1,9 @@
 {
-  "565" : {
+  "629" : {
+    "command" : "participant2.topology.party_to_participant_mappings.authorize(TopologyChangeOp.Add, alice, participant2.id, RequestSide.To, ParticipantPermission.Submission)",
+    "output" : "res2: com.google.protobuf.ByteString = <ByteString@53f40698 size=556 contents=\"\\n\\251\\004\\n\\327\\001\\n\\322\\001\\n\\317\\001\\022 jqLDzf9rK0vQ4jIS2bJrPAwsu8QMQ9Cv2...\">"
+  },
+  "550" : {
     "command" : "",
     "output" : ""
   },
@@ -7,85 +11,57 @@
     "command" : "participant1.ledger_api.users.get(user.id)",
     "output" : "res9: User = User(\n  id = \"myuser\",\n  primaryParty = None,\n  isActive = true,\n  annotations = Map(\"baz\" -> \"bar\", \"description\" -> \"This is a new description\"),\n  identityProviderId = \"\"\n)"
   },
-  "591" : {
+  "623" : {
     "command" : "",
     "output" : ""
   },
   "428" : {
     "command" : "participant1.ledger_api.users.rights.grant(id = user.id, actAs = Set(alice, bob), readAs = Set(eve), participantAdmin = true)",
-    "output" : "res11: UserRights = UserRights(\n  actAs = Set(bob::12207af325a3...),\n  readAs = Set(eve::12207af325a3...),\n  participantAdmin = true,\n  identityProviderAdmin = false\n)"
+    "output" : "res11: UserRights = UserRights(\n  actAs = Set(bob::1220688e05e5...),\n  readAs = Set(eve::1220688e05e5...),\n  participantAdmin = true,\n  identityProviderAdmin = false\n)"
+  },
+  "439" : {
+    "command" : "participant1.ledger_api.users.rights.list(user.id)",
+    "output" : "res13: UserRights = UserRights(\n  actAs = Set(alice::1220688e05e5...),\n  readAs = Set(bob::1220688e05e5..., eve::1220688e05e5...),\n  participantAdmin = false,\n  identityProviderAdmin = false\n)"
   },
   "590" : {
     "command" : "",
     "output" : ""
   },
-  "393" : {
+  "573" : {
+    "command" : "participant2.domains.disconnect(\"mydomain\")",
+    "output" : ""
+  },
+  "621" : {
+    "command" : "val alice = participant1.parties.enable(\"Alice\")",
+    "output" : "alice : PartyId = Alice::1220a9e37971..."
+  },
+  "705" : {
     "command" : "",
     "output" : ""
   },
-  "618" : {
-    "command" : "participant2.domains.disconnect_all()",
-    "output" : ""
-  },
-  "402" : {
-    "command" : "participant1.ledger_api.users.get(\"myuser\", identityProviderId=\"idp-id1\")",
-    "output" : "res6: User = User(\n  id = \"myuser\",\n  primaryParty = None,\n  isActive = true,\n  annotations = Map(\"baz\" -> \"bar\", \"description\" -> \"This is a new description\"),\n  identityProviderId = \"idp-id1\"\n)"
-  },
-  "557" : {
-    "command" : "repair.party_migration.step3_enable_on_target(alice, participant2)",
-    "output" : ""
-  },
-  "673" : {
-    "command" : "",
-    "output" : ""
-  },
-  "446" : {
-    "command" : "participant1.ledger_api.users.list(filterUser = \"my\")",
-    "output" : "res15: UsersPage = UsersPage(\n  users = Vector(\n    User(\n      id = \"myotheruser\",\n      primaryParty = None,\n      isActive = true,\n      annotations = Map(),\n      identityProviderId = \"\"\n    ),\n    User(\n      id = \"myuser\",\n      primaryParty = None,\n      isActive = true,\n      annotations = Map(\"baz\" -> \"bar\", \"description\" -> \"This is a new description\"),\n      identityProviderId = \"\"\n    )\n  ),\n  nextPageToken = \"\"\n)"
-  },
-  "667" : {
-    "command" : "repair.party_migration.step2_import_acs(participant2, \"alice.acs.gz\")",
-    "output" : ""
-  },
-  "659" : {
-    "command" : "participant1.repair.download(Set(alice), \"alice.acs.gz\", filterDomainId=\"mydomain\", timestamp = Some(timestamp))",
-    "output" : ""
-  },
-  "645" : {
-    "command" : "participant1.health.ping(participant1.id)",
-    "output" : "res6: Duration = 635 milliseconds"
-  },
-  "518" : {
-    "command" : "",
-    "output" : ""
+  "549" : {
+    "command" : "val alice = participant1.parties.enable(\"Alice\")",
+    "output" : "alice : PartyId = Alice::1220763c0992..."
   },
   "408" : {
     "command" : "participant1.ledger_api.users.get(\"myuser\", identityProviderId=\"\")",
     "output" : "res8: User = User(\n  id = \"myuser\",\n  primaryParty = None,\n  isActive = true,\n  annotations = Map(\"baz\" -> \"bar\", \"description\" -> \"This is a new description\"),\n  identityProviderId = \"\"\n)"
   },
+  "677" : {
+    "command" : "participant1.health.ping(participant1.id)",
+    "output" : "res6: Duration = 450 milliseconds"
+  },
   "597" : {
-    "command" : "participant2.topology.party_to_participant_mappings.authorize(TopologyChangeOp.Add, alice, participant2.id, RequestSide.To, ParticipantPermission.Submission)",
-    "output" : "res2: com.google.protobuf.ByteString = <ByteString@f166652 size=554 contents=\"\\n\\247\\004\\n\\327\\001\\n\\322\\001\\n\\317\\001\\022 065F3gyr8JKybE1s2NaUZw37lRbPTwaw2...\">"
+    "command" : "",
+    "output" : ""
   },
   "372" : {
     "command" : "val user = participant1.ledger_api.users.create(id = \"myuser\", actAs = Set(alice), readAs = Set(bob), primaryParty = Some(alice), participantAdmin = false, isActive = true, annotations = Map(\"foo\" -> \"bar\", \"description\" -> \"This is a description\"))",
-    "output" : "user : User = User(\n  id = \"myuser\",\n  primaryParty = Some(value = alice::12207af325a3...),\n  isActive = true,\n  annotations = Map(\"foo\" -> \"bar\", \"description\" -> \"This is a description\"),\n  identityProviderId = \"\"\n)"
+    "output" : "user : User = User(\n  id = \"myuser\",\n  primaryParty = Some(value = alice::1220688e05e5...),\n  isActive = true,\n  annotations = Map(\"foo\" -> \"bar\", \"description\" -> \"This is a description\"),\n  identityProviderId = \"\"\n)"
   },
   "460" : {
     "command" : "participant1.ledger_api.users.list(\"myotheruser\")",
     "output" : "res17: UsersPage = UsersPage(users = Vector(), nextPageToken = \"\")"
-  },
-  "439" : {
-    "command" : "participant1.ledger_api.users.rights.list(user.id)",
-    "output" : "res13: UserRights = UserRights(\n  actAs = Set(alice::12207af325a3...),\n  readAs = Set(bob::12207af325a3..., eve::12207af325a3...),\n  participantAdmin = false,\n  identityProviderAdmin = false\n)"
-  },
-  "678" : {
-    "command" : "",
-    "output" : ""
-  },
-  "546" : {
-    "command" : "repair.party_migration.step2_import_acs(participant2, \"alice.acs.gz\")",
-    "output" : ""
   },
   "598" : {
     "command" : "",
@@ -99,25 +75,45 @@
     "command" : "participant1.ledger_api.users.update_idp(\"myuser\", sourceIdentityProviderId=\"idp-id1\", targetIdentityProviderId=\"\")",
     "output" : ""
   },
-  "566" : {
+  "630" : {
     "command" : "",
     "output" : ""
   },
-  "551" : {
+  "583" : {
     "command" : "participant2.domains.reconnect(\"mydomain\")",
     "output" : "res6: Boolean = true"
   },
-  "541" : {
-    "command" : "participant2.domains.disconnect(\"mydomain\")",
-    "output" : ""
-  },
-  "558" : {
+  "710" : {
     "command" : "",
     "output" : ""
   },
-  "530" : {
+  "578" : {
+    "command" : "repair.party_migration.step2_import_acs(participant2, \"alice.acs.gz\")",
+    "output" : ""
+  },
+  "650" : {
+    "command" : "participant2.domains.disconnect_all()",
+    "output" : ""
+  },
+  "622" : {
+    "command" : "",
+    "output" : ""
+  },
+  "393" : {
+    "command" : "",
+    "output" : ""
+  },
+  "584" : {
+    "command" : "",
+    "output" : ""
+  },
+  "562" : {
     "command" : "repair.party_migration.step1_hold_and_store_acs(alice, participant1, targetParticipantId, \"alice.acs.gz\")",
-    "output" : "res3: Map[DomainId, Long] = Map()"
+    "output" : ""
+  },
+  "402" : {
+    "command" : "participant1.ledger_api.users.get(\"myuser\", identityProviderId=\"idp-id1\")",
+    "output" : "res6: User = User(\n  id = \"myuser\",\n  primaryParty = None,\n  isActive = true,\n  annotations = Map(\"baz\" -> \"bar\", \"description\" -> \"This is a new description\"),\n  identityProviderId = \"idp-id1\"\n)"
   },
   "391" : {
     "command" : "val updatedUser = participant1.ledger_api.users.update(id = user.id, modifier = user => { user.copy(primaryParty = None, annotations = user.annotations.updated(\"description\", \"This is a new description\").removed(\"foo\").updated(\"baz\", \"bar\")) })",
@@ -127,7 +123,7 @@
     "command" : "participant1.ledger_api.users.create(id = \"myotheruser\")",
     "output" : "res14: User = User(\n  id = \"myotheruser\",\n  primaryParty = None,\n  isActive = true,\n  annotations = Map(),\n  identityProviderId = \"\"\n)"
   },
-  "672" : {
+  "704" : {
     "command" : "participant2.domains.reconnect_all()",
     "output" : ""
   },
@@ -137,42 +133,42 @@
   },
   "434" : {
     "command" : "participant1.ledger_api.users.rights.revoke(id = user.id, actAs = Set(bob), readAs = Set(alice), participantAdmin = true)",
-    "output" : "res12: UserRights = UserRights(\n  actAs = Set(bob::12207af325a3...),\n  readAs = Set(),\n  participantAdmin = true,\n  identityProviderAdmin = false\n)"
+    "output" : "res12: UserRights = UserRights(\n  actAs = Set(bob::1220688e05e5...),\n  readAs = Set(),\n  participantAdmin = true,\n  identityProviderAdmin = false\n)"
   },
-  "631" : {
-    "command" : "participant1.parties.list(\"Alice\")",
-    "output" : "res5: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Alice::1220df7d96ce...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant2::1220a532b115...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220a35ef9f4..., permission = Submission)\n        )\n      ),\n      ParticipantDomains(\n        participant = PAR::participant1::1220df7d96ce...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220a35ef9f4..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
-  },
-  "552" : {
-    "command" : "",
-    "output" : ""
-  },
-  "626" : {
-    "command" : "participant1.topology.party_to_participant_mappings.authorize(TopologyChangeOp.Add, alice, participant2.id, RequestSide.From, ParticipantPermission.Submission)",
-    "output" : "res4: com.google.protobuf.ByteString = <ByteString@56f89b1b size=556 contents=\"\\n\\251\\004\\n\\327\\001\\n\\322\\001\\n\\317\\001\\022 LJCGYk1KGUI0bPaSEJHCulUglzsQ3lIr2...\">"
+  "685" : {
+    "command" : "val timestamp = participant1.topology.party_to_participant_mappings.list(filterStore=\"mydomain\", filterParty=\"Alice\").map(_.context.validFrom).max",
+    "output" : "timestamp : Instant = 2023-11-21T16:34:08.572527Z"
   },
   "455" : {
     "command" : "participant1.ledger_api.users.delete(\"myotheruser\")",
     "output" : ""
   },
   "563" : {
-    "command" : "participant1.domains.disconnect(\"mydomain\")",
+    "command" : "",
     "output" : ""
   },
-  "653" : {
-    "command" : "val timestamp = participant1.topology.party_to_participant_mappings.list(filterStore=\"mydomain\", filterParty=\"Alice\").map(_.context.validFrom).max",
-    "output" : "timestamp : Instant = 2023-06-22T12:42:10.034684Z"
+  "658" : {
+    "command" : "participant1.topology.party_to_participant_mappings.authorize(TopologyChangeOp.Add, alice, participant2.id, RequestSide.From, ParticipantPermission.Submission)",
+    "output" : "res4: com.google.protobuf.ByteString = <ByteString@1ac5ac56 size=556 contents=\"\\n\\251\\004\\n\\327\\001\\n\\322\\001\\n\\317\\001\\022 yjSSLUWXNVibCV86JQ8aWTK1PXqzlsdm2...\">"
   },
   "589" : {
-    "command" : "val alice = participant1.parties.enable(\"Alice\")",
-    "output" : "alice : PartyId = Alice::1220df7d96ce..."
+    "command" : "repair.party_migration.step3_enable_on_target(alice, participant2)",
+    "output" : ""
   },
-  "531" : {
+  "663" : {
+    "command" : "participant1.parties.list(\"Alice\")",
+    "output" : "res5: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Alice::1220a9e37971...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant1::1220a9e37971...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::122006622d39..., permission = Submission)\n        )\n      ),\n      ParticipantDomains(\n        participant = PAR::participant2::12205a909fd7...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::122006622d39..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
+  },
+  "548" : {
     "command" : "",
     "output" : ""
   },
-  "516" : {
-    "command" : "",
+  "446" : {
+    "command" : "participant1.ledger_api.users.list(filterUser = \"my\")",
+    "output" : "res15: UsersPage = UsersPage(\n  users = Vector(\n    User(\n      id = \"myotheruser\",\n      primaryParty = None,\n      isActive = true,\n      annotations = Map(),\n      identityProviderId = \"\"\n    ),\n    User(\n      id = \"myuser\",\n      primaryParty = None,\n      isActive = true,\n      annotations = Map(\"baz\" -> \"bar\", \"description\" -> \"This is a new description\"),\n      identityProviderId = \"\"\n    )\n  ),\n  nextPageToken = \"\"\n)"
+  },
+  "595" : {
+    "command" : "participant1.domains.disconnect(\"mydomain\")",
     "output" : ""
   },
   "465" : {
@@ -181,42 +177,46 @@
   },
   "363" : {
     "command" : "val Seq(alice, bob, eve) = Seq(\"alice\", \"bob\", \"eve\").map(p => participant1.parties.enable(name = p, waitForDomain = DomainChoice.All))",
-    "output" : "Seq(alice, bob, eve) : Seq[PartyId] = List(alice::12207af325a3..., bob::12207af325a3..., eve::12207af325a3...)"
+    "output" : "Seq(alice, bob, eve) : Seq[PartyId] = List(alice::1220688e05e5..., bob::1220688e05e5..., eve::1220688e05e5...)"
   },
-  "524" : {
+  "556" : {
     "command" : "val targetParticipantId = participant2.id",
-    "output" : "targetParticipantId : ParticipantId = PAR::participant2::12207334a68d..."
+    "output" : "targetParticipantId : ParticipantId = PAR::participant2::122076c45f69..."
   },
-  "588" : {
-    "command" : "",
-    "output" : ""
-  },
-  "517" : {
-    "command" : "val alice = participant1.parties.enable(\"Alice\")",
-    "output" : "alice : PartyId = Alice::12204dc1e4c4..."
-  },
-  "632" : {
-    "command" : "",
+  "699" : {
+    "command" : "repair.party_migration.step2_import_acs(participant2, \"alice.acs.gz\")",
     "output" : ""
   },
   "401" : {
     "command" : "participant1.ledger_api.users.update_idp(\"myuser\", sourceIdentityProviderId=\"\", targetIdentityProviderId=\"idp-id1\")",
     "output" : ""
   },
+  "620" : {
+    "command" : "",
+    "output" : ""
+  },
   "422" : {
     "command" : "participant1.ledger_api.users.rights.list(user.id)",
-    "output" : "res10: UserRights = UserRights(\n  actAs = Set(alice::12207af325a3...),\n  readAs = Set(bob::12207af325a3...),\n  participantAdmin = false,\n  identityProviderAdmin = false\n)"
+    "output" : "res10: UserRights = UserRights(\n  actAs = Set(alice::1220688e05e5...),\n  readAs = Set(bob::1220688e05e5...),\n  participantAdmin = false,\n  identityProviderAdmin = false\n)"
   },
   "373" : {
     "command" : "",
     "output" : ""
   },
-  "564" : {
-    "command" : "repair.party_migration.step4_clean_up_source(alice, participant1, \"alice.acs.gz\")",
+  "664" : {
+    "command" : "",
     "output" : ""
   },
   "400" : {
     "command" : "participant1.ledger_api.identity_provider_config.create(\"idp-id1\", isDeactivated = false, jwksUrl = \"http://someurl\", issuer = \"issuer1\", audience = None)",
     "output" : "res4: com.digitalasset.canton.ledger.api.domain.IdentityProviderConfig = IdentityProviderConfig(\n  identityProviderId = Id(value = \"idp-id1\"),\n  isDeactivated = false,\n  jwksUrl = JwksUrl(value = \"http://someurl\"),\n  issuer = \"issuer1\",\n  audience = None\n)"
+  },
+  "596" : {
+    "command" : "repair.party_migration.step4_clean_up_source(alice, participant1, \"alice.acs.gz\")",
+    "output" : ""
+  },
+  "691" : {
+    "command" : "participant1.repair.download(Set(alice), \"alice.acs.gz\", filterDomainId=\"mydomain\", timestamp = Some(timestamp))",
+    "output" : ""
   }
 }

--- a/docs/3.0.0/docs/canton/includes/snippet_data/usermanual/manage_domain_entities.json
+++ b/docs/3.0.0/docs/canton/includes/snippet_data/usermanual/manage_domain_entities.json
@@ -1,7 +1,7 @@
 {
   "138" : {
     "command" : "mediator1.mediator.initialize(domainId, MediatorId(domainId), domainParameters, sequencerConnections, None)",
-    "output" : "res20: PublicKey = SigningPublicKey(id = 1220189c84ae..., format = Tink, scheme = Ed25519)"
+    "output" : "res20: PublicKey = SigningPublicKey(id = 122003ec9ec6..., format = Tink, scheme = Ed25519)"
   },
   "120" : {
     "command" : "domainManager1.topology.all.list().collectOfType[TopologyChangeOp.Positive].writeToFile(\"tmp/domain-bootstrapping-files/topology-transactions.proto\")",
@@ -9,11 +9,11 @@
   },
   "84" : {
     "command" : "val domainIdString = domainManager1.id.toProtoPrimitive",
-    "output" : "domainIdString : String = \"domainManager1::1220be641b8b69c9e56c6548ac78437f05e2fdc0be96df9a70dfe2e403d28da0de9b\""
+    "output" : "domainIdString : String = \"domainManager1::1220adceb9ccc890826cb65b28bedff049855a4727f9f8dc78c7007757c2e0a7911b\""
   },
   "92" : {
     "command" : "val domainId = DomainId.tryFromString(domainIdString)",
-    "output" : "domainId : DomainId = domainManager1::1220be641b8b..."
+    "output" : "domainId : DomainId = domainManager1::1220adceb9cc..."
   },
   "129" : {
     "command" : "sequencer1.initialization.bootstrap_topology(initialTopology)",
@@ -25,7 +25,7 @@
   },
   "144" : {
     "command" : "val sequencerConnection = SequencerConnections.tryReadFromFile(\"tmp/domain-bootstrapping-files/sequencer-connection.proto\")",
-    "output" : "sequencerConnection : SequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:30141,\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
+    "output" : "sequencerConnection : SequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:31089,\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
   },
   "113" : {
     "command" : "domainManager1.setup.helper.authorizeKey(mediatorKey, \"mediator1\", MediatorId(domainId))",
@@ -33,7 +33,7 @@
   },
   "91" : {
     "command" : "val domainParameters = com.digitalasset.canton.admin.api.client.data.StaticDomainParameters.tryReadFromFile(\"tmp/domain-bootstrapping-files/params.proto\")",
-    "output" : "domainParameters : StaticDomainParameters = StaticDomainParametersV1(\n  uniqueContractKeys = true,\n  requiredSigningKeySchemes = Set(Ed25519, ECDSA-P256, ECDSA-P384),\n  requiredEncryptionKeySchemes = Set(ECIES-P256_HMAC256_AES128-GCM),\n  requiredSymmetricKeySchemes = Set(AES128-GCM),\n  requiredHashAlgorithms = Set(Sha256),\n  requiredCryptoKeyFormats = Set(Tink),\n  protocolVersion = 4\n)"
+    "output" : "domainParameters : StaticDomainParameters = StaticDomainParametersV1(\n  uniqueContractKeys = true,\n  requiredSigningKeySchemes = Set(Ed25519, ECDSA-P256, ECDSA-P384),\n  requiredEncryptionKeySchemes = Set(ECIES-P256_HMAC256_AES128-GCM),\n  requiredSymmetricKeySchemes = Set(AES128-GCM),\n  requiredHashAlgorithms = Set(Sha256),\n  requiredCryptoKeyFormats = Set(Tink, Raw, DER),\n  protocolVersion = 5\n)"
   },
   "130" : {
     "command" : "SequencerConnections.single(sequencer1.sequencerConnection).writeToFile(\"tmp/domain-bootstrapping-files/sequencer-connection.proto\")",
@@ -45,7 +45,7 @@
   },
   "99" : {
     "command" : "val sequencerPublicKey = SigningPublicKey.tryReadFromFile(\"tmp/domain-bootstrapping-files/seq1-key.proto\")",
-    "output" : "sequencerPublicKey : SigningPublicKey = SigningPublicKey(id = 122050ae909a..., format = Tink, scheme = Ed25519)"
+    "output" : "sequencerPublicKey : SigningPublicKey = SigningPublicKey(id = 1220a04f9806..., format = Tink, scheme = Ed25519)"
   },
   "42" : {
     "command" : "domainManager1.setup.bootstrap_domain(Seq(sequencer1), Seq(mediator1))",
@@ -61,11 +61,11 @@
   },
   "93" : {
     "command" : "val initResponse = sequencer1.initialization.initialize_from_beginning(domainId, domainParameters)",
-    "output" : "initResponse : com.digitalasset.canton.domain.sequencing.admin.grpc.InitializeSequencerResponse = InitializeSequencerResponse(\n  keyId = \"sequencer-id\",\n  publicKey = SigningPublicKey(id = 122050ae909a..., format = Tink, scheme = Ed25519),\n  replicated = false\n)"
+    "output" : "initResponse : com.digitalasset.canton.domain.sequencing.admin.grpc.InitializeSequencerResponse = InitializeSequencerResponse(\n  keyId = \"sequencer-id\",\n  publicKey = SigningPublicKey(id = 1220a04f9806..., format = Tink, scheme = Ed25519),\n  replicated = false\n)"
   },
   "152" : {
     "command" : "participant1.health.ping(participant1)",
-    "output" : "res26: Duration = 948 milliseconds"
+    "output" : "res26: Duration = 447 milliseconds"
   },
   "28" : {
     "command" : "",
@@ -73,7 +73,7 @@
   },
   "137" : {
     "command" : "val domainParameters = com.digitalasset.canton.admin.api.client.data.StaticDomainParameters.tryReadFromFile(\"tmp/domain-bootstrapping-files/params.proto\")",
-    "output" : "domainParameters : StaticDomainParameters = StaticDomainParametersV1(\n  uniqueContractKeys = true,\n  requiredSigningKeySchemes = Set(Ed25519, ECDSA-P256, ECDSA-P384),\n  requiredEncryptionKeySchemes = Set(ECIES-P256_HMAC256_AES128-GCM),\n  requiredSymmetricKeySchemes = Set(AES128-GCM),\n  requiredHashAlgorithms = Set(Sha256),\n  requiredCryptoKeyFormats = Set(Tink),\n  protocolVersion = 4\n)"
+    "output" : "domainParameters : StaticDomainParameters = StaticDomainParametersV1(\n  uniqueContractKeys = true,\n  requiredSigningKeySchemes = Set(Ed25519, ECDSA-P256, ECDSA-P384),\n  requiredEncryptionKeySchemes = Set(ECIES-P256_HMAC256_AES128-GCM),\n  requiredSymmetricKeySchemes = Set(AES128-GCM),\n  requiredHashAlgorithms = Set(Sha256),\n  requiredCryptoKeyFormats = Set(Tink, Raw, DER),\n  protocolVersion = 5\n)"
   },
   "33" : {
     "command" : "domainManager1.health.wait_for_identity()",
@@ -97,7 +97,7 @@
   },
   "112" : {
     "command" : "val domainId = DomainId.tryFromString(domainIdString)",
-    "output" : "domainId : DomainId = domainManager1::1220be641b8b..."
+    "output" : "domainId : DomainId = domainManager1::1220adceb9cc..."
   },
   "145" : {
     "command" : "domainManager1.setup.init(sequencerConnection)",
@@ -109,7 +109,7 @@
   },
   "127" : {
     "command" : "val initialTopology = com.digitalasset.canton.topology.store.StoredTopologyTransactions.tryReadFromFile(\"tmp/domain-bootstrapping-files/topology-transactions.proto\").collectOfType[TopologyChangeOp.Positive]",
-    "output" : "initialTopology : store.StoredTopologyTransactions[TopologyChangeOp.Positive] = Seq(\n  StoredTopologyTransaction(\n    sequenced = 2023-06-12T12:19:31.150925Z,\n    validFrom = 2023-06-12T12:19:31.150925Z,\n    validUntil = 2023-06-12T12:19:31.150925Z,\n    op = Add,\n.."
+    "output" : "initialTopology : store.StoredTopologyTransactions[TopologyChangeOp.Positive] = Seq(\n  StoredTopologyTransaction(\n    sequenced = 2023-11-21T16:33:51.196822Z,\n    validFrom = 2023-11-21T16:33:51.196822Z,\n    validUntil = 2023-11-21T16:33:51.196822Z,\n    op = Add,\n.."
   },
   "26" : {
     "command" : "",
@@ -117,7 +117,7 @@
   },
   "114" : {
     "command" : "domainManager1.topology.mediator_domain_states.authorize(TopologyChangeOp.Add, domainId, MediatorId(domainId), RequestSide.Both)",
-    "output" : "res13: com.google.protobuf.ByteString = <ByteString@227271fd size=560 contents=\"\\n\\255\\004\\n\\333\\001\\n\\326\\001\\n\\323\\001\\022 TJu4dWv2cpqPUOi2StZtQyuEE2BjPM0UR...\">"
+    "output" : "res13: com.google.protobuf.ByteString = <ByteString@1ee7ad55 size=560 contents=\"\\n\\255\\004\\n\\333\\001\\n\\326\\001\\n\\323\\001\\022 ngOdEFtwCQFCTHnfKV1yn8T6SCHugG4iR...\">"
   },
   "139" : {
     "command" : "mediator1.health.wait_for_initialized()",
@@ -137,11 +137,11 @@
   },
   "51" : {
     "command" : "participant1.health.ping(participant1)",
-    "output" : "res7: Duration = 5514 milliseconds"
+    "output" : "res7: Duration = 3729 milliseconds"
   },
   "136" : {
     "command" : "val sequencerConnections = SequencerConnections.tryReadFromFile(\"tmp/domain-bootstrapping-files/sequencer-connection.proto\")",
-    "output" : "sequencerConnections : SequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:30141,\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
+    "output" : "sequencerConnections : SequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:31089,\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
   },
   "94" : {
     "command" : "initResponse.publicKey.writeToFile(\"tmp/domain-bootstrapping-files/seq1-key.proto\")",
@@ -149,7 +149,7 @@
   },
   "111" : {
     "command" : "val mediatorKey = SigningPublicKey.tryReadFromFile(\"tmp/domain-bootstrapping-files/med1-key.proto\")",
-    "output" : "mediatorKey : SigningPublicKey = SigningPublicKey(id = 122097079077..., format = Tink, scheme = Ed25519)"
+    "output" : "mediatorKey : SigningPublicKey = SigningPublicKey(id = 1220c535c489..., format = Tink, scheme = Ed25519)"
   },
   "83" : {
     "command" : "domainManager1.service.get_static_domain_parameters.writeToFile(\"tmp/domain-bootstrapping-files/params.proto\")",

--- a/docs/3.0.0/docs/canton/includes/snippet_data/usermanual/manage_domains.json
+++ b/docs/3.0.0/docs/canton/includes/snippet_data/usermanual/manage_domains.json
@@ -1,7 +1,7 @@
 {
   "101" : {
     "command" : "participant1.health.ping(participant1)",
-    "output" : "res10: Duration = 2646 milliseconds"
+    "output" : "res10: Duration = 2749 milliseconds"
   },
   "84" : {
     "command" : "",
@@ -21,7 +21,7 @@
   },
   "73" : {
     "command" : "domainManager1.topology.participant_domain_states.list(filterStore=\"Authorized\").map(_.item)",
-    "output" : "res6: Seq[ParticipantState] = Vector(\n  ParticipantState(\n    From,\n    domainManager1::1220ce9a486a...,\n    PAR::participant1::12201c55b3f9...,\n    Submission,\n    Ordinary\n  )\n)"
+    "output" : "res6: Seq[ParticipantState] = Vector(\n  ParticipantState(\n    From,\n    domainManager1::1220aa441d01...,\n    PAR::participant1::1220bbd645a9...,\n    Submission,\n    Ordinary\n  )\n)"
   },
   "66" : {
     "command" : "",
@@ -29,11 +29,11 @@
   },
   "95" : {
     "command" : "domainManager1.topology.participant_domain_states.list(filterStore=\"Authorized\").map(_.item)",
-    "output" : "res9: Seq[ParticipantState] = Vector(\n  ParticipantState(\n    From,\n    domainManager1::1220ce9a486a...,\n    PAR::participant1::12201c55b3f9...,\n    Submission,\n    Ordinary\n  ),\n  ParticipantState(\n    To,\n    domainManager1::1220ce9a486a...,\n    PAR::participant1::12201c55b3f9...,\n    Submission,\n    Ordinary\n  )\n)"
+    "output" : "res9: Seq[ParticipantState] = Vector(\n  ParticipantState(\n    From,\n    domainManager1::1220aa441d01...,\n    PAR::participant1::1220bbd645a9...,\n    Submission,\n    Ordinary\n  ),\n  ParticipantState(\n    To,\n    domainManager1::1220aa441d01...,\n    PAR::participant1::1220bbd645a9...,\n    Submission,\n    Ordinary\n  )\n)"
   },
   "50" : {
     "command" : "val participantAsString = participant1.id.toProtoPrimitive",
-    "output" : "participantAsString : String = \"PAR::participant1::12201c55b3f9bd2090569099ed1a2eb60a872cad7170cb286a5e09b01bf32d856037\""
+    "output" : "participantAsString : String = \"PAR::participant1::1220bbd645a9f90894fa0dfe381a7e6a70323894dde2df6c275ec1f652d9c62a5355\""
   },
   "43" : {
     "command" : "",
@@ -41,7 +41,7 @@
   },
   "55" : {
     "command" : "val participantIdFromString = ParticipantId.tryFromProtoPrimitive(participantAsString)",
-    "output" : "participantIdFromString : ParticipantId = PAR::participant1::12201c55b3f9..."
+    "output" : "participantIdFromString : ParticipantId = PAR::participant1::1220bbd645a9..."
   },
   "36" : {
     "command" : "",
@@ -49,11 +49,11 @@
   },
   "42" : {
     "command" : "participant1.domains.register(config)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PARTICIPANT_IS_NOT_ACTIVE(9,20d5cc73): The participant is not yet active\n  Request: RegisterDomain(DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(endpoints = http://127.0.0.1:30078, transportSecurity = false, customTrustCertificates = None()),\n   ...\n  CorrelationId: 20d5cc7385cb9dc0895e47ef8fc0495f\n  Context: HashMap(participant -> participant1, test -> ManagePermissionedDomainsDocumentationManual, serverResponse -> Domain Domain 'mydomain' has rejected our on-boarding attempt, domain -> mydomain, tid -> 20d5cc7385cb9dc0895e47ef8fc0495f)\n  Command ParticipantAdministration$domains$.register invoked from cmd10000006.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PARTICIPANT_IS_NOT_ACTIVE(9,68af0255): The participant is not yet active\n  Request: RegisterDomain(DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(endpoints = http://127.0.0.1:31031, transportSecurity = false, customTrustCertificates = None()),\n   ...\n  CorrelationId: 68af02550fe11af863bdec96574d3711\n  Context: HashMap(participant -> participant1, test -> ManagePermissionedDomainsDocumentationManual, serverResponse -> Domain Domain 'mydomain' has rejected our on-boarding attempt, domain -> mydomain, tid -> 68af02550fe11af863bdec96574d3711)\n  Command ParticipantAdministration$domains$.register invoked from cmd10000006.sc:1"
   },
   "37" : {
     "command" : "val config = DomainConnectionConfig(\"mydomain\", sequencer1.sequencerConnection)",
-    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://127.0.0.1:30078,\n    transportSecurity = false,\n.."
+    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://127.0.0.1:31031,\n    transportSecurity = false,\n.."
   },
   "89" : {
     "command" : "domainManager1.participants.active(participantIdFromString)",

--- a/docs/3.0.0/docs/canton/includes/snippet_data/usermanual/packagemanagement.json
+++ b/docs/3.0.0/docs/canton/includes/snippet_data/usermanual/packagemanagement.json
@@ -5,15 +5,15 @@
   },
   "124" : {
     "command" : "val darHash_ = participant1.dars.list().filter(_.name == \"CantonExamples\").head.hash",
-    "output" : "darHash_ : String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "darHash_ : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "173" : {
     "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(archiveIouCmd))",
-    "output" : "res24: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220e94572b389df0216fefdbbd67933938779a64c789fa2a2fd01a9ad19ea34125d\",\n  commandId = \"a638b802-02b4-4fdb-a4f6-a3d59a6777f5\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
+    "output" : "res24: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"12203c1dc0084a7781bf911ebe41fdbac7f4b14837e03a6def5f5fafb0a074d77f37\",\n  commandId = \"055d0083-42db-4b43-b69d-4c43f11e12a8\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
   },
   "118" : {
     "command" : "val packagesBefore = participant1.packages.list().map(_.packageId).toSet",
-    "output" : "packagesBefore : Set[String] = HashSet(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"5921708ce82f4255deb1b26d2c05358b548720938a5a325718dc69f381ba47ff\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"bef3d1e9c2f8be31f80c032e930c85e336da27b64ebb1e3a31c9072e9df3a14b\",\n  \"6839a6d3d430c569b2425e9391717b44ca324b88ba621d597778811b2d05031d\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"e22bce619ae24ca3b8e6519281cb5a33b64b3190cc763248b4c3f9ad5087a92c\",\n  \"d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97\",\n  \"6c2c0667393c5f92f1885163068cd31800d2264eb088eb6fc740e11241b2bf06\",\n.."
+    "output" : "packagesBefore : Set[String] = HashSet(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"5921708ce82f4255deb1b26d2c05358b548720938a5a325718dc69f381ba47ff\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"6839a6d3d430c569b2425e9391717b44ca324b88ba621d597778811b2d05031d\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"e22bce619ae24ca3b8e6519281cb5a33b64b3190cc763248b4c3f9ad5087a92c\",\n  \"d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97\",\n  \"6c2c0667393c5f92f1885163068cd31800d2264eb088eb6fc740e11241b2bf06\",\n  \"fdd56e2ece40d67781248bc47663c9112122e35eec580b7e93ee7cfa83cda2cc\",\n.."
   },
   "159" : {
     "command" : "participant1.domains.connect_local(mydomain)",
@@ -21,11 +21,11 @@
   },
   "263" : {
     "command" : "val iou = participant1.ledger_api.acs.find_generic(participant1.adminParty, _.templateId.isModuleEntity(\"Iou\", \"Iou\"))",
-    "output" : "iou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#12204b37add31c559ac455ef8b81c5b2b4b4a9fc582aa8af26312b9fdcff5f8f0722:0\",\n    contractId = \"00f83a2f1d08029ba57a7d094db04e384e65ca77db569936e4b4ead52805993eb4ca0112209b309891c946638a730ced565114bd0a976b5df45f3a12d4f2d78d5c2fc2ce4d\",\n    templateId = Some(\n      value = Identifier(\n        packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n        moduleName = \"Iou\",\n        entityName = \"Iou\"\n      )\n.."
+    "output" : "iou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#1220146ec7742454833c3f1a0b228970d68cb34b4f50bec8683f99c6bff0604f07ba:0\",\n    contractId = \"0001abed8aaa5d6a1682fd1c8014ef41c71fecf480d09a2092c82397c6207f50b0ca02122012b02ffbb7256b408bb9d224ad70d5b85c19727674819e3c9cbdb0ae8d285eb1\",\n    templateId = Some(\n      value = Identifier(\n        packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n        moduleName = \"Iou\",\n        entityName = \"Iou\"\n      )\n.."
   },
   "195" : {
     "command" : "participant1.dars.remove(darHash)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,6d26d83c): An error was encountered whilst trying to unvet the DAR DarDescriptor(SHA-256:c783022e36ad...,CantonExamples) with main package 9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0 for DAR removal. Details: IdentityManagerParentError(Mapping(VettedPackages(\n  participant = participant1::12203c8338b7...,\n  packages = Seq(\n    9d65f326a67a...,\n    bef3d1e9c2f8...,\n    cb0552debf21...,\n    3f4deaf145a1...,\n    86828b984346...,\n    f20de1e4e37b...,\n    76bf0fd12bd9...,\n    38e6274601b2...,\n    d58cf...\n  Request: RemoveDar(1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476)\n  CorrelationId: 6d26d83cdf69a4e4f41f56f2d3f1e28c\n  Context: Map(participant -> participant1, tid -> 6d26d83cdf69a4e4f41f56f2d3f1e28c, test -> PackageDarManagementDocumentationIntegrationTest)\n  Command ParticipantAdministration$dars$.remove invoked from cmd10000076.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,b66245d6): An error was encountered whilst trying to unvet the DAR DarDescriptor(SHA-256:cf7693f5858d...,CantonExamples) with main package 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680 for DAR removal. Details: IdentityManagerParentError(Mapping(VettedPackages(\n  participant = participant1::1220232a47de...,\n  packages = Seq(\n    6087107abcaa...,\n    a566728bb2d4...,\n    cb0552debf21...,\n    3f4deaf145a1...,\n    86828b984346...,\n    f20de1e4e37b...,\n    76bf0fd12bd9...,\n    38e6274601b2...,\n    d58cf...\n  Request: RemoveDar(1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c)\n  CorrelationId: b66245d684292adb6d13ada6c04748be\n  Context: Map(participant -> participant1, tid -> b66245d684292adb6d13ada6c04748be, test -> PackageDarManagementDocumentationIntegrationTest)\n  Command ParticipantAdministration$dars$.remove invoked from cmd10000076.sc:1"
   },
   "276" : {
     "command" : "participant1.packages.remove(packageId)",
@@ -33,15 +33,15 @@
   },
   "247" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "darHash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "42" : {
     "command" : "val darContent = participant2.dars.list_contents(hash)",
-    "output" : "darContent : DarMetadata = DarMetadata(\n  name = \"CantonExamples\",\n  main = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n  packages = Vector(\n    \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n    \"bef3d1e9c2f8be31f80c032e930c85e336da27b64ebb1e3a31c9072e9df3a14b\",\n    \"cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a\",\n    \"3f4deaf145a15cdcfa762c058005e2edb9baa75bb7f95a4f8f6f937378e86415\",\n.."
+    "output" : "darContent : DarMetadata = DarMetadata(\n  name = \"CantonExamples\",\n  main = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n  packages = Vector(\n    \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n    \"a566728bb2d4ad0103eb11ff8140296f4cea4fc94f1f95ddc6c3e4f983d107f1\",\n    \"cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a\",\n    \"3f4deaf145a15cdcfa762c058005e2edb9baa75bb7f95a4f8f6f937378e86415\",\n.."
   },
   "37" : {
     "command" : "val hash = dars.head.hash",
-    "output" : "hash : String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "hash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "125" : {
     "command" : "",
@@ -49,7 +49,7 @@
   },
   "157" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "darHash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "189" : {
     "command" : "val packageIds = participant1.packages.list().filter(_.sourceDescription == \"CantonExamples\").map(_.packageId).map(PackageId.assertFromString)",
@@ -57,11 +57,11 @@
   },
   "20" : {
     "command" : "participant2.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "res1: String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "res1: String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "253" : {
     "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
-    "output" : "res39: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"12204b37add31c559ac455ef8b81c5b2b4b4a9fc582aa8af26312b9fdcff5f8f0722\",\n  commandId = \"9c107e7c-e63a-46af-bfbc-7dc36d0e6a31\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1686572343L,\n      nanos = 324270000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n.."
+    "output" : "res39: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220146ec7742454833c3f1a0b228970d68cb34b4f50bec8683f99c6bff0604f07ba\",\n  commandId = \"e03c5505-f87f-4f72-be36-8d5584fa9f55\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1700584416L,\n      nanos = 493182000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n.."
   },
   "238" : {
     "command" : "participant1.packages.remove(packageId)",
@@ -73,11 +73,11 @@
   },
   "221" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "darHash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "265" : {
     "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(archiveIouCmd))",
-    "output" : "res42: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220fb7be1e400fe1f2d4506b8c5fa1c383e200150667e1feffbbe6b81f4b23695a1\",\n  commandId = \"9605fb99-b2f5-4483-aadf-82f9464041e3\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1686572344L,\n      nanos = 187726000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n  ),\n  offset = \"00000000000000000c\",\n.."
+    "output" : "res42: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220bfb03a10fbf503f040654e7574cc4061f668a8bd3ff08ea5e646dae18e587fb0\",\n  commandId = \"5b1d6640-b222-4939-a77d-480f99a3db50\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1700584417L,\n      nanos = 29686000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n  ),\n  offset = \"00000000000000000c\",\n.."
   },
   "292" : {
     "command" : "participant1.packages.remove(packageId, force = true)",
@@ -85,11 +85,11 @@
   },
   "233" : {
     "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove, participant1.id, packageIds, force = true)",
-    "output" : "res35: com.google.protobuf.ByteString = <ByteString@4fb290fb size=2384 contents=\"\\n\\315\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 mpi2lnnmh4OW4bQLCDbKw64QaIc9acP...\">"
+    "output" : "res35: com.google.protobuf.ByteString = <ByteString@156c7f50 size=2386 contents=\"\\n\\317\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 BlnATewcV5NuKFGXRrt5wz4VfXVnY0c...\">"
   },
   "270" : {
     "command" : "val packageIds = participant1.topology.vetted_packages.list().map(_.item.packageIds).filter(_.contains(packageId)).head",
-    "output" : "packageIds : Seq[com.digitalasset.canton.package.LfPackageId] = Vector(\n  \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n  \"bef3d1e9c2f8be31f80c032e930c85e336da27b64ebb1e3a31c9072e9df3a14b\",\n.."
+    "output" : "packageIds : Seq[com.digitalasset.canton.package.LfPackageId] = Vector(\n  \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n  \"a566728bb2d4ad0103eb11ff8140296f4cea4fc94f1f95ddc6c3e4f983d107f1\",\n.."
   },
   "201" : {
     "command" : "participant1.dars.remove(darHash)",
@@ -97,7 +97,7 @@
   },
   "28" : {
     "command" : "participant2.dars.list()",
-    "output" : "res2: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\",\n    name = \"CantonExamples\"\n  ),\n  DarDescription(\n    hash = \"122012a6f2b7c0b666e7541ce6f5d4273ab8d00da671b4d3bbb9bebb6a5120ec02c5\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  )\n)"
+    "output" : "res2: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220caf9b815c77d40b24801fc88acaa85bffac5cc315644c8242923d039d8df6d73\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  ),\n  DarDescription(\n    hash = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\",\n    name = \"CantonExamples\"\n  )\n)"
   },
   "160" : {
     "command" : "val createIouCmd = ledger_api_utils.create(packageId,\"Iou\",\"Iou\",Map(\"payer\" -> participant1.adminParty,\"owner\" -> participant1.adminParty,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
@@ -113,19 +113,19 @@
   },
   "166" : {
     "command" : "participant1.dars.remove(darHash)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,40ff158c): The DAR DarDescriptor(SHA-256:c783022e36ad...,CantonExamples) cannot be removed because its main package 9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0 is in-use by contract ContractId(005170f294b69a37a7ba0c30a8f0c6ea1ab81e142e74fb146f19104af801cac302ca0112203845e89891f897f3bbc66395732e4994ccd4b3e26ebc9a46ca0e272d4c284422)\non domain mydomain::1220bf7c580f....\n  Request: RemoveDar(1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476)\n  CorrelationId: 40ff158cd233c870d3dcba1e95b267bb\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, pkg -> 9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0, tid -> 40ff158cd233c870d3dcba1e95b267bb)\n  Command ParticipantAdministration$dars$.remove invoked from cmd10000056.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,2b508204): The DAR DarDescriptor(SHA-256:cf7693f5858d...,CantonExamples) cannot be removed because its main package 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680 is in-use by contract ContractId(000359c4dc4a41db95ea9e4f1ff951f7e38e17046bad59290b8e9908c995b12c1bca021220f5752932c841588a2c752277f0d2d23899dce9dc52ef10bce474200edd81d6fa)\non domain mydomain::1220c4144403....\n  Request: RemoveDar(1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c)\n  CorrelationId: 2b508204c633bbfa288bd2b8fefd2af6\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, pkg -> 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680, tid -> 2b508204c633bbfa288bd2b8fefd2af6)\n  Command ParticipantAdministration$dars$.remove invoked from cmd10000056.sc:1"
   },
   "264" : {
     "command" : "val archiveIouCmd = ledger_api_utils.exercise(\"Archive\", Map.empty, iou.event)",
-    "output" : "archiveIouCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Exercise(\n    value = ExerciseCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n          moduleName = \"Iou\",\n          entityName = \"Iou\"\n        )\n      ),\n.."
+    "output" : "archiveIouCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Exercise(\n    value = ExerciseCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n          moduleName = \"Iou\",\n          entityName = \"Iou\"\n        )\n      ),\n.."
   },
   "161" : {
     "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
-    "output" : "res21: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220140615c40a381f9b867ceb78961bb1fbaceb82c8c52259ce4c5e83940bd4fc4e\",\n  commandId = \"09fd6428-b7a8-49eb-9972-85f1f3dd9376\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
+    "output" : "res21: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"12206a7a4f3b183ba3a5185956e606d9c78e7582354f9754372fa1204cc5dcfa46a3\",\n  commandId = \"b73849ae-cb3a-4ebb-a465-9636b11192e9\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
   },
   "187" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\", vetAllPackages = false)",
-    "output" : "darHash : String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "darHash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "172" : {
     "command" : "val archiveIouCmd = ledger_api_utils.exercise(\"Archive\", Map.empty, iou.event)",
@@ -133,7 +133,7 @@
   },
   "271" : {
     "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove, participant1.id, packageIds, force = true)",
-    "output" : "res44: com.google.protobuf.ByteString = <ByteString@6328d67d size=2384 contents=\"\\n\\315\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 LJkyooFPhwkMj4HzoHpmsrxdXvEDWsP...\">"
+    "output" : "res44: com.google.protobuf.ByteString = <ByteString@345869e6 size=2386 contents=\"\\n\\317\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 WXXn7d50sfBZmYDgHysRBdVvs1FomFs...\">"
   },
   "130" : {
     "command" : "participant1.dars.remove(darHash)",
@@ -141,15 +141,15 @@
   },
   "135" : {
     "command" : "val packageIds = participant1.packages.list().filter(_.sourceDescription == \"CantonExamples\").map(_.packageId)",
-    "output" : "packageIds : Seq[String] = Vector(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"e491352788e56ca4603acc411ffe1a49fefd76ed8b163af86cf5ee5f4c38645b\",\n  \"cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a\",\n  \"38e6274601b21d7202bb995bc5ec147decda5a01b68d57dda422425038772af7\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"f20de1e4e37b92280264c08bf15eca0be0bc5babd7a7b5e574997f154c00cb78\",\n  \"283fdcf3bbbc04db4ee15ba5760dbe459aee1087f358b7e6cd4d7da2ff36e776\",\n  \"8a7806365bbd98d88b4c13832ebfa305f6abaeaf32cfa2b7dd25c4fa489b79fb\",\n.."
+    "output" : "packageIds : Seq[String] = Vector(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"e491352788e56ca4603acc411ffe1a49fefd76ed8b163af86cf5ee5f4c38645b\",\n  \"55aeefaf7bfb7f275f52b402f419f71c8e529b6ec625812d2a4e80f280fd86d4\",\n  \"cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a\",\n  \"38e6274601b21d7202bb995bc5ec147decda5a01b68d57dda422425038772af7\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"a566728bb2d4ad0103eb11ff8140296f4cea4fc94f1f95ddc6c3e4f983d107f1\",\n  \"f20de1e4e37b92280264c08bf15eca0be0bc5babd7a7b5e574997f154c00cb78\",\n.."
   },
   "258" : {
     "command" : "participant1.packages.remove(packageId)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,7f16ca92): Package 9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0 is currently in-use by contract ContractId(00f83a2f1d08029ba57a7d094db04e384e65ca77db569936e4b4ead52805993eb4ca0112209b309891c946638a730ced565114bd0a976b5df45f3a12d4f2d78d5c2fc2ce4d) on domain mydomain::1220bf7c580f.... It may also be in-use by other contracts.\n  Request: RemovePackage(9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0,false)\n  CorrelationId: 7f16ca92dea13a8d2e27e2a68d3ed5fe\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, domain -> mydomain::1220bf7c580f..., pkg -> 9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0, tid -> 7f16ca92dea13a8d2e27e2a68d3ed5fe, contract -> ContractId(00f83a2f1d08029ba57a7d094db04e384e65ca77db569936e4b4ead52805993eb4ca0112209b309891c946638a730ced565114bd0a976b5df45f3a12d4f2d78d5c2fc2ce4d))\n  Command ParticipantAdministration$packages$.remove invoked from cmd10000103.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,b97124bc): Package 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680 is currently in-use by contract ContractId(0001abed8aaa5d6a1682fd1c8014ef41c71fecf480d09a2092c82397c6207f50b0ca02122012b02ffbb7256b408bb9d224ad70d5b85c19727674819e3c9cbdb0ae8d285eb1) on domain mydomain::1220c4144403.... It may also be in-use by other contracts.\n  Request: RemovePackage(6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680,false)\n  CorrelationId: b97124bc42d19f00c5a8ca1ecbd6982c\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, domain -> mydomain::1220c4144403..., pkg -> 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680, tid -> b97124bc42d19f00c5a8ca1ecbd6982c, contract -> ContractId(0001abed8aaa5d6a1682fd1c8014ef41c71fecf480d09a2092c82397c6207f50b0ca02122012b02ffbb7256b408bb9d224ad70d5b85c19727674819e3c9cbdb0ae8d285eb1))\n  Command ParticipantAdministration$packages$.remove invoked from cmd10000103.sc:1"
   },
   "158" : {
     "command" : "val packageId = participant1.packages.find(\"Iou\").head.packageId",
-    "output" : "packageId : String = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\""
+    "output" : "packageId : String = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\""
   },
   "55" : {
     "command" : "participant2.packages.list_contents(darContent.main)",
@@ -157,31 +157,31 @@
   },
   "171" : {
     "command" : "val iou = participant1.ledger_api.acs.find_generic(participant1.adminParty, _.templateId.isModuleEntity(\"Iou\", \"Iou\"))",
-    "output" : "iou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#1220140615c40a381f9b867ceb78961bb1fbaceb82c8c52259ce4c5e83940bd4fc4e:0\",\n    contractId = \"005170f294b69a37a7ba0c30a8f0c6ea1ab81e142e74fb146f19104af801cac302ca0112203845e89891f897f3bbc66395732e4994ccd4b3e26ebc9a46ca0e272d4c284422\",\n    templateId = Some(\n      value = Identifier(\n        packageId = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n        moduleName = \"Iou\",\n        entityName = \"Iou\"\n      )\n.."
+    "output" : "iou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#12206a7a4f3b183ba3a5185956e606d9c78e7582354f9754372fa1204cc5dcfa46a3:0\",\n    contractId = \"000359c4dc4a41db95ea9e4f1ff951f7e38e17046bad59290b8e9908c995b12c1bca021220f5752932c841588a2c752277f0d2d23899dce9dc52ef10bce474200edd81d6fa\",\n    templateId = Some(\n      value = Identifier(\n        packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n        moduleName = \"Iou\",\n        entityName = \"Iou\"\n      )\n.."
   },
   "75" : {
     "command" : "participant2.topology.vetted_packages.list()",
-    "output" : "res8: Seq[ListVettedPackagesResult] = Vector(\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2023-06-12T12:18:42.142697Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@110816a5 size=2582 contents=\"\\n\\223\\024\\n\\301\\021\\n\\274\\021\\n\\271\\021\\022 QJVnZH6yMsV48KljIgN1QyQ53uSqnNBtJ...\">,\n.."
+    "output" : "res8: Seq[ListVettedPackagesResult] = Vector(\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2023-11-21T16:33:24.605693Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@1e555edc size=2582 contents=\"\\n\\223\\024\\n\\301\\021\\n\\274\\021\\n\\271\\021\\022 oXqmBXDwBBWJimTXiqLZjPpQb04spxHiJ...\">,\n.."
   },
   "119" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "darHash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "287" : {
     "command" : "participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "res46: String = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\""
+    "output" : "res46: String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
   },
   "36" : {
     "command" : "val dars = participant2.dars.list(filterName = \"CantonExamples\")",
-    "output" : "dars : Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220c783022e36adf132a905711d40850477d4b817e39f1b44d62af0f4a7a3c05476\",\n    name = \"CantonExamples\"\n  )\n)"
+    "output" : "dars : Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\",\n    name = \"CantonExamples\"\n  )\n)"
   },
   "146" : {
     "command" : "val packages = participant1.packages.list().map(_.packageId).toSet",
-    "output" : "packages : Set[String] = HashSet(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"5921708ce82f4255deb1b26d2c05358b548720938a5a325718dc69f381ba47ff\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"bef3d1e9c2f8be31f80c032e930c85e336da27b64ebb1e3a31c9072e9df3a14b\",\n  \"6839a6d3d430c569b2425e9391717b44ca324b88ba621d597778811b2d05031d\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"e22bce619ae24ca3b8e6519281cb5a33b64b3190cc763248b4c3f9ad5087a92c\",\n  \"d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97\",\n  \"6c2c0667393c5f92f1885163068cd31800d2264eb088eb6fc740e11241b2bf06\",\n.."
+    "output" : "packages : Set[String] = HashSet(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"5921708ce82f4255deb1b26d2c05358b548720938a5a325718dc69f381ba47ff\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"6839a6d3d430c569b2425e9391717b44ca324b88ba621d597778811b2d05031d\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"e22bce619ae24ca3b8e6519281cb5a33b64b3190cc763248b4c3f9ad5087a92c\",\n  \"d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97\",\n  \"6c2c0667393c5f92f1885163068cd31800d2264eb088eb6fc740e11241b2bf06\",\n  \"fdd56e2ece40d67781248bc47663c9112122e35eec580b7e93ee7cfa83cda2cc\",\n.."
   },
   "190" : {
     "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Add, participant1.id, packageIds)",
-    "output" : "res29: com.google.protobuf.ByteString = <ByteString@27db41fd size=2382 contents=\"\\n\\313\\022\\n\\373\\017\\n\\366\\017\\n\\363\\017\\022 0SDxlEAROOtxd441yH4iwrMCwtqn7ZB2J...\">"
+    "output" : "res29: com.google.protobuf.ByteString = <ByteString@6dbccbfb size=2384 contents=\"\\n\\315\\022\\n\\373\\017\\n\\366\\017\\n\\363\\017\\022 1X1RwdJgZmcfaJrFjbOLxEWnsLn6kbGWJ...\">"
   },
   "47" : {
     "command" : "participant2.packages.list()",
@@ -189,7 +189,7 @@
   },
   "200" : {
     "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove, participant1.id, packageIds, force = true)",
-    "output" : "res30: com.google.protobuf.ByteString = <ByteString@237238b1 size=2384 contents=\"\\n\\315\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 0SDxlEAROOtxd441yH4iwrMCwtqn7ZB...\">"
+    "output" : "res30: com.google.protobuf.ByteString = <ByteString@52a4a9e size=2386 contents=\"\\n\\317\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 1X1RwdJgZmcfaJrFjbOLxEWnsLn6kbG...\">"
   },
   "178" : {
     "command" : "participant1.dars.remove(darHash)",
@@ -197,14 +197,14 @@
   },
   "227" : {
     "command" : "participant1.packages.remove(packageId)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,a10cdd12): Package 9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0 is currently vetted and available to use.\n  Request: RemovePackage(9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0,false)\n  CorrelationId: a10cdd12ceeefbc4a17c2bc21b469371\n  Context: Map(participant -> participant1, tid -> a10cdd12ceeefbc4a17c2bc21b469371, test -> PackageDarManagementDocumentationIntegrationTest)\n  Command ParticipantAdministration$packages$.remove invoked from cmd10000087.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,3a2b5f94): Package 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680 is currently vetted and available to use.\n  Request: RemovePackage(6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680,false)\n  CorrelationId: 3a2b5f94ab9f89fd56ecfc722b33fd62\n  Context: Map(participant -> participant1, tid -> 3a2b5f94ab9f89fd56ecfc722b33fd62, test -> PackageDarManagementDocumentationIntegrationTest)\n  Command ParticipantAdministration$packages$.remove invoked from cmd10000087.sc:1"
   },
   "222" : {
     "command" : "val packageId = participant1.packages.find(\"Iou\").head.packageId",
-    "output" : "packageId : String = \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\""
+    "output" : "packageId : String = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\""
   },
   "232" : {
     "command" : "val packageIds = participant1.topology.vetted_packages.list().map(_.item.packageIds).filter(_.contains(packageId)).head",
-    "output" : "packageIds : Seq[com.digitalasset.canton.package.LfPackageId] = Vector(\n  \"9d65f326a67a0dc9a723dbaa3abb1b67831858940cfe6376475d7959120fe6d0\",\n  \"bef3d1e9c2f8be31f80c032e930c85e336da27b64ebb1e3a31c9072e9df3a14b\",\n.."
+    "output" : "packageIds : Seq[com.digitalasset.canton.package.LfPackageId] = Vector(\n  \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n  \"a566728bb2d4ad0103eb11ff8140296f4cea4fc94f1f95ddc6c3e4f983d107f1\",\n.."
   }
 }

--- a/docs/3.0.0/docs/canton/includes/snippet_data/usermanual/upgrading.json
+++ b/docs/3.0.0/docs/canton/includes/snippet_data/usermanual/upgrading.json
@@ -1,126 +1,126 @@
 {
-  "416" : {
+  "481" : {
     "command" : "",
     "output" : ""
   },
-  "147" : {
+  "440" : {
+    "command" : "",
+    "output" : ""
+  },
+  "538" : {
+    "command" : "",
+    "output" : ""
+  },
+  "184" : {
+    "command" : "",
+    "output" : ""
+  },
+  "189" : {
+    "command" : "participant.health.ping(participant)",
+    "output" : "res7: Duration = 817 milliseconds"
+  },
+  "132" : {
     "command" : "participant.start()",
-    "output" : ""
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - failed to initialize participant: There are 6 pending migrations to get to database schema version 7. Currently on version 1.1. Please run `participant.db.migrate` to apply pending migrations\n  Command LocalParticipantReference.start invoked from cmd10000002.sc:1"
   },
-  "160" : {
-    "command" : "participant.domains.connect_local(testdomain)",
-    "output" : ""
-  },
-  "361" : {
+  "424" : {
     "command" : "",
     "output" : ""
   },
-  "420" : {
-    "command" : "",
-    "output" : ""
-  },
-  "371" : {
-    "command" : "participant.health.ping(participant)",
-    "output" : "res10: Duration = 890 milliseconds"
-  },
-  "360" : {
-    "command" : "participant.domains.list_connected()",
-    "output" : "res8: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'newdomain',\n    domainId = newdomain::1220b732056e...,\n    healthy = true\n  )\n)"
-  },
-  "166" : {
-    "command" : "participant.domains.reconnect_all()",
-    "output" : ""
-  },
-  "177" : {
-    "command" : "participant.health.ping(participant)",
-    "output" : "res7: Duration = 987 milliseconds"
-  },
-  "314" : {
-    "command" : "participant.domains.disconnect(\"olddomain\")",
-    "output" : ""
-  },
-  "305" : {
-    "command" : "",
-    "output" : ""
-  },
-  "138" : {
+  "141" : {
     "command" : "participant.db.migrate()",
     "output" : ""
   },
-  "347" : {
-    "command" : "participant.repair.migrate_domain(\"olddomain\", config)",
-    "output" : ""
-  },
-  "417" : {
+  "537" : {
     "command" : "",
     "output" : ""
   },
-  "320" : {
+  "425" : {
     "command" : "",
     "output" : ""
   },
-  "307" : {
-    "command" : "participant.resources.set_resource_limits(ResourceLimits(Some(0), Some(0)))",
-    "output" : ""
+  "462" : {
+    "command" : "val config = DomainConnectionConfig(\"newdomain\", newdomain.sequencerConnection)",
+    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'newdomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://127.0.0.1:31108,\n    transportSecurity = false,\n.."
   },
-  "366" : {
-    "command" : "participant.resources.set_resource_limits(ResourceLimits(None, None))",
-    "output" : ""
-  },
-  "335" : {
+  "455" : {
     "command" : "val config = DomainConnectionConfig(\"newdomain\", GrpcSequencerConnection.tryCreate(\"https://127.0.0.1:5018\"))",
     "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'newdomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = https://127.0.0.1:5018,\n    transportSecurity = true,\n.."
   },
-  "159" : {
-    "command" : "testdomain.start()",
-    "output" : ""
-  },
-  "172" : {
+  "426" : {
     "command" : "",
     "output" : ""
   },
-  "419" : {
+  "539" : {
     "command" : "participant.domains.connect_local(newdomain)",
     "output" : ""
   },
-  "130" : {
-    "command" : "participant.start()",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - failed to initialize participant: There are 5 pending migrations to get to database schema version 6. Currently on version 1.1. Please run `participant.db.migrate` to apply pending migrations\n  Command LocalParticipantReference.start invoked from cmd10000002.sc:1"
+  "171" : {
+    "command" : "testdomain.start()",
+    "output" : ""
   },
-  "306" : {
+  "536" : {
     "command" : "",
     "output" : ""
   },
-  "431" : {
-    "command" : "participant.domains.list_registered().map { case (c,_) => (c.domain, c.priority) }",
-    "output" : "res3: Seq[(com.digitalasset.canton.DomainAlias, Int)] = Vector((Domain 'newdomain', 10), (Domain 'olddomain', 0))"
+  "183" : {
+    "command" : "participant.domains.list_connected()",
+    "output" : "res6: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'testdomain',\n    domainId = testdomain::1220b3e68c56...,\n    healthy = true\n  )\n)"
   },
-  "426" : {
-    "command" : "participant.domains.modify(\"newdomain\", _.copy(priority=10))",
-    "output" : ""
-  },
-  "342" : {
-    "command" : "val config = DomainConnectionConfig(\"newdomain\", newdomain.sequencerConnection)",
-    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'newdomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://127.0.0.1:30154,\n    transportSecurity = false,\n.."
-  },
-  "355" : {
+  "475" : {
     "command" : "participant.domains.reconnect_all()",
     "output" : ""
   },
-  "319" : {
+  "480" : {
+    "command" : "participant.domains.list_connected()",
+    "output" : "res8: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'newdomain',\n    domainId = newdomain::1220fb737b48...,\n    healthy = true\n  )\n)"
+  },
+  "439" : {
     "command" : "participant.domains.list_connected()",
     "output" : "res3: Seq[ListConnectedDomainsResult] = Vector()"
   },
-  "304" : {
+  "546" : {
+    "command" : "participant.domains.modify(\"newdomain\", _.copy(priority=10))",
+    "output" : ""
+  },
+  "467" : {
+    "command" : "participant.repair.migrate_domain(\"olddomain\", config)",
+    "output" : ""
+  },
+  "551" : {
+    "command" : "participant.domains.list_registered().map { case (c,_) => (c.domain, c.priority) }",
+    "output" : "res3: Seq[(com.digitalasset.canton.DomainAlias, Int)] = Vector((Domain 'newdomain', 10), (Domain 'olddomain', 0))"
+  },
+  "540" : {
     "command" : "",
     "output" : ""
   },
-  "171" : {
-    "command" : "participant.domains.list_connected()",
-    "output" : "res6: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'testdomain',\n    domainId = testdomain::122056e307f0...,\n    healthy = true\n  )\n)"
-  },
-  "418" : {
-    "command" : "",
+  "159" : {
+    "command" : "participant.start()",
     "output" : ""
+  },
+  "172" : {
+    "command" : "participant.domains.connect_local(testdomain)",
+    "output" : ""
+  },
+  "434" : {
+    "command" : "participant.domains.disconnect(\"olddomain\")",
+    "output" : ""
+  },
+  "427" : {
+    "command" : "participant.resources.set_resource_limits(ResourceLimits(Some(0), Some(0)))",
+    "output" : ""
+  },
+  "178" : {
+    "command" : "participant.domains.reconnect_all()",
+    "output" : ""
+  },
+  "486" : {
+    "command" : "participant.resources.set_resource_limits(ResourceLimits(None, None))",
+    "output" : ""
+  },
+  "491" : {
+    "command" : "participant.health.ping(participant)",
+    "output" : "res10: Duration = 555 milliseconds"
   }
 }

--- a/docs/3.0.0/docs/canton/usermanual/identity_management.rst
+++ b/docs/3.0.0/docs/canton/usermanual/identity_management.rst
@@ -621,7 +621,7 @@ Starting with a party being allocated on participant1:
     .. assert:: { participants.all.domains.connect_local(mydomain); true }
     .. success:: val alice = participant1.parties.enable("Alice")
     .. assert:: { utils.synchronize_topology(); true }
-    .. assert:: { participant1.ledger_api.commands.submit_flat(Seq(alice), Seq(com.digitalasset.canton.participant.admin.workflows.PingPong.Cycle("hello", alice.toPrim).create.command)); true }
+    .. assert:: { import scala.jdk.CollectionConverters._; participant1.ledger_api.javaapi.commands.submit_flat(Seq(alice), new com.digitalasset.canton.participant.admin.workflows.java.pingpong.Cycle("hello", alice.toProtoPrimitive).create.commands.asScala.toSeq); true }
 
 To add this party to participant2, participant2 must first agree to host the party. This
 is done by authorizing the ``RequestSide.To`` of the party to participant mapping on the target participant:
@@ -708,7 +708,7 @@ Once the entire active contract store has been imported, the target participant 
 Now, both participant host the party and can act on behalf of it.
 
 .. snippet:: party_on_two_nodes
-    .. assert:: { val cycle = participant2.ledger_api.acs.await(alice, com.digitalasset.canton.participant.admin.workflows.PingPong.Cycle); participant2.ledger_api.commands.submit_flat(Seq(alice), Seq(cycle.contractId.exerciseRepeat().command)); true }
+    .. assert:: { import scala.jdk.CollectionConverters._; val cycle = participant2.ledger_api.javaapi.acs.await(com.digitalasset.canton.participant.admin.workflows.java.pingpong.Cycle.COMPANION)(alice); participant2.ledger_api.javaapi.commands.submit_flat(Seq(alice), cycle.id.exerciseRepeat().commands.asScala.toSeq); true }
 
 .. _manually_initializing_node:
 


### PR DESCRIPTION
`PingPong` (a test Daml contract) is now only available through the Java Bindings (see https://github.com/DACH-NY/canton/pull/15189). Thus the `snippet` directives in the Canton `identity_management.rst` file need to be adapted. 

While maybe not needed, this change also regenerates the `snippet` output data using the respective Canton versions `2.8.0` and `3.0.0`.