### PR TITLE
update protobuf links (2.6, 2.7)

### DIFF
--- a/docs/2.6.5/docs/app-dev/grpc/index.rst
+++ b/docs/2.6.5/docs/app-dev/grpc/index.rst
@@ -14,7 +14,7 @@ If you're not familiar with gRPC and protobuf, we strongly recommend following t
 Get Started
 ***********
 
-You can get the protobufs from a `GitHub release <protobufs_>`_, or from the ``daml`` repository `here <https://github.com/digital-asset/daml/tree/main/ledger-api/grpc-definitions>`__.
+You can get the protobufs from a `GitHub release <protobufs_>`_, or from the ``daml`` repository `here <https://github.com/digital-asset/daml/tree/v2.6.5/ledger-api/grpc-definitions>`__.
 
 Protobuf Reference Documentation
 ********************************

--- a/docs/2.7.6/docs/app-dev/grpc/index.rst
+++ b/docs/2.7.6/docs/app-dev/grpc/index.rst
@@ -14,7 +14,7 @@ If you're not familiar with gRPC and protobuf, we strongly recommend following t
 Get Started
 ***********
 
-You can get the protobufs from a `GitHub release <protobufs_>`_, or from the ``daml`` repository `here <https://github.com/digital-asset/daml/tree/main/ledger-api/grpc-definitions>`__.
+You can get the protobufs from a `GitHub release <protobufs_>`_, or from the ``daml`` repository `here <https://github.com/digital-asset/daml/tree/v2.7.6/ledger-api/grpc-definitions>`__.
 
 Protobuf Reference Documentation
 ********************************


### PR DESCRIPTION
Someone who knows where this went should update the 2.8.0 and 3.0.0 sites.