### PR TITLE
cron: ignore latest snapshot (2.8.0-snapshot.20231213.0)

### DIFF
--- a/bin/publish-snapshots
+++ b/bin/publish-snapshots
@@ -61,6 +61,7 @@ broken() (
 2.8.0-snapshot.20231117.0
 2.8.0-snapshot.20231129.0
 2.8.0-snapshot.20231206.0
+2.8.0-snapshot.20231213.0
 EOF
   echo "$known_broken" | grep $version >/dev/null
 )


### PR DESCRIPTION
It's broken because of the drivers.