### PR TITLE
Update daml-3.x section on dynamic domain parameters

### DIFF
--- a/docs/3.0.0/docs/canton/usermanual/manage_domains.rst
+++ b/docs/3.0.0/docs/canton/usermanual/manage_domains.rst
@@ -130,15 +130,7 @@ A participant can get the current parameters on a domain it is connected to usin
    :end-before: user-manual-entry-begin:-end: GetDynamicDomainParameters
    :dedent:
 
-Parameters that were transitioned from static to dynamic with protocol version 4 need to be retrieved individually:
-
-.. literalinclude:: /canton/includes/mirrored/enterprise/app/src/test/scala/com/digitalasset/canton/integration/tests/dynamicdomainparameters/DomainParametersChangeIntegrationTest.scala
-   :language: scala
-   :start-after: user-manual-entry-begin:-begin: GetSingleDynamicDomainParameter
-   :end-before: user-manual-entry-begin:-end: GetSingleDynamicDomainParameter
-   :dedent:
-
-Dynamic parameters can bet set individually using:
+Dynamic parameters can be proposed by any domain owner. Typically sequencers are domain owners:
 
 .. literalinclude:: /canton/includes/mirrored/enterprise/app/src/test/scala/com/digitalasset/canton/integration/tests/dynamicdomainparameters/DomainParametersChangeIntegrationTest.scala
    :language: scala
@@ -146,7 +138,7 @@ Dynamic parameters can bet set individually using:
    :end-before: user-manual-entry-begin:-end: SetDynamicDomainParameters
    :dedent:
 
-Alternatively, several can be set at the same time:
+Note that several dynamic parameters can be set at the same time:
 
 .. literalinclude:: /canton/includes/mirrored/enterprise/app/src/test/scala/com/digitalasset/canton/integration/tests/dynamicdomainparameters/DomainParametersChangeIntegrationTest.scala
    :language: scala


### PR DESCRIPTION
The mechanism to manipulate "dynamic domain parameters" is changing in daml 3 compared to daml 2. I have changed the code snippets embedded in `manage_domains.rst` accordingly as described in https://github.com/DACH-NY/canton/pull/15623 . This PR updates the documentation to be in sync as well.

Advances https://github.com/DACH-NY/canton/issues/15693