### PR TITLE
Rewrote installation guide to use new reference config

### DIFF
--- a/docs/2.9.0/docs/canton/includes/snippet_data/tutorials/getting_started.json
+++ b/docs/2.9.0/docs/canton/includes/snippet_data/tutorials/getting_started.json
@@ -1,274 +1,274 @@
 {
-  "481" : {
-    "command" : "val pkgPaint = participant1.packages.find(\"Paint\").head",
-    "output" : "pkgPaint : com.digitalasset.canton.participant.admin.v0.PackageDescription = PackageDescription(\n  packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n  sourceDescription = \"CantonExamples\"\n)"
+  "533" : {
+    "command" : "val acceptOffer = ledger_api_utils.exercise(\"AcceptByOwner\", Map(\"iouId\" -> LfContractId.assertFromString(aliceIou.event.contractId)),paintOffer.event)",
+    "output" : "acceptOffer : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Exercise(\n    value = ExerciseCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n.."
   },
-  "280" : {
-    "command" : "",
-    "output" : ""
-  },
-  "452" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(alice), Seq(createIouCmd))",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcClientError: INVALID_ARGUMENT/DAML_AUTHORIZATION_ERROR(8,1efe0fcf): Interpretation error: Error: node NodeId(0) (6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680:Iou:Iou) requires authorizers Bank::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482, but only Alice::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9 were given\n  Request: SubmitAndWaitTransactionTree(\n  actAs = Alice::1220f4191f94...,\n.."
-  },
-  "392" : {
-    "command" : "val bank = participant2.parties.enable(\"Bank\", waitForDomain = DomainChoice.All)",
-    "output" : "bank : PartyId = Bank::1220a497955f..."
-  },
-  "328" : {
-    "command" : "val p2UidString = participant2.id.uid.toProtoPrimitive",
-    "output" : "p2UidString : String = \"participant2::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\""
-  },
-  "286" : {
+  "288" : {
     "command" : "mydomain.parties.list(\"Bob\")",
-    "output" : "res18: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Bob::1220a497955f...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant2::1220a497955f...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220440cf3c3..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
+    "output" : "res18: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Bob::12201f864d90...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant2::12201f864d90...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::12205e5dccac..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
   },
-  "208" : {
-    "command" : "",
-    "output" : ""
+  "302" : {
+    "command" : "participant1.health.ping(participant2)",
+    "output" : ".."
   },
-  "462" : {
-    "command" : "val aliceIou = participant1.ledger_api.acs.find_generic(alice, _.templateId.isModuleEntity(\"Iou\", \"Iou\"))",
-    "output" : "aliceIou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#1220451d0751815e7bf2618d13534f3779048a49c273ee7b7c7cfa9ae401161c1b23:0\",\n    contractId = \"0008a2a92f69282ca09f2f08fead9a332672e7fe1140d97d5ce14678f0be8c46b3ca021220edff6f7f2a5ae36e0c94c82398397d7972aa3a312a3b9854c95e051a6d72bdbc\",\n.."
-  },
-  "310" : {
-    "command" : "val p2Id = ParticipantId.tryFromProtoPrimitive(extractedId)",
-    "output" : "p2Id : ParticipantId = PAR::participant2::1220a497955f..."
-  },
-  "363" : {
-    "command" : "participant1.dars.list()",
-    "output" : "res30: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220caf9b815c77d40b24801fc88acaa85bffac5cc315644c8242923d039d8df6d73\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  ),\n  DarDescription(\n    hash = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\",\n    name = \"CantonExamples\"\n  )\n)"
-  },
-  "517" : {
-    "command" : "",
-    "output" : ""
-  },
-  "369" : {
+  "371" : {
     "command" : "participant2.dars.list()",
-    "output" : "res31: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220caf9b815c77d40b24801fc88acaa85bffac5cc315644c8242923d039d8df6d73\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  ),\n  DarDescription(\n    hash = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\",\n    name = \"CantonExamples\"\n  )\n)"
+    "output" : "res31: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37\",\n    name = \"CantonExamples\"\n  ),\n  DarDescription(\n    hash = \"122066e542ea6f3319ee8eb495caf75e2f068420994044ee9d5e26b5733738b0b02f\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  )\n)"
   },
-  "511" : {
+  "73" : {
+    "command" : "Seq(1,2,3).map(_ * 2)",
+    "output" : "res1: Seq[Int] = List(2, 4, 6)"
+  },
+  "513" : {
     "command" : "",
     "output" : ""
+  },
+  "271" : {
+    "command" : "",
+    "output" : ""
+  },
+  "282" : {
+    "command" : "",
+    "output" : ""
+  },
+  "175" : {
+    "command" : "participant1.health.status",
+    "output" : "res6: com.digitalasset.canton.health.admin.data.NodeStatus[com.digitalasset.canton.health.admin.data.ParticipantStatus] = Participant id: PAR::participant1::12206c5020b625f957d39633d4504eaf6f9594f0c1a666c3f777d0330f4ec91297ba\nUptime: 7.373859s\nPorts: \n\tledger: 32134\n\tadmin: 32135\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized"
+  },
+  "365" : {
+    "command" : "participant1.dars.list()",
+    "output" : "res30: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37\",\n    name = \"CantonExamples\"\n  ),\n  DarDescription(\n    hash = \"122066e542ea6f3319ee8eb495caf75e2f068420994044ee9d5e26b5733738b0b02f\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  )\n)"
+  },
+  "518" : {
+    "command" : "participant1.ledger_api.acs.of_party(alice).map(x => (x.templateId, x.arguments))",
+    "output" : "res45: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::12201f864d90d364f7026b590512a5b651f78c9e7274329c2a33c390233a6863a10f\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::12206c5020b625f957d39633d4504eaf6f9594f0c1a666c3f777d0330f4ec91297ba\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  ),\n  (\n    TemplateId(\n      packageId = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n      moduleName = \"Paint\",\n      entityName = \"OfferToPaintHouseByPainter\"\n    ),\n    HashMap(\n      \"painter\" -> \"Bob::12201f864d90d364f7026b590512a5b651f78c9e7274329c2a33c390233a6863a10f\",\n      \"houseOwner\" -> \"Alice::12206c5020b625f957d39633d4504eaf6f9594f0c1a666c3f777d0330f4ec91297ba\",\n      \"bank\" -> \"Bank::12201f864d90d364f7026b590512a5b651f78c9e7274329c2a33c390233a6863a10f\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
+  },
+  "352" : {
+    "command" : "nodes.local",
+    "output" : "res28: Seq[com.digitalasset.canton.console.LocalInstanceReferenceCommon] = ArraySeq(Participant 'participant1', Participant 'participant2', Domain 'mydomain')"
+  },
+  "170" : {
+    "command" : "health.status",
+    "output" : "res5: EnterpriseCantonStatus = Status for Domain 'mydomain':\nDomain id: mydomain::12205e5dccac4791f8fc0aa9e7f3d2674c4997010808aaedd7686bc0bddd81c1949f\nUptime: 13.419242s\nPorts: \n\tadmin: 32139\n\tpublic: 32138\nConnected Participants: None\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()\n\nStatus for Participant 'participant1':\nParticipant id: PAR::participant1::12206c5020b625f957d39633d4504eaf6f9594f0c1a666c3f777d0330f4ec91297ba\nUptime: 7.255084s\nPorts: \n\tledger: 32134\n\tadmin: 32135\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized\n\nStatus for Participant 'participant2':\nParticipant id: PAR::participant2::12201f864d90d364f7026b590512a5b651f78c9e7274329c2a33c390233a6863a10f\nUptime: 7.26054s\nPorts: \n\tledger: 32136\n\tadmin: 32137\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized"
   },
   "269" : {
     "command" : "",
     "output" : ""
   },
-  "202" : {
-    "command" : "health.status",
-    "output" : "res10: EnterpriseCantonStatus = Status for Domain 'mydomain':\nDomain id: mydomain::1220440cf3c3df32ba71a54aeea88aadbd859fe728311aef4fdfd365abfc987dbeb4\nUptime: 16.09241s\nPorts: \n\tadmin: 30769\n\tpublic: 30768\nConnected Participants: \n\tPAR::participant2::1220a497955f...\n\tPAR::participant1::1220f4191f94...\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()\n\n.."
-  },
-  "174" : {
+  "372" : {
     "command" : "",
     "output" : ""
   },
-  "320" : {
-    "command" : "val aliceAsStr = alice.toProtoPrimitive",
-    "output" : "aliceAsStr : String = \"Alice::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\""
-  },
-  "436" : {
-    "command" : "val pkgIou = participant1.packages.find(\"Iou\").head",
-    "output" : "pkgIou : com.digitalasset.canton.participant.admin.v0.PackageDescription = PackageDescription(\n  packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n  sourceDescription = \"CantonExamples\"\n)"
-  },
-  "504" : {
-    "command" : "participant2.ledger_api.acs.of_party(bob).map(x => (x.templateId, x.arguments))",
-    "output" : "res43: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n      moduleName = \"Paint\",\n      entityName = \"OfferToPaintHouseByPainter\"\n    ),\n    HashMap(\n      \"painter\" -> \"Bob::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\",\n      \"houseOwner\" -> \"Alice::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\",\n      \"bank\" -> \"Bank::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
-  },
-  "344" : {
-    "command" : "participants.all.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "res27: Map[com.digitalasset.canton.console.ParticipantReference, String] = Map(\n  Participant 'participant1' -> \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\",\n  Participant 'participant2' -> \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\"\n)"
+  "357" : {
+    "command" : "participants.all",
+    "output" : "res29: Seq[com.digitalasset.canton.console.ParticipantReference] = List(Participant 'participant1', Participant 'participant2')"
   },
   "196" : {
-    "command" : "participant2.domains.connect_local(mydomain)",
+    "command" : "participant1.domains.connect_local(mydomain)",
     "output" : ""
   },
-  "475" : {
-    "command" : "participant1.ledger_api.acs.of_party(alice).map(x => (x.templateId, x.arguments))",
-    "output" : "res38: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
+  "289" : {
+    "command" : "",
+    "output" : ""
   },
-  "179" : {
-    "command" : "mydomain.health.status",
-    "output" : "res7: com.digitalasset.canton.health.admin.data.NodeStatus[mydomain.Status] = Domain id: mydomain::1220440cf3c3df32ba71a54aeea88aadbd859fe728311aef4fdfd365abfc987dbeb4\nUptime: 12.336155s\nPorts: \n\tadmin: 30769\n\tpublic: 30768\nConnected Participants: None\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()"
+  "448" : {
+    "command" : "participant2.ledger_api.commands.submit(Seq(bank), Seq(createIouCmd))",
+    "output" : "res35: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220b9e8c63956f7c846b2b0097f02912d3e5d2be4275d3600579415c550fb8f7146\",\n  commandId = \"6107ebd8-7409-4dfb-9f37-3e84ce536048\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1702930024L,\n      nanos = 273703000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n  ),\n  offset = \"000000000000000015\",\n.."
   },
-  "321" : {
-    "command" : "val aliceParsed = PartyId.tryFromProtoPrimitive(aliceAsStr)",
-    "output" : "aliceParsed : PartyId = Alice::1220f4191f94..."
+  "492" : {
+    "command" : "val createOfferCmd = ledger_api_utils.create(pkgPaint.packageId, \"Paint\", \"OfferToPaintHouseByPainter\", Map(\"bank\" -> bank, \"houseOwner\" -> alice, \"painter\" -> bob, \"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\")))",
+    "output" : "createOfferCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Create(\n    value = CreateCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n.."
   },
-  "106" : {
-    "command" : "participant1.help(\"start\")",
-    "output" : "start\nStart the instance"
+  "443" : {
+    "command" : "val createIouCmd = ledger_api_utils.create(pkgIou.packageId,\"Iou\",\"Iou\",Map(\"payer\" -> bank,\"owner\" -> alice,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
+    "output" : "createIouCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Create(\n    value = CreateCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n.."
+  },
+  "211" : {
+    "command" : "participant1.health.ping(participant2)",
+    "output" : "res11: Duration = 555 milliseconds"
   },
   "238" : {
-    "command" : "participant2.id",
-    "output" : "res14: ParticipantId = PAR::participant2::1220a497955f..."
+    "command" : "mydomain.id",
+    "output" : "res12: DomainId = mydomain::12205e5dccac..."
   },
-  "467" : {
-    "command" : "participant1.ledger_api.acs.of_party(alice)",
-    "output" : "res37: Seq[com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent] = List(\n  WrappedCreatedEvent(\n    event = CreatedEvent(\n      eventId = \"#1220451d0751815e7bf2618d13534f3779048a49c273ee7b7c7cfa9ae401161c1b23:0\",\n      contractId = \"0008a2a92f69282ca09f2f08fead9a332672e7fe1140d97d5ce14678f0be8c46b3ca021220edff6f7f2a5ae36e0c94c82398397d7972aa3a312a3b9854c95e051a6d72bdbc\",\n      templateId = Some(\n        value = Identifier(\n          packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n.."
+  "280" : {
+    "command" : "",
+    "output" : ""
+  },
+  "507" : {
+    "command" : "",
+    "output" : ""
+  },
+  "312" : {
+    "command" : "val p2Id = ParticipantId.tryFromProtoPrimitive(extractedId)",
+    "output" : "p2Id : ParticipantId = PAR::participant2::12201f864d90..."
+  },
+  "74" : {
+    "command" : "",
+    "output" : ""
+  },
+  "307" : {
+    "command" : "val extractedId = participant2.id.toProtoPrimitive",
+    "output" : "extractedId : String = \"PAR::participant2::12201f864d90d364f7026b590512a5b651f78c9e7274329c2a33c390233a6863a10f\""
+  },
+  "512" : {
+    "command" : "participant2.ledger_api.acs.of_party(bank).map(x => (x.templateId, x.arguments))",
+    "output" : "res44: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::12201f864d90d364f7026b590512a5b651f78c9e7274329c2a33c390233a6863a10f\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::12206c5020b625f957d39633d4504eaf6f9594f0c1a666c3f777d0330f4ec91297ba\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
+  },
+  "270" : {
+    "command" : "val bob = participant2.parties.enable(\"Bob\")",
+    "output" : "bob : PartyId = Bob::12201f864d90..."
+  },
+  "366" : {
+    "command" : "",
+    "output" : ""
+  },
+  "534" : {
+    "command" : "participant1.ledger_api.commands.submit_flat(Seq(alice), Seq(acceptOffer))",
+    "output" : "res48: com.daml.ledger.api.v1.transaction.Transaction = Transaction(\n  transactionId = \"1220e543077c60386290bd9ab8dec61b728aa74ad61a928456e43019e5c4a28f652c\",\n  commandId = \"33e463cd-abea-433e-8529-8491accd9d0e\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n.."
+  },
+  "102" : {
+    "command" : "help",
+    "output" : "Top-level Commands\n------------------\nexit - Leave the console\nhelp - Help with console commands; type help(\"<command>\") for detailed help for <command>\n\nGeneric Node References\n-----------------------\ndomainManagers - All domain manager nodes (.all, .local, .remote)\n.."
   },
   "197" : {
     "command" : "",
     "output" : ""
   },
-  "329" : {
-    "command" : "val p2FromUid = ParticipantId(UniqueIdentifier.tryFromProtoPrimitive(p2UidString))",
-    "output" : "p2FromUid : ParticipantId = PAR::participant2::1220a497955f..."
+  "493" : {
+    "command" : "participant2.ledger_api.commands.submit_flat(Seq(bob), Seq(createOfferCmd))",
+    "output" : "res41: com.daml.ledger.api.v1.transaction.Transaction = Transaction(\n  transactionId = \"1220929c5491b163624172c85a5c1b5c2954393f876ec015c910e7ca73ed6085b1a7\",\n  commandId = \"0ebe5896-02ec-448c-aacf-c9383f58fb14\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n.."
   },
-  "285" : {
+  "324" : {
     "command" : "",
     "output" : ""
   },
-  "457" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(bank), Seq(createIouCmd))",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: NOT_FOUND/NO_DOMAIN_ON_WHICH_ALL_SUBMITTERS_CAN_SUBMIT(11,05ea6bcf): This participant can not submit as the given submitter on any connected domain\n  Request: SubmitAndWaitTransactionTree(\n  actAs = Bank::1220a497955f...,\n.."
-  },
-  "173" : {
-    "command" : "participant1.health.status",
-    "output" : "res6: com.digitalasset.canton.health.admin.data.NodeStatus[com.digitalasset.canton.health.admin.data.ParticipantStatus] = Participant id: PAR::participant1::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\nUptime: 7.248153s\nPorts: \n\tledger: 30764\n\tadmin: 30765\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized"
-  },
-  "237" : {
-    "command" : "participant1.id",
-    "output" : "res13: ParticipantId = PAR::participant1::1220f4191f94..."
-  },
-  "105" : {
-    "command" : "help(\"participant1\")",
-    "output" : "participant1\nManage participant 'participant1'; type 'participant1 help' or 'participant1 help(\"<methodName>\")' for more help"
-  },
-  "266" : {
-    "command" : "val alice = participant1.parties.enable(\"Alice\")",
-    "output" : "alice : PartyId = Alice::1220f4191f94..."
-  },
-  "530" : {
-    "command" : "import com.digitalasset.canton.protocol.LfContractId",
+  "519" : {
+    "command" : "",
     "output" : ""
   },
-  "279" : {
+  "317" : {
+    "command" : "participant1.health.ping(p2Id)",
+    "output" : "res22: Duration = 346 milliseconds"
+  },
+  "176" : {
+    "command" : "",
+    "output" : ""
+  },
+  "281" : {
     "command" : "mydomain.parties.list(\"Alice\")",
-    "output" : "res17: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Alice::1220f4191f94...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant1::1220f4191f94...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220440cf3c3..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
+    "output" : "res17: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Alice::12206c5020b6...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant1::12206c5020b6...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::12205e5dccac..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
   },
-  "180" : {
-    "command" : "",
-    "output" : ""
+  "204" : {
+    "command" : "health.status",
+    "output" : "res10: EnterpriseCantonStatus = Status for Domain 'mydomain':\nDomain id: mydomain::12205e5dccac4791f8fc0aa9e7f3d2674c4997010808aaedd7686bc0bddd81c1949f\nUptime: 18.989735s\nPorts: \n\tadmin: 32139\n\tpublic: 32138\nConnected Participants: \n\tPAR::participant1::12206c5020b6...\n\tPAR::participant2::12201f864d90...\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()\n\n.."
   },
-  "71" : {
-    "command" : "Seq(1,2,3).map(_ * 2)",
-    "output" : "res1: Seq[Int] = List(2, 4, 6)"
+  "498" : {
+    "command" : "val paintOffer = participant1.ledger_api.acs.find_generic(alice, _.templateId.isModuleEntity(\"Paint\", \"OfferToPaintHouseByPainter\"))",
+    "output" : "paintOffer : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#1220929c5491b163624172c85a5c1b5c2954393f876ec015c910e7ca73ed6085b1a7:0\",\n    contractId = \"00b6a205992013d7b870612797baf34fc2bebc2a25d7dd0bfbcbfc441300a109a9ca021220e2f7dbadb8c1c99c2f8baac2afd5bdff5b404ab32a8c9b164c41a38ed8beccea\",\n    templateId = Some(\n      value = Identifier(\n.."
   },
-  "236" : {
-    "command" : "mydomain.id",
-    "output" : "res12: DomainId = mydomain::1220440cf3c3..."
+  "181" : {
+    "command" : "mydomain.health.status",
+    "output" : "res7: com.digitalasset.canton.health.admin.data.NodeStatus[mydomain.Status] = Domain id: mydomain::12205e5dccac4791f8fc0aa9e7f3d2674c4997010808aaedd7686bc0bddd81c1949f\nUptime: 13.765133s\nPorts: \n\tadmin: 32139\n\tpublic: 32138\nConnected Participants: None\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()"
   },
-  "350" : {
-    "command" : "nodes.local",
-    "output" : "res28: Seq[com.digitalasset.canton.console.LocalInstanceReferenceCommon] = ArraySeq(Participant 'participant1', Participant 'participant2', Domain 'mydomain')"
-  },
-  "278" : {
-    "command" : "",
-    "output" : ""
-  },
-  "267" : {
-    "command" : "",
-    "output" : ""
-  },
-  "505" : {
-    "command" : "",
-    "output" : ""
-  },
-  "490" : {
-    "command" : "val createOfferCmd = ledger_api_utils.create(pkgPaint.packageId, \"Paint\", \"OfferToPaintHouseByPainter\", Map(\"bank\" -> bank, \"houseOwner\" -> alice, \"painter\" -> bob, \"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\")))",
-    "output" : "createOfferCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Create(\n    value = CreateCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n.."
-  },
-  "531" : {
-    "command" : "val acceptOffer = ledger_api_utils.exercise(\"AcceptByOwner\", Map(\"iouId\" -> LfContractId.assertFromString(aliceIou.event.contractId)),paintOffer.event)",
-    "output" : "acceptOffer : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Exercise(\n    value = ExerciseCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n.."
-  },
-  "209" : {
-    "command" : "participant1.health.ping(participant2)",
-    "output" : "res11: Duration = 573 milliseconds"
-  },
-  "516" : {
+  "477" : {
     "command" : "participant1.ledger_api.acs.of_party(alice).map(x => (x.templateId, x.arguments))",
-    "output" : "res45: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  ),\n  (\n    TemplateId(\n      packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n      moduleName = \"Paint\",\n      entityName = \"OfferToPaintHouseByPainter\"\n    ),\n    HashMap(\n      \"painter\" -> \"Bob::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\",\n      \"houseOwner\" -> \"Alice::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\",\n      \"bank\" -> \"Bank::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
+    "output" : "res38: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::12201f864d90d364f7026b590512a5b651f78c9e7274329c2a33c390233a6863a10f\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::12206c5020b625f957d39633d4504eaf6f9594f0c1a666c3f777d0330f4ec91297ba\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
   },
-  "355" : {
-    "command" : "participants.all",
-    "output" : "res29: Seq[com.digitalasset.canton.console.ParticipantReference] = List(Participant 'participant1', Participant 'participant2')"
+  "323" : {
+    "command" : "val aliceParsed = PartyId.tryFromProtoPrimitive(aliceAsStr)",
+    "output" : "aliceParsed : PartyId = Alice::12206c5020b6..."
   },
-  "194" : {
-    "command" : "participant1.domains.connect_local(mydomain)",
+  "483" : {
+    "command" : "val pkgPaint = participant1.packages.find(\"Paint\").head",
+    "output" : "pkgPaint : com.digitalasset.canton.participant.admin.v0.PackageDescription = PackageDescription(\n  packageId = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n  sourceDescription = \"CantonExamples\"\n)"
+  },
+  "240" : {
+    "command" : "participant2.id",
+    "output" : "res14: ParticipantId = PAR::participant2::12201f864d90..."
+  },
+  "198" : {
+    "command" : "participant2.domains.connect_local(mydomain)",
     "output" : ""
   },
-  "441" : {
-    "command" : "val createIouCmd = ledger_api_utils.create(pkgIou.packageId,\"Iou\",\"Iou\",Map(\"payer\" -> bank,\"owner\" -> alice,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
-    "output" : "createIouCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Create(\n    value = CreateCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n.."
+  "108" : {
+    "command" : "participant1.help(\"start\")",
+    "output" : "start\nStart the instance"
   },
-  "370" : {
+  "330" : {
+    "command" : "val p2UidString = participant2.id.uid.toProtoPrimitive",
+    "output" : "p2UidString : String = \"participant2::12201f864d90d364f7026b590512a5b651f78c9e7274329c2a33c390233a6863a10f\""
+  },
+  "394" : {
+    "command" : "val bank = participant2.parties.enable(\"Bank\", waitForDomain = DomainChoice.All)",
+    "output" : "bank : PartyId = Bank::12201f864d90..."
+  },
+  "438" : {
+    "command" : "val pkgIou = participant1.packages.find(\"Iou\").head",
+    "output" : "pkgIou : com.digitalasset.canton.participant.admin.v0.PackageDescription = PackageDescription(\n  packageId = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n  sourceDescription = \"CantonExamples\"\n)"
+  },
+  "199" : {
     "command" : "",
     "output" : ""
   },
-  "72" : {
+  "182" : {
     "command" : "",
     "output" : ""
   },
-  "446" : {
-    "command" : "participant2.ledger_api.commands.submit(Seq(bank), Seq(createIouCmd))",
-    "output" : "res35: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220451d0751815e7bf2618d13534f3779048a49c273ee7b7c7cfa9ae401161c1b23\",\n  commandId = \"eda539cd-fb2f-44a9-bb62-03b962b04a39\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1700582453L,\n      nanos = 135011000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n  ),\n  offset = \"000000000000000015\",\n.."
+  "331" : {
+    "command" : "val p2FromUid = ParticipantId(UniqueIdentifier.tryFromProtoPrimitive(p2UidString))",
+    "output" : "p2FromUid : ParticipantId = PAR::participant2::12201f864d90..."
   },
-  "510" : {
-    "command" : "participant2.ledger_api.acs.of_party(bank).map(x => (x.templateId, x.arguments))",
-    "output" : "res44: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n      moduleName = \"Iou\",\n      entityName = \"Iou\"\n    ),\n    HashMap(\n      \"payer\" -> \"Bank::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\",\n      \"viewers\" -> List(elements = Vector()),\n      \"owner\" -> \"Alice::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
+  "346" : {
+    "command" : "participants.all.dars.upload(\"dars/CantonExamples.dar\")",
+    "output" : "res27: Map[com.digitalasset.canton.console.ParticipantReference, String] = Map(\n  Participant 'participant1' -> \"12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37\",\n  Participant 'participant2' -> \"12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37\"\n)"
   },
   "287" : {
     "command" : "",
     "output" : ""
   },
-  "300" : {
-    "command" : "participant1.health.ping(participant2)",
-    "output" : ".."
-  },
-  "315" : {
-    "command" : "participant1.health.ping(p2Id)",
-    "output" : "res22: Duration = 309 milliseconds"
-  },
-  "168" : {
-    "command" : "health.status",
-    "output" : "res5: EnterpriseCantonStatus = Status for Domain 'mydomain':\nDomain id: mydomain::1220440cf3c3df32ba71a54aeea88aadbd859fe728311aef4fdfd365abfc987dbeb4\nUptime: 12.047341s\nPorts: \n\tadmin: 30769\n\tpublic: 30768\nConnected Participants: None\nSequencer: SequencerHealthStatus(active = true)\nComponents: \n\tsequencer : Ok()\n\tmemory_storage : Ok()\n\tdomain-topology-sender : Ok()\n\nStatus for Participant 'participant1':\nParticipant id: PAR::participant1::1220f4191f94b3034e23470e8bbf65f21c49dd3ac419d9fe3501435026faa0c5fbb9\nUptime: 7.149419s\nPorts: \n\tledger: 30764\n\tadmin: 30765\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized\n\nStatus for Participant 'participant2':\nParticipant id: PAR::participant2::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\nUptime: 7.165978s\nPorts: \n\tledger: 30766\n\tadmin: 30767\nConnected domains: None\nUnhealthy domains: None\nActive: true\nComponents: \n\tmemory_storage : Ok()\n\tsync-domain : Not Initialized\n\tsync-domain-ephemeral : Not Initialized\n\tsequencer-client : Not Initialized"
-  },
-  "305" : {
-    "command" : "val extractedId = participant2.id.toProtoPrimitive",
-    "output" : "extractedId : String = \"PAR::participant2::1220a497955f0027b37c7a5f41ebf0432cc99a25e0ad60192c4d23d44e0468908482\""
-  },
-  "268" : {
-    "command" : "val bob = participant2.parties.enable(\"Bob\")",
-    "output" : "bob : PartyId = Bob::1220a497955f..."
-  },
-  "195" : {
+  "210" : {
     "command" : "",
     "output" : ""
+  },
+  "107" : {
+    "command" : "help(\"participant1\")",
+    "output" : "participant1\nManage participant 'participant1'; type 'participant1 help' or 'participant1 help(\"<methodName>\")' for more help"
+  },
+  "239" : {
+    "command" : "participant1.id",
+    "output" : "res13: ParticipantId = PAR::participant1::12206c5020b6..."
   },
   "532" : {
-    "command" : "participant1.ledger_api.commands.submit_flat(Seq(alice), Seq(acceptOffer))",
-    "output" : "res48: com.daml.ledger.api.v1.transaction.Transaction = Transaction(\n  transactionId = \"12201a27a5c76be0588cde35110ac25e20ba0cf6c8c783dc0277c38f42714661332e\",\n  commandId = \"3063bcaf-4182-4283-9358-de053938185e\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n.."
+    "command" : "import com.digitalasset.canton.protocol.LfContractId",
+    "output" : ""
+  },
+  "506" : {
+    "command" : "participant2.ledger_api.acs.of_party(bob).map(x => (x.templateId, x.arguments))",
+    "output" : "res43: Seq[(TemplateId, Map[String, Any])] = List(\n  (\n    TemplateId(\n      packageId = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n      moduleName = \"Paint\",\n      entityName = \"OfferToPaintHouseByPainter\"\n    ),\n    HashMap(\n      \"painter\" -> \"Bob::12201f864d90d364f7026b590512a5b651f78c9e7274329c2a33c390233a6863a10f\",\n      \"houseOwner\" -> \"Alice::12206c5020b625f957d39633d4504eaf6f9594f0c1a666c3f777d0330f4ec91297ba\",\n      \"bank\" -> \"Bank::12201f864d90d364f7026b590512a5b651f78c9e7274329c2a33c390233a6863a10f\",\n      \"amount.currency\" -> \"EUR\",\n      \"amount.value\" -> \"100.0000000000\"\n    )\n  )\n)"
+  },
+  "268" : {
+    "command" : "val alice = participant1.parties.enable(\"Alice\")",
+    "output" : "alice : PartyId = Alice::12206c5020b6..."
+  },
+  "464" : {
+    "command" : "val aliceIou = participant1.ledger_api.acs.find_generic(alice, _.templateId.isModuleEntity(\"Iou\", \"Iou\"))",
+    "output" : "aliceIou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#1220b9e8c63956f7c846b2b0097f02912d3e5d2be4275d3600579415c550fb8f7146:0\",\n    contractId = \"0025b0a73d2a95602d84424dcab7f44907a28bfaf573eb3ab7cc5dce621bb35013ca021220f2eee0fb5e24cabdb615561548e96e3404cf377a411256121d88b5646af389b2\",\n.."
+  },
+  "459" : {
+    "command" : "participant1.ledger_api.commands.submit(Seq(bank), Seq(createIouCmd))",
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: NOT_FOUND/NO_DOMAIN_ON_WHICH_ALL_SUBMITTERS_CAN_SUBMIT(11,f2a404ff): This participant can not submit as the given submitter on any connected domain\n  Request: SubmitAndWaitTransactionTree(\n  actAs = Bank::12201f864d90...,\n.."
   },
   "322" : {
-    "command" : "",
-    "output" : ""
+    "command" : "val aliceAsStr = alice.toProtoPrimitive",
+    "output" : "aliceAsStr : String = \"Alice::12206c5020b625f957d39633d4504eaf6f9594f0c1a666c3f777d0330f4ec91297ba\""
   },
-  "491" : {
-    "command" : "participant2.ledger_api.commands.submit_flat(Seq(bob), Seq(createOfferCmd))",
-    "output" : "res41: com.daml.ledger.api.v1.transaction.Transaction = Transaction(\n  transactionId = \"122082871e91589dfb77000cd8e992aa691c6a2f829596ef097c4233ddcd62c65a21\",\n  commandId = \"0e8dccc2-ae89-4889-b731-09583074c77a\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n.."
+  "469" : {
+    "command" : "participant1.ledger_api.acs.of_party(alice)",
+    "output" : "res37: Seq[com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent] = List(\n  WrappedCreatedEvent(\n    event = CreatedEvent(\n      eventId = \"#1220b9e8c63956f7c846b2b0097f02912d3e5d2be4275d3600579415c550fb8f7146:0\",\n      contractId = \"0025b0a73d2a95602d84424dcab7f44907a28bfaf573eb3ab7cc5dce621bb35013ca021220f2eee0fb5e24cabdb615561548e96e3404cf377a411256121d88b5646af389b2\",\n      templateId = Some(\n        value = Identifier(\n          packageId = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n.."
   },
-  "496" : {
-    "command" : "val paintOffer = participant1.ledger_api.acs.find_generic(alice, _.templateId.isModuleEntity(\"Paint\", \"OfferToPaintHouseByPainter\"))",
-    "output" : "paintOffer : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#122082871e91589dfb77000cd8e992aa691c6a2f829596ef097c4233ddcd62c65a21:0\",\n    contractId = \"009b7335c3f6a9fc65916f95ec1a77cf030a873f128ca4dfc3b0763f99e782a7e8ca021220088a8a3f3c898ceec52449f67e282eaa29722769e8f01494e48848c0fdf84678\",\n    templateId = Some(\n      value = Identifier(\n.."
-  },
-  "364" : {
-    "command" : "",
-    "output" : ""
-  },
-  "100" : {
-    "command" : "help",
-    "output" : "Top-level Commands\n------------------\nexit - Leave the console\nhelp - Help with console commands; type help(\"<command>\") for detailed help for <command>\n\nGeneric Node References\n-----------------------\ndomainManagers - All domain manager nodes (.all, .local, .remote)\n.."
+  "454" : {
+    "command" : "participant1.ledger_api.commands.submit(Seq(alice), Seq(createIouCmd))",
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcClientError: INVALID_ARGUMENT/DAML_AUTHORIZATION_ERROR(8,c5ef7f99): Interpretation error: Error: node NodeId(0) (e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86:Iou:Iou) requires authorizers Bank::12201f864d90d364f7026b590512a5b651f78c9e7274329c2a33c390233a6863a10f, but only Alice::12206c5020b625f957d39633d4504eaf6f9594f0c1a666c3f777d0330f4ec91297ba were given\n  Request: SubmitAndWaitTransactionTree(\n  actAs = Alice::12206c5020b6...,\n.."
   }
 }

--- a/docs/2.9.0/docs/canton/includes/snippet_data/usermanual/connectivity.json
+++ b/docs/2.9.0/docs/canton/includes/snippet_data/usermanual/connectivity.json
@@ -5,7 +5,7 @@
   },
   "202" : {
     "command" : "val config = DomainConnectionConfig(domain = \"mydomain\", sequencerConnection, manualConnect, domainId, priority)",
-    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = Seq(http://127.0.0.1:30811, http://127.0.0.1:30809),\n    transportSecurity = false,\n    customTrustCertificates = None()\n  ),\n  manualConnect = false,\n  domainId = Some(domainManager1::1220366f0b65...),\n  priority = 10,\n  initialRetryDelay = None(),\n  maxRetryDelay = None()\n)"
+    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = Seq(http://127.0.0.1:32191, http://127.0.0.1:32189),\n    transportSecurity = false\n  ),\n  manualConnect = false,\n  domainId = domainManager1::12208743c5d9...,\n  priority = 10\n)"
   },
   "189" : {
     "command" : "participant3.domains.reconnect(\"mydomain\")",
@@ -21,7 +21,7 @@
   },
   "86" : {
     "command" : "val port = sequencer3.config.publicApi.port",
-    "output" : "port : Port = Port(n = 30807)"
+    "output" : "port : Port = Port(n = 32187)"
   },
   "67" : {
     "command" : "",
@@ -37,7 +37,7 @@
   },
   "100" : {
     "command" : "participant2.domains.connect(\"mydomain\", connection = url, certificatesPath = certificatesPath)",
-    "output" : "res8: DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = https://127.0.0.1:30807,\n    transportSecurity = true,\n    customTrustCertificates = Some(2d2d2d2d2d42)\n  ),\n  manualConnect = false,\n  domainId = None(),\n  priority = 0,\n  initialRetryDelay = None(),\n  maxRetryDelay = None()\n)"
+    "output" : "res8: DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = https://127.0.0.1:32187,\n    transportSecurity = true,\n    customTrustCertificates\n  ),\n  manualConnect = false\n)"
   },
   "174" : {
     "command" : "val priority = 10 // default is 0 if not set",
@@ -49,7 +49,7 @@
   },
   "61" : {
     "command" : "sequencer1.config.publicApi.port",
-    "output" : "res2: Port = Port(n = 30811)"
+    "output" : "res2: Port = Port(n = 32191)"
   },
   "312" : {
     "command" : "mediator1.mediator.help(\"initialize\")",
@@ -61,7 +61,7 @@
   },
   "117" : {
     "command" : "participant3.domains.connect_multi(\"mydomain\", Seq(sequencer1, sequencer2))",
-    "output" : "res9: DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = Seq(http://0.0.0.0:30811, http://127.0.0.1:30809),\n    transportSecurity = false,\n    customTrustCertificates = None()\n  ),\n  manualConnect = false,\n  domainId = None(),\n  priority = 0,\n  initialRetryDelay = None(),\n  maxRetryDelay = None()\n)"
+    "output" : "res9: DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = Seq(http://0.0.0.0:32191, http://127.0.0.1:32189),\n    transportSecurity = false\n  ),\n  manualConnect = false\n)"
   },
   "302" : {
     "command" : "participant2.domains.reconnect_all()",
@@ -69,7 +69,7 @@
   },
   "160" : {
     "command" : "val sequencerConnection = sequencerConnectionWithoutHighAvailability.addEndpoints(urls(1))",
-    "output" : "sequencerConnection : SequencerConnection = GrpcSequencerConnection(\n  endpoints = Seq(http://127.0.0.1:30811, http://127.0.0.1:30809),\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
+    "output" : "sequencerConnection : SequencerConnection = GrpcSequencerConnection(\n  endpoints = Seq(http://127.0.0.1:32191, http://127.0.0.1:32189),\n  transportSecurity = false\n)"
   },
   "297" : {
     "command" : "participant2.domains.reconnect(\"mydomain\")",
@@ -81,7 +81,7 @@
   },
   "197" : {
     "command" : "val domainId = Some(domainManager1.id)",
-    "output" : "domainId : Some[DomainId] = Some(value = domainManager1::1220366f0b65...)"
+    "output" : "domainId : Some[DomainId] = Some(value = domainManager1::12208743c5d9...)"
   },
   "329" : {
     "command" : "",
@@ -89,15 +89,15 @@
   },
   "224" : {
     "command" : "participant2.domains.list_connected()",
-    "output" : "res23: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'mydomain',\n    domainId = domainManager1::1220366f0b65...,\n    healthy = true\n  )\n)"
+    "output" : "res23: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'mydomain',\n    domainId = domainManager1::12208743c5d9...,\n    healthy = true\n  )\n)"
   },
   "317" : {
     "command" : "mediator1.sequencer_connection.get()",
-    "output" : "res35: Option[SequencerConnections] = Some(\n  value = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://0.0.0.0:30811,\n    transportSecurity = false,\n    customTrustCertificates = None()\n  )\n)"
+    "output" : "res35: Option[SequencerConnections] = Some(\n  value = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://0.0.0.0:32191,\n    transportSecurity = false\n  )\n)"
   },
   "169" : {
     "command" : "val connectionWithTLS = com.digitalasset.canton.sequencing.GrpcSequencerConnection.tryCreate(\"https://daml.com\", customTrustCertificates = Some(certificate))",
-    "output" : "connectionWithTLS : GrpcSequencerConnection = GrpcSequencerConnection(\n  endpoints = https://daml.com:443,\n  transportSecurity = true,\n  customTrustCertificates = Some(2d2d2d2d2d42)\n)"
+    "output" : "connectionWithTLS : GrpcSequencerConnection = GrpcSequencerConnection(\n  endpoints = https://daml.com:443,\n  transportSecurity = true,\n  customTrustCertificates\n)"
   },
   "141" : {
     "command" : "val domainAlias = \"mydomain\"",
@@ -133,7 +133,7 @@
   },
   "230" : {
     "command" : "participant2.domains.config(\"mydomain\")",
-    "output" : "res24: Option[DomainConnectionConfig] = Some(\n  value = DomainConnectionConfig(\n    domain = Domain 'mydomain',\n    sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n      endpoints = https://127.0.0.1:30807,\n      transportSecurity = true,\n      customTrustCertificates = Some(2d2d2d2d2d42)\n    ),\n    manualConnect = false,\n    domainId = None(),\n    priority = 0,\n    initialRetryDelay = None(),\n    maxRetryDelay = None()\n  )\n)"
+    "output" : "res24: Option[DomainConnectionConfig] = Some(\n  value = DomainConnectionConfig(\n    domain = Domain 'mydomain',\n    sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n      endpoints = https://127.0.0.1:32187,\n      transportSecurity = true,\n      customTrustCertificates\n    ),\n    manualConnect = false\n  )\n)"
   },
   "208" : {
     "command" : "participant4.domains.register(config)",
@@ -153,7 +153,7 @@
   },
   "155" : {
     "command" : "val sequencerConnectionWithoutHighAvailability = com.digitalasset.canton.sequencing.GrpcSequencerConnection.tryCreate(urls(0))",
-    "output" : "sequencerConnectionWithoutHighAvailability : GrpcSequencerConnection = GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:30811,\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
+    "output" : "sequencerConnectionWithoutHighAvailability : GrpcSequencerConnection = GrpcSequencerConnection(endpoints = http://127.0.0.1:32191, transportSecurity = false)"
   },
   "278" : {
     "command" : "participant2.domains.modify(\"mydomain\", _.copy(sequencerConnections=SequencerConnections.single(connection)))",
@@ -161,7 +161,7 @@
   },
   "267" : {
     "command" : "val certificate = com.digitalasset.canton.util.BinaryFileUtil.tryReadByteStringFromFile(\"tls/root-ca.crt\")",
-    "output" : "certificate : com.google.protobuf.ByteString = <ByteString@57da4a78 size=1960 contents=\"-----BEGIN CERTIFICATE-----\\nMIIFeTCCA2GgAwIBAgI...\">"
+    "output" : "certificate : com.google.protobuf.ByteString = <ByteString@72f2c0d1 size=1960 contents=\"-----BEGIN CERTIFICATE-----\\nMIIFeTCCA2GgAwIBAgI...\">"
   },
   "80" : {
     "command" : "sequencer3.config.publicApi.tls",
@@ -169,7 +169,7 @@
   },
   "150" : {
     "command" : "val urls = Seq(sequencer1, sequencer2).map(_.config.publicApi.port).map(port => s\"http://127.0.0.1:${port}\")",
-    "output" : "urls : Seq[String] = List(\"http://127.0.0.1:30811\", \"http://127.0.0.1:30809\")"
+    "output" : "urls : Seq[String] = List(\"http://127.0.0.1:32191\", \"http://127.0.0.1:32189\")"
   },
   "95" : {
     "command" : "val certificatesPath = \"tls/root-ca.crt\"",
@@ -177,15 +177,15 @@
   },
   "87" : {
     "command" : "val url = s\"https://127.0.0.1:${port}\"",
-    "output" : "url : String = \"https://127.0.0.1:30807\""
+    "output" : "url : String = \"https://127.0.0.1:32187\""
   },
   "218" : {
     "command" : "participant2.domains.list_registered()",
-    "output" : "res22: Seq[(DomainConnectionConfig, Boolean)] = Vector(\n  (\n    DomainConnectionConfig(\n      domain = Domain 'mydomain',\n      sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n        endpoints = https://127.0.0.1:30807,\n        transportSecurity = true,\n        customTrustCertificates = Some(2d2d2d2d2d42)\n      ),\n      manualConnect = false,\n      domainId = None(),\n      priority = 0,\n      initialRetryDelay = None(),\n      maxRetryDelay = None()\n    ),\n    true\n  )\n)"
+    "output" : "res22: Seq[(DomainConnectionConfig, Boolean)] = Vector(\n  (\n    DomainConnectionConfig(\n      domain = Domain 'mydomain',\n      sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n        endpoints = https://127.0.0.1:32187,\n        transportSecurity = true,\n        customTrustCertificates\n      ),\n      manualConnect = false\n    ),\n    true\n  )\n)"
   },
   "168" : {
     "command" : "val certificate = com.digitalasset.canton.util.BinaryFileUtil.tryReadByteStringFromFile(\"tls/root-ca.crt\")",
-    "output" : "certificate : com.google.protobuf.ByteString = <ByteString@6c6397ad size=1960 contents=\"-----BEGIN CERTIFICATE-----\\nMIIFeTCCA2GgAwIBAgI...\">"
+    "output" : "certificate : com.google.protobuf.ByteString = <ByteString@75652c1b size=1960 contents=\"-----BEGIN CERTIFICATE-----\\nMIIFeTCCA2GgAwIBAgI...\">"
   },
   "183" : {
     "command" : "val manualConnect = false",
@@ -193,6 +193,6 @@
   },
   "273" : {
     "command" : "val connection = com.digitalasset.canton.sequencing.GrpcSequencerConnection.tryCreate(url, customTrustCertificates = Some(certificate))",
-    "output" : "connection : GrpcSequencerConnection = GrpcSequencerConnection(\n  endpoints = https://127.0.0.1:30807,\n  transportSecurity = true,\n  customTrustCertificates = Some(2d2d2d2d2d42)\n)"
+    "output" : "connection : GrpcSequencerConnection = GrpcSequencerConnection(\n  endpoints = https://127.0.0.1:32187,\n  transportSecurity = true,\n  customTrustCertificates\n)"
   }
 }

--- a/docs/2.9.0/docs/canton/includes/snippet_data/usermanual/identity_management.json
+++ b/docs/2.9.0/docs/canton/includes/snippet_data/usermanual/identity_management.json
@@ -1,10 +1,10 @@
 {
-  "629" : {
-    "command" : "participant2.topology.party_to_participant_mappings.authorize(TopologyChangeOp.Add, alice, participant2.id, RequestSide.To, ParticipantPermission.Submission)",
-    "output" : "res2: com.google.protobuf.ByteString = <ByteString@6204cdaa size=556 contents=\"\\n\\251\\004\\n\\327\\001\\n\\322\\001\\n\\317\\001\\022 pOTqf8KfSAziaKfKCrYwpW7o2sEyCfTt2...\">"
-  },
   "550" : {
     "command" : "",
+    "output" : ""
+  },
+  "651" : {
+    "command" : "participant2.domains.disconnect_all()",
     "output" : ""
   },
   "416" : {
@@ -15,41 +15,33 @@
     "command" : "",
     "output" : ""
   },
-  "428" : {
-    "command" : "participant1.ledger_api.users.rights.grant(id = user.id, actAs = Set(alice, bob), readAs = Set(eve), participantAdmin = true)",
-    "output" : "res11: UserRights = UserRights(\n  actAs = Set(bob::1220ef4417b7...),\n  readAs = Set(eve::1220ef4417b7...),\n  participantAdmin = true,\n  identityProviderAdmin = false\n)"
-  },
-  "439" : {
-    "command" : "participant1.ledger_api.users.rights.list(user.id)",
-    "output" : "res13: UserRights = UserRights(\n  actAs = Set(alice::1220ef4417b7...),\n  readAs = Set(bob::1220ef4417b7..., eve::1220ef4417b7...),\n  participantAdmin = false,\n  identityProviderAdmin = false\n)"
-  },
-  "590" : {
-    "command" : "",
+  "578" : {
+    "command" : "repair.party_migration.step2_import_acs(participant2, \"alice.acs.gz\")",
     "output" : ""
   },
   "573" : {
     "command" : "participant2.domains.disconnect(\"mydomain\")",
     "output" : ""
   },
-  "621" : {
-    "command" : "val alice = participant1.parties.enable(\"Alice\")",
-    "output" : "alice : PartyId = Alice::12201637ff6c..."
-  },
   "705" : {
-    "command" : "",
+    "command" : "participant2.domains.reconnect_all()",
+    "output" : ""
+  },
+  "401" : {
+    "command" : "participant1.ledger_api.users.update_idp(\"myuser\", sourceIdentityProviderId=\"\", targetIdentityProviderId=\"idp-id1\")",
     "output" : ""
   },
   "549" : {
     "command" : "val alice = participant1.parties.enable(\"Alice\")",
-    "output" : "alice : PartyId = Alice::12206a1457fd..."
+    "output" : "alice : PartyId = Alice::122053255c00..."
+  },
+  "659" : {
+    "command" : "participant1.topology.party_to_participant_mappings.authorize(TopologyChangeOp.Add, alice, participant2.id, RequestSide.From, ParticipantPermission.Submission)",
+    "output" : "res4: com.google.protobuf.ByteString = <ByteString@2e26c961 size=556 contents=\"\\n\\251\\004\\n\\327\\001\\n\\322\\001\\n\\317\\001\\022 qh7hiVGq1528MVjs6gHMB85q4TxCrtwt2...\">"
   },
   "408" : {
     "command" : "participant1.ledger_api.users.get(\"myuser\", identityProviderId=\"\")",
     "output" : "res8: User = User(\n  id = \"myuser\",\n  primaryParty = None,\n  isActive = true,\n  annotations = Map(\"baz\" -> \"bar\", \"description\" -> \"This is a new description\"),\n  identityProviderId = \"\"\n)"
-  },
-  "677" : {
-    "command" : "participant1.health.ping(participant1.id)",
-    "output" : "res6: Duration = 355 milliseconds"
   },
   "597" : {
     "command" : "",
@@ -57,11 +49,27 @@
   },
   "372" : {
     "command" : "val user = participant1.ledger_api.users.create(id = \"myuser\", actAs = Set(alice), readAs = Set(bob), primaryParty = Some(alice), participantAdmin = false, isActive = true, annotations = Map(\"foo\" -> \"bar\", \"description\" -> \"This is a description\"))",
-    "output" : "user : User = User(\n  id = \"myuser\",\n  primaryParty = Some(value = alice::1220ef4417b7...),\n  isActive = true,\n  annotations = Map(\"foo\" -> \"bar\", \"description\" -> \"This is a description\"),\n  identityProviderId = \"\"\n)"
+    "output" : "user : User = User(\n  id = \"myuser\",\n  primaryParty = Some(value = alice::122001cc785c...),\n  isActive = true,\n  annotations = Map(\"foo\" -> \"bar\", \"description\" -> \"This is a description\"),\n  identityProviderId = \"\"\n)"
   },
   "460" : {
     "command" : "participant1.ledger_api.users.list(\"myotheruser\")",
     "output" : "res17: UsersPage = UsersPage(users = Vector(), nextPageToken = \"\")"
+  },
+  "692" : {
+    "command" : "participant1.repair.download(Set(alice), \"alice.acs.gz\", filterDomainId=\"mydomain\", timestamp = Some(timestamp))",
+    "output" : ""
+  },
+  "428" : {
+    "command" : "participant1.ledger_api.users.rights.grant(id = user.id, actAs = Set(alice, bob), readAs = Set(eve), participantAdmin = true)",
+    "output" : "res11: UserRights = UserRights(\n  actAs = Set(bob::122001cc785c...),\n  readAs = Set(eve::122001cc785c...),\n  participantAdmin = true,\n  identityProviderAdmin = false\n)"
+  },
+  "439" : {
+    "command" : "participant1.ledger_api.users.rights.list(user.id)",
+    "output" : "res13: UserRights = UserRights(\n  actAs = Set(alice::122001cc785c...),\n  readAs = Set(bob::122001cc785c..., eve::122001cc785c...),\n  participantAdmin = false,\n  identityProviderAdmin = false\n)"
+  },
+  "678" : {
+    "command" : "participant1.health.ping(participant1.id)",
+    "output" : "res6: Duration = 656 milliseconds"
   },
   "598" : {
     "command" : "",
@@ -76,6 +84,10 @@
     "output" : ""
   },
   "630" : {
+    "command" : "participant2.topology.party_to_participant_mappings.authorize(TopologyChangeOp.Add, alice, participant2.id, RequestSide.To, ParticipantPermission.Submission)",
+    "output" : "res2: com.google.protobuf.ByteString = <ByteString@5631d527 size=556 contents=\"\\n\\251\\004\\n\\327\\001\\n\\322\\001\\n\\317\\001\\022 uNTBZZDdgWBF4xe8AbgNj2tLc31mmkUA2...\">"
+  },
+  "665" : {
     "command" : "",
     "output" : ""
   },
@@ -83,21 +95,21 @@
     "command" : "participant2.domains.reconnect(\"mydomain\")",
     "output" : "res6: Boolean = true"
   },
-  "710" : {
+  "686" : {
+    "command" : "val timestamp = participant1.topology.party_to_participant_mappings.list(filterStore=\"mydomain\", filterParty=\"Alice\").map(_.context.validFrom).max",
+    "output" : "timestamp : Instant = 2023-12-18T20:08:04.166507Z"
+  },
+  "590" : {
     "command" : "",
     "output" : ""
   },
-  "578" : {
-    "command" : "repair.party_migration.step2_import_acs(participant2, \"alice.acs.gz\")",
-    "output" : ""
-  },
-  "650" : {
-    "command" : "participant2.domains.disconnect_all()",
+  "706" : {
+    "command" : "",
     "output" : ""
   },
   "622" : {
-    "command" : "",
-    "output" : ""
+    "command" : "val alice = participant1.parties.enable(\"Alice\")",
+    "output" : "alice : PartyId = Alice::12204164d7cb..."
   },
   "393" : {
     "command" : "",
@@ -115,6 +127,10 @@
     "command" : "participant1.ledger_api.users.get(\"myuser\", identityProviderId=\"idp-id1\")",
     "output" : "res6: User = User(\n  id = \"myuser\",\n  primaryParty = None,\n  isActive = true,\n  annotations = Map(\"baz\" -> \"bar\", \"description\" -> \"This is a new description\"),\n  identityProviderId = \"idp-id1\"\n)"
   },
+  "711" : {
+    "command" : "",
+    "output" : ""
+  },
   "391" : {
     "command" : "val updatedUser = participant1.ledger_api.users.update(id = user.id, modifier = user => { user.copy(primaryParty = None, annotations = user.annotations.updated(\"description\", \"This is a new description\").removed(\"foo\").updated(\"baz\", \"bar\")) })",
     "output" : "updatedUser : User = User(\n  id = \"myuser\",\n  primaryParty = None,\n  isActive = true,\n  annotations = Map(\"baz\" -> \"bar\", \"description\" -> \"This is a new description\"),\n  identityProviderId = \"\"\n)"
@@ -123,21 +139,29 @@
     "command" : "participant1.ledger_api.users.create(id = \"myotheruser\")",
     "output" : "res14: User = User(\n  id = \"myotheruser\",\n  primaryParty = None,\n  isActive = true,\n  annotations = Map(),\n  identityProviderId = \"\"\n)"
   },
-  "704" : {
-    "command" : "participant2.domains.reconnect_all()",
-    "output" : ""
-  },
   "362" : {
     "command" : "",
     "output" : ""
   },
   "434" : {
     "command" : "participant1.ledger_api.users.rights.revoke(id = user.id, actAs = Set(bob), readAs = Set(alice), participantAdmin = true)",
-    "output" : "res12: UserRights = UserRights(\n  actAs = Set(bob::1220ef4417b7...),\n  readAs = Set(),\n  participantAdmin = true,\n  identityProviderAdmin = false\n)"
+    "output" : "res12: UserRights = UserRights(\n  actAs = Set(bob::122001cc785c...),\n  readAs = Set(),\n  participantAdmin = true,\n  identityProviderAdmin = false\n)"
   },
-  "685" : {
-    "command" : "val timestamp = participant1.topology.party_to_participant_mappings.list(filterStore=\"mydomain\", filterParty=\"Alice\").map(_.context.validFrom).max",
-    "output" : "timestamp : Instant = 2023-11-21T16:01:23.395676Z"
+  "599" : {
+    "command" : "",
+    "output" : ""
+  },
+  "631" : {
+    "command" : "",
+    "output" : ""
+  },
+  "621" : {
+    "command" : "",
+    "output" : ""
+  },
+  "700" : {
+    "command" : "repair.party_migration.step2_import_acs(participant2, \"alice.acs.gz\")",
+    "output" : ""
   },
   "455" : {
     "command" : "participant1.ledger_api.users.delete(\"myotheruser\")",
@@ -147,17 +171,9 @@
     "command" : "",
     "output" : ""
   },
-  "658" : {
-    "command" : "participant1.topology.party_to_participant_mappings.authorize(TopologyChangeOp.Add, alice, participant2.id, RequestSide.From, ParticipantPermission.Submission)",
-    "output" : "res4: com.google.protobuf.ByteString = <ByteString@31af0592 size=556 contents=\"\\n\\251\\004\\n\\327\\001\\n\\322\\001\\n\\317\\001\\022 FHyvQGL5laKYdqg2LdTeXP4VpMewcVlv2...\">"
-  },
   "589" : {
     "command" : "repair.party_migration.step3_enable_on_target(alice, participant2)",
     "output" : ""
-  },
-  "663" : {
-    "command" : "participant1.parties.list(\"Alice\")",
-    "output" : "res5: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Alice::12201637ff6c...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant2::1220b163d599...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220719ba79b..., permission = Submission)\n        )\n      ),\n      ParticipantDomains(\n        participant = PAR::participant1::12201637ff6c...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::1220719ba79b..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
   },
   "548" : {
     "command" : "",
@@ -177,46 +193,34 @@
   },
   "363" : {
     "command" : "val Seq(alice, bob, eve) = Seq(\"alice\", \"bob\", \"eve\").map(p => participant1.parties.enable(name = p, waitForDomain = DomainChoice.All))",
-    "output" : "Seq(alice, bob, eve) : Seq[PartyId] = List(alice::1220ef4417b7..., bob::1220ef4417b7..., eve::1220ef4417b7...)"
+    "output" : "Seq(alice, bob, eve) : Seq[PartyId] = List(alice::122001cc785c..., bob::122001cc785c..., eve::122001cc785c...)"
   },
   "556" : {
     "command" : "val targetParticipantId = participant2.id",
-    "output" : "targetParticipantId : ParticipantId = PAR::participant2::1220b05c458a..."
-  },
-  "699" : {
-    "command" : "repair.party_migration.step2_import_acs(participant2, \"alice.acs.gz\")",
-    "output" : ""
-  },
-  "401" : {
-    "command" : "participant1.ledger_api.users.update_idp(\"myuser\", sourceIdentityProviderId=\"\", targetIdentityProviderId=\"idp-id1\")",
-    "output" : ""
-  },
-  "620" : {
-    "command" : "",
-    "output" : ""
+    "output" : "targetParticipantId : ParticipantId = PAR::participant2::12209735368d..."
   },
   "422" : {
     "command" : "participant1.ledger_api.users.rights.list(user.id)",
-    "output" : "res10: UserRights = UserRights(\n  actAs = Set(alice::1220ef4417b7...),\n  readAs = Set(bob::1220ef4417b7...),\n  participantAdmin = false,\n  identityProviderAdmin = false\n)"
+    "output" : "res10: UserRights = UserRights(\n  actAs = Set(alice::122001cc785c...),\n  readAs = Set(bob::122001cc785c...),\n  participantAdmin = false,\n  identityProviderAdmin = false\n)"
   },
   "373" : {
     "command" : "",
     "output" : ""
   },
   "664" : {
-    "command" : "",
-    "output" : ""
+    "command" : "participant1.parties.list(\"Alice\")",
+    "output" : "res5: Seq[ListPartiesResult] = Vector(\n  ListPartiesResult(\n    party = Alice::12204164d7cb...,\n    participants = Vector(\n      ParticipantDomains(\n        participant = PAR::participant1::12204164d7cb...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::12200cd38893..., permission = Submission)\n        )\n      ),\n      ParticipantDomains(\n        participant = PAR::participant2::122008c3e657...,\n        domains = Vector(\n          DomainPermission(domain = mydomain::12200cd38893..., permission = Submission)\n        )\n      )\n    )\n  )\n)"
   },
   "400" : {
     "command" : "participant1.ledger_api.identity_provider_config.create(\"idp-id1\", isDeactivated = false, jwksUrl = \"http://someurl\", issuer = \"issuer1\", audience = None)",
     "output" : "res4: com.digitalasset.canton.ledger.api.domain.IdentityProviderConfig = IdentityProviderConfig(\n  identityProviderId = Id(value = \"idp-id1\"),\n  isDeactivated = false,\n  jwksUrl = JwksUrl(value = \"http://someurl\"),\n  issuer = \"issuer1\",\n  audience = None\n)"
   },
-  "596" : {
-    "command" : "repair.party_migration.step4_clean_up_source(alice, participant1, \"alice.acs.gz\")",
+  "624" : {
+    "command" : "",
     "output" : ""
   },
-  "691" : {
-    "command" : "participant1.repair.download(Set(alice), \"alice.acs.gz\", filterDomainId=\"mydomain\", timestamp = Some(timestamp))",
+  "596" : {
+    "command" : "repair.party_migration.step4_clean_up_source(alice, participant1, \"alice.acs.gz\")",
     "output" : ""
   }
 }

--- a/docs/2.9.0/docs/canton/includes/snippet_data/usermanual/manage_domain_entities.json
+++ b/docs/2.9.0/docs/canton/includes/snippet_data/usermanual/manage_domain_entities.json
@@ -1,7 +1,7 @@
 {
   "138" : {
     "command" : "mediator1.mediator.initialize(domainId, MediatorId(domainId), domainParameters, sequencerConnections, None)",
-    "output" : "res20: PublicKey = SigningPublicKey(id = 12207a13f7a1..., format = Tink, scheme = Ed25519)"
+    "output" : "res20: PublicKey = SigningPublicKey(id = 12208419c79c..., format = Tink, scheme = Ed25519)"
   },
   "120" : {
     "command" : "domainManager1.topology.all.list().collectOfType[TopologyChangeOp.Positive].writeToFile(\"tmp/domain-bootstrapping-files/topology-transactions.proto\")",
@@ -9,11 +9,11 @@
   },
   "84" : {
     "command" : "val domainIdString = domainManager1.id.toProtoPrimitive",
-    "output" : "domainIdString : String = \"domainManager1::12205a5398acf9970bb74a45d1940155e501ad374f1789ee3d7703bd7796fee73d8e\""
+    "output" : "domainIdString : String = \"domainManager1::1220496a4a04453099e2f916caa24965a6d302af855f68a133cc6183f05e8004aa7e\""
   },
   "92" : {
     "command" : "val domainId = DomainId.tryFromString(domainIdString)",
-    "output" : "domainId : DomainId = domainManager1::12205a5398ac..."
+    "output" : "domainId : DomainId = domainManager1::1220496a4a04..."
   },
   "129" : {
     "command" : "sequencer1.initialization.bootstrap_topology(initialTopology)",
@@ -25,7 +25,7 @@
   },
   "144" : {
     "command" : "val sequencerConnection = SequencerConnections.tryReadFromFile(\"tmp/domain-bootstrapping-files/sequencer-connection.proto\")",
-    "output" : "sequencerConnection : SequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:30829,\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
+    "output" : "sequencerConnection : SequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:32209,\n  transportSecurity = false\n)"
   },
   "113" : {
     "command" : "domainManager1.setup.helper.authorizeKey(mediatorKey, \"mediator1\", MediatorId(domainId))",
@@ -45,7 +45,7 @@
   },
   "99" : {
     "command" : "val sequencerPublicKey = SigningPublicKey.tryReadFromFile(\"tmp/domain-bootstrapping-files/seq1-key.proto\")",
-    "output" : "sequencerPublicKey : SigningPublicKey = SigningPublicKey(id = 1220cbedd319..., format = Tink, scheme = Ed25519)"
+    "output" : "sequencerPublicKey : SigningPublicKey = SigningPublicKey(id = 12204286ac90..., format = Tink, scheme = Ed25519)"
   },
   "42" : {
     "command" : "domainManager1.setup.bootstrap_domain(Seq(sequencer1), Seq(mediator1))",
@@ -61,11 +61,11 @@
   },
   "93" : {
     "command" : "val initResponse = sequencer1.initialization.initialize_from_beginning(domainId, domainParameters)",
-    "output" : "initResponse : com.digitalasset.canton.domain.sequencing.admin.grpc.InitializeSequencerResponse = InitializeSequencerResponse(\n  keyId = \"sequencer-id\",\n  publicKey = SigningPublicKey(id = 1220cbedd319..., format = Tink, scheme = Ed25519),\n  replicated = false\n)"
+    "output" : "initResponse : com.digitalasset.canton.domain.sequencing.admin.grpc.InitializeSequencerResponse = InitializeSequencerResponse(\n  keyId = \"sequencer-id\",\n  publicKey = SigningPublicKey(id = 12204286ac90..., format = Tink, scheme = Ed25519),\n  replicated = false\n)"
   },
   "152" : {
     "command" : "participant1.health.ping(participant1)",
-    "output" : "res26: Duration = 361 milliseconds"
+    "output" : "res26: Duration = 460 milliseconds"
   },
   "28" : {
     "command" : "",
@@ -97,7 +97,7 @@
   },
   "112" : {
     "command" : "val domainId = DomainId.tryFromString(domainIdString)",
-    "output" : "domainId : DomainId = domainManager1::12205a5398ac..."
+    "output" : "domainId : DomainId = domainManager1::1220496a4a04..."
   },
   "145" : {
     "command" : "domainManager1.setup.init(sequencerConnection)",
@@ -109,7 +109,7 @@
   },
   "127" : {
     "command" : "val initialTopology = com.digitalasset.canton.topology.store.StoredTopologyTransactions.tryReadFromFile(\"tmp/domain-bootstrapping-files/topology-transactions.proto\").collectOfType[TopologyChangeOp.Positive]",
-    "output" : "initialTopology : store.StoredTopologyTransactions[TopologyChangeOp.Positive] = Seq(\n  StoredTopologyTransaction(\n    sequenced = 2023-11-21T16:01:05.580750Z,\n    validFrom = 2023-11-21T16:01:05.580750Z,\n    validUntil = 2023-11-21T16:01:05.580750Z,\n    op = Add,\n.."
+    "output" : "initialTopology : store.StoredTopologyTransactions[TopologyChangeOp.Positive] = Seq(\n  StoredTopologyTransaction(\n    sequenced = 2023-12-18T20:07:26.923151Z,\n    validFrom = 2023-12-18T20:07:26.923151Z,\n    validUntil = 2023-12-18T20:07:26.923151Z,\n    op = Add,\n.."
   },
   "26" : {
     "command" : "",
@@ -117,7 +117,7 @@
   },
   "114" : {
     "command" : "domainManager1.topology.mediator_domain_states.authorize(TopologyChangeOp.Add, domainId, MediatorId(domainId), RequestSide.Both)",
-    "output" : "res13: com.google.protobuf.ByteString = <ByteString@3de2507a size=560 contents=\"\\n\\255\\004\\n\\333\\001\\n\\326\\001\\n\\323\\001\\022 gq1gqFyqx99AOvBQRufV5aTRlQc2Fw5xR...\">"
+    "output" : "res13: com.google.protobuf.ByteString = <ByteString@200a98c7 size=560 contents=\"\\n\\255\\004\\n\\333\\001\\n\\326\\001\\n\\323\\001\\022 vIOFx0aoxhISVlPeVQIUw0NmOMGHOnztR...\">"
   },
   "139" : {
     "command" : "mediator1.health.wait_for_initialized()",
@@ -137,11 +137,11 @@
   },
   "51" : {
     "command" : "participant1.health.ping(participant1)",
-    "output" : "res7: Duration = 411 milliseconds"
+    "output" : "res7: Duration = 2009 milliseconds"
   },
   "136" : {
     "command" : "val sequencerConnections = SequencerConnections.tryReadFromFile(\"tmp/domain-bootstrapping-files/sequencer-connection.proto\")",
-    "output" : "sequencerConnections : SequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:30829,\n  transportSecurity = false,\n  customTrustCertificates = None()\n)"
+    "output" : "sequencerConnections : SequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n  endpoints = http://127.0.0.1:32209,\n  transportSecurity = false\n)"
   },
   "94" : {
     "command" : "initResponse.publicKey.writeToFile(\"tmp/domain-bootstrapping-files/seq1-key.proto\")",
@@ -149,7 +149,7 @@
   },
   "111" : {
     "command" : "val mediatorKey = SigningPublicKey.tryReadFromFile(\"tmp/domain-bootstrapping-files/med1-key.proto\")",
-    "output" : "mediatorKey : SigningPublicKey = SigningPublicKey(id = 1220117ddd66..., format = Tink, scheme = Ed25519)"
+    "output" : "mediatorKey : SigningPublicKey = SigningPublicKey(id = 1220ae264649..., format = Tink, scheme = Ed25519)"
   },
   "83" : {
     "command" : "domainManager1.service.get_static_domain_parameters.writeToFile(\"tmp/domain-bootstrapping-files/params.proto\")",

--- a/docs/2.9.0/docs/canton/includes/snippet_data/usermanual/manage_domains.json
+++ b/docs/2.9.0/docs/canton/includes/snippet_data/usermanual/manage_domains.json
@@ -1,7 +1,7 @@
 {
   "101" : {
     "command" : "participant1.health.ping(participant1)",
-    "output" : "res10: Duration = 2822 milliseconds"
+    "output" : "res10: Duration = 4293 milliseconds"
   },
   "84" : {
     "command" : "",
@@ -21,7 +21,7 @@
   },
   "73" : {
     "command" : "domainManager1.topology.participant_domain_states.list(filterStore=\"Authorized\").map(_.item)",
-    "output" : "res6: Seq[ParticipantState] = Vector(\n  ParticipantState(\n    From,\n    domainManager1::1220d2ee4eb7...,\n    PAR::participant1::122004e7fb4e...,\n    Submission,\n    Ordinary\n  )\n)"
+    "output" : "res6: Seq[ParticipantState] = Vector(\n  ParticipantState(\n    From,\n    domainManager1::12204c361ba9...,\n    PAR::participant1::1220efb797a7...,\n    Submission,\n    Ordinary\n  )\n)"
   },
   "66" : {
     "command" : "",
@@ -29,11 +29,11 @@
   },
   "95" : {
     "command" : "domainManager1.topology.participant_domain_states.list(filterStore=\"Authorized\").map(_.item)",
-    "output" : "res9: Seq[ParticipantState] = Vector(\n  ParticipantState(\n    From,\n    domainManager1::1220d2ee4eb7...,\n    PAR::participant1::122004e7fb4e...,\n    Submission,\n    Ordinary\n  ),\n  ParticipantState(\n    To,\n    domainManager1::1220d2ee4eb7...,\n    PAR::participant1::122004e7fb4e...,\n    Submission,\n    Ordinary\n  )\n)"
+    "output" : "res9: Seq[ParticipantState] = Vector(\n  ParticipantState(\n    From,\n    domainManager1::12204c361ba9...,\n    PAR::participant1::1220efb797a7...,\n    Submission,\n    Ordinary\n  ),\n  ParticipantState(\n    To,\n    domainManager1::12204c361ba9...,\n    PAR::participant1::1220efb797a7...,\n    Submission,\n    Ordinary\n  )\n)"
   },
   "50" : {
     "command" : "val participantAsString = participant1.id.toProtoPrimitive",
-    "output" : "participantAsString : String = \"PAR::participant1::122004e7fb4e6490729681a35ddc903cdd9d1783e440bbff67fcc50ccce910ae0ae2\""
+    "output" : "participantAsString : String = \"PAR::participant1::1220efb797a7136e89fb11b6cc9ea4ab72f3e7dab1c46deb1a6888f2254df668aca5\""
   },
   "43" : {
     "command" : "",
@@ -41,7 +41,7 @@
   },
   "55" : {
     "command" : "val participantIdFromString = ParticipantId.tryFromProtoPrimitive(participantAsString)",
-    "output" : "participantIdFromString : ParticipantId = PAR::participant1::122004e7fb4e..."
+    "output" : "participantIdFromString : ParticipantId = PAR::participant1::1220efb797a7..."
   },
   "36" : {
     "command" : "",
@@ -49,11 +49,11 @@
   },
   "42" : {
     "command" : "participant1.domains.register(config)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PARTICIPANT_IS_NOT_ACTIVE(9,a7de072c): The participant is not yet active\n  Request: RegisterDomain(DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(endpoints = http://127.0.0.1:30755, transportSecurity = false, customTrustCertificates = None()),\n   ...\n  CorrelationId: a7de072ca88d4d52dc747af45c19032d\n  Context: HashMap(participant -> participant1, test -> ManagePermissionedDomainsDocumentationManual, serverResponse -> Domain Domain 'mydomain' has rejected our on-boarding attempt, domain -> mydomain, tid -> a7de072ca88d4d52dc747af45c19032d)\n  Command ParticipantAdministration$domains$.register invoked from cmd10000006.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PARTICIPANT_IS_NOT_ACTIVE(9,a605fad6): The participant is not yet active\n  Request: RegisterDomain(DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(endpoints = http://127.0.0.1:32147, transportSecurity = false),\n  manualConnect = false\n))\n  CorrelationId: a605fad67e7f937a95ddc3bda4b32f80\n  Context: HashMap(participant -> participant1, test -> ManagePermissionedDomainsDocumentationManual, serverResponse -> Domain Domain 'mydomain' has rejected our on-boarding attempt, domain -> mydomain, tid -> a605fad67e7f937a95ddc3bda4b32f80)\n  Command ParticipantAdministration$domains$.register invoked from cmd10000006.sc:1"
   },
   "37" : {
     "command" : "val config = DomainConnectionConfig(\"mydomain\", sequencer1.sequencerConnection)",
-    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://127.0.0.1:30755,\n    transportSecurity = false,\n.."
+    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'mydomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://127.0.0.1:32147,\n    transportSecurity = false\n.."
   },
   "89" : {
     "command" : "domainManager1.participants.active(participantIdFromString)",

--- a/docs/2.9.0/docs/canton/includes/snippet_data/usermanual/packagemanagement.json
+++ b/docs/2.9.0/docs/canton/includes/snippet_data/usermanual/packagemanagement.json
@@ -5,15 +5,15 @@
   },
   "124" : {
     "command" : "val darHash_ = participant1.dars.list().filter(_.name == \"CantonExamples\").head.hash",
-    "output" : "darHash_ : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
+    "output" : "darHash_ : String = \"12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37\""
   },
   "173" : {
     "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(archiveIouCmd))",
-    "output" : "res24: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220eb5d82ae2925552306be22fcf86e501377e8b4a2b17254f8acf7b0ce69bd881f\",\n  commandId = \"88a6e285-9826-4386-994f-172cfd772ebe\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
+    "output" : "res24: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220fb621877f234a59b1183f07ce01dc410cf2308b79e55e4d57d48e62cdf5528f5\",\n  commandId = \"057687fb-0026-4e19-b7b4-0ad1274d3e61\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
   },
   "118" : {
     "command" : "val packagesBefore = participant1.packages.list().map(_.packageId).toSet",
-    "output" : "packagesBefore : Set[String] = HashSet(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"5921708ce82f4255deb1b26d2c05358b548720938a5a325718dc69f381ba47ff\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"6839a6d3d430c569b2425e9391717b44ca324b88ba621d597778811b2d05031d\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"e22bce619ae24ca3b8e6519281cb5a33b64b3190cc763248b4c3f9ad5087a92c\",\n  \"d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97\",\n  \"6c2c0667393c5f92f1885163068cd31800d2264eb088eb6fc740e11241b2bf06\",\n  \"fdd56e2ece40d67781248bc47663c9112122e35eec580b7e93ee7cfa83cda2cc\",\n.."
+    "output" : "packagesBefore : Set[String] = HashSet(\n  \"b1c181d36e9c2e6a540c457fb4e5ae822f11d9a18fb120912770acc889730af2\",\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"5921708ce82f4255deb1b26d2c05358b548720938a5a325718dc69f381ba47ff\",\n  \"616cc046a57fca4ed024b4e7ee5cecf44025f7acc1f1a12991019df69935b6c8\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"6839a6d3d430c569b2425e9391717b44ca324b88ba621d597778811b2d05031d\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"e22bce619ae24ca3b8e6519281cb5a33b64b3190cc763248b4c3f9ad5087a92c\",\n  \"d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97\",\n.."
   },
   "159" : {
     "command" : "participant1.domains.connect_local(mydomain)",
@@ -21,11 +21,11 @@
   },
   "263" : {
     "command" : "val iou = participant1.ledger_api.acs.find_generic(participant1.adminParty, _.templateId.isModuleEntity(\"Iou\", \"Iou\"))",
-    "output" : "iou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#12206a583221a67e432ba7a7ed6097cf3e9216ed2b2bf76874b24d3e01d3d3760b75:0\",\n    contractId = \"0089706b2eecd481436897fe503f438458539b6e8c41f270e38516a92b31032109ca021220e9f0db900b810a0ac8409559f7f146d89ab25cd892be3d2c950f8af66f192614\",\n    templateId = Some(\n      value = Identifier(\n        packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n        moduleName = \"Iou\",\n        entityName = \"Iou\"\n      )\n.."
+    "output" : "iou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#12208cc00581e86615cab10c9f1d382c552637e2ea6a338c6fe301a32d35e0313a9e:0\",\n    contractId = \"003ea590b8814406960c4af423f46c53398d87979af069e54d4e35704983e4cb8bca0212204d060c0b8b0ba669369232a4b119a8bb5cdb80aefeb39c6629d0e50686686cea\",\n    templateId = Some(\n      value = Identifier(\n        packageId = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n        moduleName = \"Iou\",\n        entityName = \"Iou\"\n      )\n.."
   },
   "195" : {
     "command" : "participant1.dars.remove(darHash)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,44730a8c): An error was encountered whilst trying to unvet the DAR DarDescriptor(SHA-256:cf7693f5858d...,CantonExamples) with main package 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680 for DAR removal. Details: IdentityManagerParentError(Mapping(VettedPackages(\n  participant = participant1::122042762b7b...,\n  packages = Seq(\n    6087107abcaa...,\n    a566728bb2d4...,\n    cb0552debf21...,\n    3f4deaf145a1...,\n    86828b984346...,\n    f20de1e4e37b...,\n    76bf0fd12bd9...,\n    38e6274601b2...,\n    d58cf...\n  Request: RemoveDar(1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c)\n  CorrelationId: 44730a8c36a5f1142283fa4cfab20bdc\n  Context: Map(participant -> participant1, tid -> 44730a8c36a5f1142283fa4cfab20bdc, test -> PackageDarManagementDocumentationIntegrationTest)\n  Command ParticipantAdministration$dars$.remove invoked from cmd10000076.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,a31a1282): An error was encountered whilst trying to unvet the DAR DarDescriptor(SHA-256:4b56f9730c63...,CantonExamples) with main package e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86 for DAR removal. Details: IdentityManagerParentError(Mapping(VettedPackages(\n  participant = participant1::122011b6abb3...,\n  packages = Seq(\n    e79d5d0217e0...,\n    616cc046a57f...,\n    cb0552debf21...,\n    3f4deaf145a1...,\n    86828b984346...,\n    f20de1e4e37b...,\n    76bf0fd12bd9...,\n    38e6274601b2...,\n    d58cf...\n  Request: RemoveDar(12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37)\n  CorrelationId: a31a12827ce2b5e7494c0b9838a0b639\n  Context: Map(participant -> participant1, tid -> a31a12827ce2b5e7494c0b9838a0b639, test -> PackageDarManagementDocumentationIntegrationTest)\n  Command ParticipantAdministration$dars$.remove invoked from cmd10000076.sc:1"
   },
   "276" : {
     "command" : "participant1.packages.remove(packageId)",
@@ -33,15 +33,15 @@
   },
   "247" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
+    "output" : "darHash : String = \"12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37\""
   },
   "42" : {
     "command" : "val darContent = participant2.dars.list_contents(hash)",
-    "output" : "darContent : DarMetadata = DarMetadata(\n  name = \"CantonExamples\",\n  main = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n  packages = Vector(\n    \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n    \"a566728bb2d4ad0103eb11ff8140296f4cea4fc94f1f95ddc6c3e4f983d107f1\",\n    \"cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a\",\n    \"3f4deaf145a15cdcfa762c058005e2edb9baa75bb7f95a4f8f6f937378e86415\",\n.."
+    "output" : "darContent : DarMetadata = DarMetadata(\n  name = \"CantonExamples\",\n  main = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n  packages = Vector(\n    \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n    \"616cc046a57fca4ed024b4e7ee5cecf44025f7acc1f1a12991019df69935b6c8\",\n    \"cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a\",\n    \"3f4deaf145a15cdcfa762c058005e2edb9baa75bb7f95a4f8f6f937378e86415\",\n.."
   },
   "37" : {
     "command" : "val hash = dars.head.hash",
-    "output" : "hash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
+    "output" : "hash : String = \"12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37\""
   },
   "125" : {
     "command" : "",
@@ -49,7 +49,7 @@
   },
   "157" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
+    "output" : "darHash : String = \"12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37\""
   },
   "189" : {
     "command" : "val packageIds = participant1.packages.list().filter(_.sourceDescription == \"CantonExamples\").map(_.packageId).map(PackageId.assertFromString)",
@@ -57,11 +57,11 @@
   },
   "20" : {
     "command" : "participant2.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "res1: String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
+    "output" : "res1: String = \"12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37\""
   },
   "253" : {
     "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
-    "output" : "res39: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"12206a583221a67e432ba7a7ed6097cf3e9216ed2b2bf76874b24d3e01d3d3760b75\",\n  commandId = \"acdf8522-5d80-4e06-b479-2174827b3afd\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1700582453L,\n      nanos = 82326000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n.."
+    "output" : "res39: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"12208cc00581e86615cab10c9f1d382c552637e2ea6a338c6fe301a32d35e0313a9e\",\n  commandId = \"54e4c0cf-f336-47c6-8f09-866f4670ceb4\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1702930030L,\n      nanos = 373008000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n.."
   },
   "238" : {
     "command" : "participant1.packages.remove(packageId)",
@@ -73,11 +73,11 @@
   },
   "221" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
+    "output" : "darHash : String = \"12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37\""
   },
   "265" : {
     "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(archiveIouCmd))",
-    "output" : "res42: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"122032f35a1bca685ed4c8a42b7cf0c1029ae5155fa8a57d895f9eea319d640ab3d0\",\n  commandId = \"a47f3270-b3a7-40ab-9305-12b3bce8c7c0\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1700582453L,\n      nanos = 531855000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n  ),\n  offset = \"00000000000000000c\",\n.."
+    "output" : "res42: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220f4d476193d08c92779f248e24e4c8b06ef3a754bce53c68151219e2accfc5d16\",\n  commandId = \"a6fe2498-e73c-4b02-b4b7-2aba71dd9073\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1702930030L,\n      nanos = 759714000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n  ),\n  offset = \"00000000000000000c\",\n.."
   },
   "292" : {
     "command" : "participant1.packages.remove(packageId, force = true)",
@@ -85,11 +85,11 @@
   },
   "233" : {
     "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove, participant1.id, packageIds, force = true)",
-    "output" : "res35: com.google.protobuf.ByteString = <ByteString@78a09f12 size=2386 contents=\"\\n\\317\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 AA9hgdF6EdW1O3HrrGffNCi12iz5JfF...\">"
+    "output" : "res35: com.google.protobuf.ByteString = <ByteString@17097e34 size=2386 contents=\"\\n\\317\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 7qlhcsn5HA9RsMn3SkbB3GYyLQKMm0j...\">"
   },
   "270" : {
     "command" : "val packageIds = participant1.topology.vetted_packages.list().map(_.item.packageIds).filter(_.contains(packageId)).head",
-    "output" : "packageIds : Seq[com.digitalasset.canton.package.LfPackageId] = Vector(\n  \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n  \"a566728bb2d4ad0103eb11ff8140296f4cea4fc94f1f95ddc6c3e4f983d107f1\",\n.."
+    "output" : "packageIds : Seq[com.digitalasset.canton.package.LfPackageId] = Vector(\n  \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n  \"616cc046a57fca4ed024b4e7ee5cecf44025f7acc1f1a12991019df69935b6c8\",\n.."
   },
   "201" : {
     "command" : "participant1.dars.remove(darHash)",
@@ -97,7 +97,7 @@
   },
   "28" : {
     "command" : "participant2.dars.list()",
-    "output" : "res2: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220caf9b815c77d40b24801fc88acaa85bffac5cc315644c8242923d039d8df6d73\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  ),\n  DarDescription(\n    hash = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\",\n    name = \"CantonExamples\"\n  )\n)"
+    "output" : "res2: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37\",\n    name = \"CantonExamples\"\n  ),\n  DarDescription(\n    hash = \"122066e542ea6f3319ee8eb495caf75e2f068420994044ee9d5e26b5733738b0b02f\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  )\n)"
   },
   "160" : {
     "command" : "val createIouCmd = ledger_api_utils.create(packageId,\"Iou\",\"Iou\",Map(\"payer\" -> participant1.adminParty,\"owner\" -> participant1.adminParty,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
@@ -113,19 +113,19 @@
   },
   "166" : {
     "command" : "participant1.dars.remove(darHash)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,0c6258f1): The DAR DarDescriptor(SHA-256:cf7693f5858d...,CantonExamples) cannot be removed because its main package 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680 is in-use by contract ContractId(002ac723b60cf62b827fa1fbfb4760fbf35b337d19519c30a56ba4df5b1ef7aec8ca0212207ed3d4db9505f19e9aa96a6dd1e7f51eeaa883bb6af3f559400d4ec814b7ffc8)\non domain mydomain::12208be8725d....\n  Request: RemoveDar(1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c)\n  CorrelationId: 0c6258f136abe1f759cadb551d35cfd4\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, pkg -> 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680, tid -> 0c6258f136abe1f759cadb551d35cfd4)\n  Command ParticipantAdministration$dars$.remove invoked from cmd10000056.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,76833a7e): The DAR DarDescriptor(SHA-256:4b56f9730c63...,CantonExamples) cannot be removed because its main package e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86 is in-use by contract ContractId(002f49536ae7bd520bdf4f69bb0dda4a7a0b57f82b9b5827613bbfa7fb0ef7a72eca021220a0efd34339f6cffc799b2d92d40aa7365d2185af092c7b0e4494b771d6919f34)\non domain mydomain::12201f74aa53....\n  Request: RemoveDar(12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37)\n  CorrelationId: 76833a7e4dd2cdda7535e0324a46051e\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, pkg -> e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86, tid -> 76833a7e4dd2cdda7535e0324a46051e)\n  Command ParticipantAdministration$dars$.remove invoked from cmd10000056.sc:1"
   },
   "264" : {
     "command" : "val archiveIouCmd = ledger_api_utils.exercise(\"Archive\", Map.empty, iou.event)",
-    "output" : "archiveIouCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Exercise(\n    value = ExerciseCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n          moduleName = \"Iou\",\n          entityName = \"Iou\"\n        )\n      ),\n.."
+    "output" : "archiveIouCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Exercise(\n    value = ExerciseCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n          moduleName = \"Iou\",\n          entityName = \"Iou\"\n        )\n      ),\n.."
   },
   "161" : {
     "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
-    "output" : "res21: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220f85c004ec07426ad8085d75d9be6055375b59a4d25f88dcd4f8917c2cb7c32f1\",\n  commandId = \"05db6b8f-cbd6-4420-baa9-16288075383a\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
+    "output" : "res21: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220addf8d7a2d77b6288be93b4c9d1f91b1366741b70c9f639c49b4090b1b9afa39\",\n  commandId = \"43306a54-3bbc-4668-9f0a-cffc03b923d4\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
   },
   "187" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\", vetAllPackages = false)",
-    "output" : "darHash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
+    "output" : "darHash : String = \"12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37\""
   },
   "172" : {
     "command" : "val archiveIouCmd = ledger_api_utils.exercise(\"Archive\", Map.empty, iou.event)",
@@ -133,7 +133,7 @@
   },
   "271" : {
     "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove, participant1.id, packageIds, force = true)",
-    "output" : "res44: com.google.protobuf.ByteString = <ByteString@7c1f16ea size=2386 contents=\"\\n\\317\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 2aXrz9G79rgWdmaV06VuNHedCk2vgyl...\">"
+    "output" : "res44: com.google.protobuf.ByteString = <ByteString@6e9ee50d size=2386 contents=\"\\n\\317\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 j4JV7UIj8M9jGME4RLBiAOL68duamSM...\">"
   },
   "130" : {
     "command" : "participant1.dars.remove(darHash)",
@@ -141,15 +141,15 @@
   },
   "135" : {
     "command" : "val packageIds = participant1.packages.list().filter(_.sourceDescription == \"CantonExamples\").map(_.packageId)",
-    "output" : "packageIds : Seq[String] = Vector(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"e491352788e56ca4603acc411ffe1a49fefd76ed8b163af86cf5ee5f4c38645b\",\n  \"55aeefaf7bfb7f275f52b402f419f71c8e529b6ec625812d2a4e80f280fd86d4\",\n  \"cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a\",\n  \"38e6274601b21d7202bb995bc5ec147decda5a01b68d57dda422425038772af7\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"a566728bb2d4ad0103eb11ff8140296f4cea4fc94f1f95ddc6c3e4f983d107f1\",\n  \"f20de1e4e37b92280264c08bf15eca0be0bc5babd7a7b5e574997f154c00cb78\",\n.."
+    "output" : "packageIds : Seq[String] = Vector(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"e491352788e56ca4603acc411ffe1a49fefd76ed8b163af86cf5ee5f4c38645b\",\n  \"cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a\",\n  \"38e6274601b21d7202bb995bc5ec147decda5a01b68d57dda422425038772af7\",\n  \"4a1a998b915e20b6553a6501a28d3db358dd336aa18f2c1ff2b11ab5bd060ce4\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"f20de1e4e37b92280264c08bf15eca0be0bc5babd7a7b5e574997f154c00cb78\",\n  \"8a7806365bbd98d88b4c13832ebfa305f6abaeaf32cfa2b7dd25c4fa489b79fb\",\n.."
   },
   "258" : {
     "command" : "participant1.packages.remove(packageId)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,67ecba2f): Package 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680 is currently in-use by contract ContractId(0089706b2eecd481436897fe503f438458539b6e8c41f270e38516a92b31032109ca021220e9f0db900b810a0ac8409559f7f146d89ab25cd892be3d2c950f8af66f192614) on domain mydomain::12208be8725d.... It may also be in-use by other contracts.\n  Request: RemovePackage(6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680,false)\n  CorrelationId: 67ecba2f154fa15ff11c2d601d34d37b\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, domain -> mydomain::12208be8725d..., pkg -> 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680, tid -> 67ecba2f154fa15ff11c2d601d34d37b, contract -> ContractId(0089706b2eecd481436897fe503f438458539b6e8c41f270e38516a92b31032109ca021220e9f0db900b810a0ac8409559f7f146d89ab25cd892be3d2c950f8af66f192614))\n  Command ParticipantAdministration$packages$.remove invoked from cmd10000103.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,30865f52): Package e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86 is currently in-use by contract ContractId(003ea590b8814406960c4af423f46c53398d87979af069e54d4e35704983e4cb8bca0212204d060c0b8b0ba669369232a4b119a8bb5cdb80aefeb39c6629d0e50686686cea) on domain mydomain::12201f74aa53.... It may also be in-use by other contracts.\n  Request: RemovePackage(e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86,false)\n  CorrelationId: 30865f521b1fcb84a46ecab3f7c59490\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, domain -> mydomain::12201f74aa53..., pkg -> e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86, tid -> 30865f521b1fcb84a46ecab3f7c59490, contract -> ContractId(003ea590b8814406960c4af423f46c53398d87979af069e54d4e35704983e4cb8bca0212204d060c0b8b0ba669369232a4b119a8bb5cdb80aefeb39c6629d0e50686686cea))\n  Command ParticipantAdministration$packages$.remove invoked from cmd10000103.sc:1"
   },
   "158" : {
     "command" : "val packageId = participant1.packages.find(\"Iou\").head.packageId",
-    "output" : "packageId : String = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\""
+    "output" : "packageId : String = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\""
   },
   "55" : {
     "command" : "participant2.packages.list_contents(darContent.main)",
@@ -157,31 +157,31 @@
   },
   "171" : {
     "command" : "val iou = participant1.ledger_api.acs.find_generic(participant1.adminParty, _.templateId.isModuleEntity(\"Iou\", \"Iou\"))",
-    "output" : "iou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#1220f85c004ec07426ad8085d75d9be6055375b59a4d25f88dcd4f8917c2cb7c32f1:0\",\n    contractId = \"002ac723b60cf62b827fa1fbfb4760fbf35b337d19519c30a56ba4df5b1ef7aec8ca0212207ed3d4db9505f19e9aa96a6dd1e7f51eeaa883bb6af3f559400d4ec814b7ffc8\",\n    templateId = Some(\n      value = Identifier(\n        packageId = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n        moduleName = \"Iou\",\n        entityName = \"Iou\"\n      )\n.."
+    "output" : "iou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#1220addf8d7a2d77b6288be93b4c9d1f91b1366741b70c9f639c49b4090b1b9afa39:0\",\n    contractId = \"002f49536ae7bd520bdf4f69bb0dda4a7a0b57f82b9b5827613bbfa7fb0ef7a72eca021220a0efd34339f6cffc799b2d92d40aa7365d2185af092c7b0e4494b771d6919f34\",\n    templateId = Some(\n      value = Identifier(\n        packageId = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n        moduleName = \"Iou\",\n        entityName = \"Iou\"\n      )\n.."
   },
   "75" : {
     "command" : "participant2.topology.vetted_packages.list()",
-    "output" : "res8: Seq[ListVettedPackagesResult] = Vector(\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2023-11-21T16:00:41.982758Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@502a94b6 size=2582 contents=\"\\n\\223\\024\\n\\301\\021\\n\\274\\021\\n\\271\\021\\022 8xi7SfjelEqmNg2t3i9OGbbEhhJR6Vm2J...\">,\n.."
+    "output" : "res8: Seq[ListVettedPackagesResult] = Vector(\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2023-12-18T20:06:59.363184Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@4f5229e size=2582 contents=\"\\n\\223\\024\\n\\301\\021\\n\\274\\021\\n\\271\\021\\022 NoNcLTuFKkZEBj28ieMgFtRTKQ39mMjJJ...\">,\n.."
   },
   "119" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
+    "output" : "darHash : String = \"12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37\""
   },
   "287" : {
     "command" : "participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "res46: String = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\""
+    "output" : "res46: String = \"12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37\""
   },
   "36" : {
     "command" : "val dars = participant2.dars.list(filterName = \"CantonExamples\")",
-    "output" : "dars : Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220cf7693f5858d55ade97827b9ca92d17185bd904914ea5d0150a6cd86b95e0c1c\",\n    name = \"CantonExamples\"\n  )\n)"
+    "output" : "dars : Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12204b56f9730c63911b9d6f57acbce4daaac2c9c29d6aa50182722a4c2bc6b64a37\",\n    name = \"CantonExamples\"\n  )\n)"
   },
   "146" : {
     "command" : "val packages = participant1.packages.list().map(_.packageId).toSet",
-    "output" : "packages : Set[String] = HashSet(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"5921708ce82f4255deb1b26d2c05358b548720938a5a325718dc69f381ba47ff\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"6839a6d3d430c569b2425e9391717b44ca324b88ba621d597778811b2d05031d\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"e22bce619ae24ca3b8e6519281cb5a33b64b3190cc763248b4c3f9ad5087a92c\",\n  \"d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97\",\n  \"6c2c0667393c5f92f1885163068cd31800d2264eb088eb6fc740e11241b2bf06\",\n  \"fdd56e2ece40d67781248bc47663c9112122e35eec580b7e93ee7cfa83cda2cc\",\n.."
+    "output" : "packages : Set[String] = HashSet(\n  \"b1c181d36e9c2e6a540c457fb4e5ae822f11d9a18fb120912770acc889730af2\",\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"5921708ce82f4255deb1b26d2c05358b548720938a5a325718dc69f381ba47ff\",\n  \"616cc046a57fca4ed024b4e7ee5cecf44025f7acc1f1a12991019df69935b6c8\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"6839a6d3d430c569b2425e9391717b44ca324b88ba621d597778811b2d05031d\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"e22bce619ae24ca3b8e6519281cb5a33b64b3190cc763248b4c3f9ad5087a92c\",\n  \"d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97\",\n.."
   },
   "190" : {
     "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Add, participant1.id, packageIds)",
-    "output" : "res29: com.google.protobuf.ByteString = <ByteString@460615d5 size=2384 contents=\"\\n\\315\\022\\n\\373\\017\\n\\366\\017\\n\\363\\017\\022 BNKfe1wxqqwhoi4q3SXf6hz6rPVg5438J...\">"
+    "output" : "res29: com.google.protobuf.ByteString = <ByteString@2671bf8 size=2384 contents=\"\\n\\315\\022\\n\\373\\017\\n\\366\\017\\n\\363\\017\\022 QnTlH1x8fSzH0GzH9SXSXe342JGYmfraJ...\">"
   },
   "47" : {
     "command" : "participant2.packages.list()",
@@ -189,7 +189,7 @@
   },
   "200" : {
     "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove, participant1.id, packageIds, force = true)",
-    "output" : "res30: com.google.protobuf.ByteString = <ByteString@6239c893 size=2386 contents=\"\\n\\317\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 BNKfe1wxqqwhoi4q3SXf6hz6rPVg543...\">"
+    "output" : "res30: com.google.protobuf.ByteString = <ByteString@4e52228d size=2386 contents=\"\\n\\317\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 QnTlH1x8fSzH0GzH9SXSXe342JGYmfr...\">"
   },
   "178" : {
     "command" : "participant1.dars.remove(darHash)",
@@ -197,14 +197,14 @@
   },
   "227" : {
     "command" : "participant1.packages.remove(packageId)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,98b8b97e): Package 6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680 is currently vetted and available to use.\n  Request: RemovePackage(6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680,false)\n  CorrelationId: 98b8b97e9275a9112cd8f04a83f1d170\n  Context: Map(participant -> participant1, tid -> 98b8b97e9275a9112cd8f04a83f1d170, test -> PackageDarManagementDocumentationIntegrationTest)\n  Command ParticipantAdministration$packages$.remove invoked from cmd10000087.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,6c6194f8): Package e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86 is currently vetted and available to use.\n  Request: RemovePackage(e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86,false)\n  CorrelationId: 6c6194f8f4dbe2e067d221241ba5b71f\n  Context: Map(participant -> participant1, tid -> 6c6194f8f4dbe2e067d221241ba5b71f, test -> PackageDarManagementDocumentationIntegrationTest)\n  Command ParticipantAdministration$packages$.remove invoked from cmd10000087.sc:1"
   },
   "222" : {
     "command" : "val packageId = participant1.packages.find(\"Iou\").head.packageId",
-    "output" : "packageId : String = \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\""
+    "output" : "packageId : String = \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\""
   },
   "232" : {
     "command" : "val packageIds = participant1.topology.vetted_packages.list().map(_.item.packageIds).filter(_.contains(packageId)).head",
-    "output" : "packageIds : Seq[com.digitalasset.canton.package.LfPackageId] = Vector(\n  \"6087107abcaa8ebc5a7d2b4831741e858ee2d30867bf7c29289c811c0e44f680\",\n  \"a566728bb2d4ad0103eb11ff8140296f4cea4fc94f1f95ddc6c3e4f983d107f1\",\n.."
+    "output" : "packageIds : Seq[com.digitalasset.canton.package.LfPackageId] = Vector(\n  \"e79d5d0217e0eea6f1f22b45d07034fd8451878721f774ccbac18ea5c4280f86\",\n  \"616cc046a57fca4ed024b4e7ee5cecf44025f7acc1f1a12991019df69935b6c8\",\n.."
   }
 }

--- a/docs/2.9.0/docs/canton/includes/snippet_data/usermanual/upgrading.json
+++ b/docs/2.9.0/docs/canton/includes/snippet_data/usermanual/upgrading.json
@@ -1,29 +1,13 @@
 {
-  "481" : {
-    "command" : "",
-    "output" : ""
-  },
-  "440" : {
-    "command" : "",
-    "output" : ""
-  },
-  "538" : {
-    "command" : "",
-    "output" : ""
-  },
-  "184" : {
-    "command" : "",
+  "628" : {
+    "command" : "participant.domains.modify(\"newdomain\", _.copy(priority=10))",
     "output" : ""
   },
   "189" : {
     "command" : "participant.health.ping(participant)",
-    "output" : "res7: Duration = 568 milliseconds"
+    "output" : "res7: Duration = 1137 milliseconds"
   },
-  "132" : {
-    "command" : "participant.start()",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - failed to initialize participant: There are 6 pending migrations to get to database schema version 7. Currently on version 1.1. Please run `participant.db.migrate` to apply pending migrations\n  Command LocalParticipantReference.start invoked from cmd10000002.sc:1"
-  },
-  "424" : {
+  "522" : {
     "command" : "",
     "output" : ""
   },
@@ -32,95 +16,111 @@
     "output" : ""
   },
   "537" : {
-    "command" : "",
-    "output" : ""
-  },
-  "425" : {
-    "command" : "",
-    "output" : ""
-  },
-  "462" : {
-    "command" : "val config = DomainConnectionConfig(\"newdomain\", newdomain.sequencerConnection)",
-    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'newdomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://127.0.0.1:30848,\n    transportSecurity = false,\n.."
-  },
-  "455" : {
     "command" : "val config = DomainConnectionConfig(\"newdomain\", GrpcSequencerConnection.tryCreate(\"https://127.0.0.1:5018\"))",
-    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'newdomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = https://127.0.0.1:5018,\n    transportSecurity = true,\n.."
+    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'newdomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = https://127.0.0.1:5018,\n    transportSecurity = true\n.."
   },
-  "426" : {
+  "622" : {
     "command" : "",
     "output" : ""
   },
-  "539" : {
-    "command" : "participant.domains.connect_local(newdomain)",
-    "output" : ""
-  },
-  "171" : {
-    "command" : "testdomain.start()",
-    "output" : ""
-  },
-  "536" : {
-    "command" : "",
-    "output" : ""
-  },
-  "183" : {
+  "562" : {
     "command" : "participant.domains.list_connected()",
-    "output" : "res6: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'testdomain',\n    domainId = testdomain::122078500722...,\n    healthy = true\n  )\n)"
-  },
-  "475" : {
-    "command" : "participant.domains.reconnect_all()",
-    "output" : ""
-  },
-  "480" : {
-    "command" : "participant.domains.list_connected()",
-    "output" : "res8: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'newdomain',\n    domainId = newdomain::1220ea53572c...,\n    healthy = true\n  )\n)"
-  },
-  "439" : {
-    "command" : "participant.domains.list_connected()",
-    "output" : "res3: Seq[ListConnectedDomainsResult] = Vector()"
-  },
-  "546" : {
-    "command" : "participant.domains.modify(\"newdomain\", _.copy(priority=10))",
-    "output" : ""
-  },
-  "467" : {
-    "command" : "participant.repair.migrate_domain(\"olddomain\", config)",
-    "output" : ""
-  },
-  "551" : {
-    "command" : "participant.domains.list_registered().map { case (c,_) => (c.domain, c.priority) }",
-    "output" : "res3: Seq[(com.digitalasset.canton.DomainAlias, Int)] = Vector((Domain 'newdomain', 10), (Domain 'olddomain', 0))"
-  },
-  "540" : {
-    "command" : "",
-    "output" : ""
+    "output" : "res8: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'newdomain',\n    domainId = newdomain::1220b421f727...,\n    healthy = true\n  )\n)"
   },
   "159" : {
     "command" : "participant.start()",
     "output" : ""
   },
-  "172" : {
-    "command" : "participant.domains.connect_local(testdomain)",
+  "621" : {
+    "command" : "participant.domains.connect_local(newdomain)",
     "output" : ""
   },
-  "434" : {
+  "516" : {
     "command" : "participant.domains.disconnect(\"olddomain\")",
     "output" : ""
   },
-  "427" : {
-    "command" : "participant.resources.set_resource_limits(ResourceLimits(Some(0), Some(0)))",
+  "557" : {
+    "command" : "participant.domains.reconnect_all()",
+    "output" : ""
+  },
+  "544" : {
+    "command" : "val config = DomainConnectionConfig(\"newdomain\", newdomain.sequencerConnection)",
+    "output" : "config : DomainConnectionConfig = DomainConnectionConfig(\n  domain = Domain 'newdomain',\n  sequencerConnections = Sequencer 'DefaultSequencer' -> GrpcSequencerConnection(\n    endpoints = http://127.0.0.1:32222,\n    transportSecurity = false\n.."
+  },
+  "171" : {
+    "command" : "testdomain.start()",
+    "output" : ""
+  },
+  "506" : {
+    "command" : "",
     "output" : ""
   },
   "178" : {
     "command" : "participant.domains.reconnect_all()",
     "output" : ""
   },
-  "486" : {
+  "184" : {
+    "command" : "",
+    "output" : ""
+  },
+  "619" : {
+    "command" : "",
+    "output" : ""
+  },
+  "132" : {
+    "command" : "participant.start()",
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - failed to initialize participant: There are 6 pending migrations to get to database schema version 7. Currently on version 1.1. Please run `participant.db.migrate` to apply pending migrations\n  Command LocalParticipantReference.start invoked from cmd10000002.sc:1"
+  },
+  "507" : {
+    "command" : "",
+    "output" : ""
+  },
+  "633" : {
+    "command" : "participant.domains.list_registered().map { case (c,_) => (c.domain, c.priority) }",
+    "output" : "res3: Seq[(com.digitalasset.canton.DomainAlias, Int)] = Vector((Domain 'newdomain', 10), (Domain 'olddomain', 0))"
+  },
+  "508" : {
+    "command" : "",
+    "output" : ""
+  },
+  "618" : {
+    "command" : "",
+    "output" : ""
+  },
+  "573" : {
+    "command" : "participant.health.ping(participant)",
+    "output" : "res10: Duration = 930 milliseconds"
+  },
+  "172" : {
+    "command" : "participant.domains.connect_local(testdomain)",
+    "output" : ""
+  },
+  "509" : {
+    "command" : "participant.resources.set_resource_limits(ResourceLimits(Some(0), Some(0)))",
+    "output" : ""
+  },
+  "521" : {
+    "command" : "participant.domains.list_connected()",
+    "output" : "res3: Seq[ListConnectedDomainsResult] = Vector()"
+  },
+  "563" : {
+    "command" : "",
+    "output" : ""
+  },
+  "568" : {
     "command" : "participant.resources.set_resource_limits(ResourceLimits(None, None))",
     "output" : ""
   },
-  "491" : {
-    "command" : "participant.health.ping(participant)",
-    "output" : "res10: Duration = 681 milliseconds"
+  "549" : {
+    "command" : "participant.repair.migrate_domain(\"olddomain\", config)",
+    "output" : ""
+  },
+  "620" : {
+    "command" : "",
+    "output" : ""
+  },
+  "183" : {
+    "command" : "participant.domains.list_connected()",
+    "output" : "res6: Seq[ListConnectedDomainsResult] = Vector(\n  ListConnectedDomainsResult(\n    domainAlias = Domain 'testdomain',\n    domainId = testdomain::1220d743cd2c...,\n    healthy = true\n  )\n)"
   }
 }

--- a/docs/2.9.0/docs/canton/tutorials/getting_started.rst
+++ b/docs/2.9.0/docs/canton/tutorials/getting_started.rst
@@ -27,7 +27,7 @@ Canton is a JVM application. To run it natively you need Java 11 or higher insta
 Alternatively Canton is available as a `docker image <https://hub.docker.com/r/digitalasset/canton-open-source>`__ (see :ref:`Canton docker instructions <docker-instructions>`).
 
 Canton is platform-agnostic. For development purposes, it runs on macOS,
-Linux, and Windows. Linux is the supported platform for production.  
+Linux, and Windows. Linux is the supported platform for production.
 
 Note: Windows garbles the Canton console output
 unless you are running Windows 10 and you enable terminal colors (e.g., by
@@ -43,6 +43,7 @@ The extracted archive has the following structure:
 
   .
   ├── bin
+  ├── config
   ├── daml
   ├── dars
   ├── demo
@@ -52,6 +53,7 @@ The extracted archive has the following structure:
   └── ...
 
 - ``bin``: contains the scripts for running Canton (``canton`` under Unix-like systems and ``canton.bat`` under Windows)
+- ``config``: contains a set of reference configuration files for each node type
 - ``daml``: contains the source code for some sample smart contracts
 - ``dars``: contains the compiled and packaged code of the above contracts
 - ``demo``: contains everything needed to run the interactive Canton demo

--- a/docs/2.9.0/docs/canton/usermanual/apis.rst
+++ b/docs/2.9.0/docs/canton/usermanual/apis.rst
@@ -60,6 +60,9 @@ will default to the built-in ``JVM`` trust store. The file must contain all clie
 the API. The format is just a collection of PEM certificates (in the right order or hierarchy), not a
 java based trust store.
 
+If you want to use mTLS on the Admin API, you must sign the client certificates with the certificate
+defined in the ``trust-collection-file``.
+
 In order to operate the server just with server-side authentication, you can just omit the section
 on ``client-auth``. However, if ``client-auth`` is set to ``require``, then Canton also requires a client certificate,
 as various Canton internal processes will connect to the process itself through the API.
@@ -74,13 +77,12 @@ the default JVM values will be used.
     Error messages on TLS issues provided by the networking library ``netty`` are less than optimal.
     If you are struggling with setting up TLS, please enable ``DEBUG`` logging on the ``io.netty`` logger.
 
-Note that the configuration hierarchy for a `remote participant console <https://docs.daml.com/__VERSION__/canton/scaladoc/com/digitalasset/canton/participant/config/RemoteParticipantConfig.html>`__ is slightly different
-from the in-process console or participant shown above. For configuring a remote console with TLS, please see the `scaladocs for a TlsClientConfig <https://docs.daml.com/__VERSION__/canton/scaladoc/com/digitalasset/canton/config/TlsClientConfig.html>`__
-(see also :ref:`how scaladocs relates to the configuration <configuration_reference>`).
+Note that the configuration hierarchy for a :ref:`remote participant console <canton_remote_console>` is
+slightly different from the in-process console or participant shown above.
 
 If you need to create a set of testing TLS certificates, you can use the following openssl commands:
 
-.. literalinclude:: /canton/includes/mirrored/enterprise/app/src/test/resources/gen-test-certs.sh
+.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/config/tls/gen-test-certs.sh
    :start-after: architecture-handbook-entry-begin: GenTestCerts
    :end-before: architecture-handbook-entry-end: GenTestCerts
 
@@ -145,7 +147,7 @@ The Ledger Api supports `JWT <https://jwt.io/>`_ based authorization checks as d
 
 In order to enable JWT authorization checks, your safe configuration options are
 
-.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/jwt/certificate.conf
+.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/config/jwt/certificate.conf
 
 - ``jwt-rs-256-crt``.
   The participant will expect all tokens to be signed with RS256 (RSA Signature with SHA-256) with the public key loaded from the given X.509 certificate file.
@@ -167,7 +169,7 @@ Instead of specifying the path to a certificate, you can also a
 participant will expect all tokens to be signed with RS256 (RSA Signature
 with SHA-256) with the public key loaded from the given JWKS URL.
 
-.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/jwt/jwks.conf
+.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/config/jwt/jwks.conf
 
 .. warning::
 
@@ -175,7 +177,7 @@ with SHA-256) with the public key loaded from the given JWKS URL.
   that case, the participant will expect all tokens to be signed with
   HMAC256 with the given plaintext secret. This is not considered safe for production.
 
-.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/jwt/unsafe-hmac256.conf
+.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/config/jwt/unsafe-hmac256.conf
 
 .. note:: To prevent man-in-the-middle attacks, it is highly recommended to use
           TLS with server authentication as described in :ref:`tls-configuration` for
@@ -184,10 +186,7 @@ with SHA-256) with the public key loaded from the given JWKS URL.
 Note that you can define multiple authorization plugins. If more than one is defined, the system will use the claim of the
 first auth plugin that does not return Unauthorized.
 
-If no authorization plugins are defined, a default (wildcard) authorization method is used. Under it, all valid ledger API requests are accepted without the system performing any request authorization.
-To explicitly define the default authorization method, use the following configuration:
-
-.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/wildcard.conf
+If no authorization plugins are defined, a default (wildcard) authorization method is used.
 
 Leeway Parameters for JWT Authorization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -200,7 +199,7 @@ Leeway can be defined either specifically for the **Expiration Time ("exp")**, *
 leeway for each of the three specific fields override the default value if present. The leeway parameters should be
 given in seconds and can be defined as in the example configuration below:
 
-.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/jwt/leeway-parameters.conf
+.. literalinclude:: /canton/includes/mirrored/community/app/src/test/resources/documentation-snippets/leeway-parameters.conf
 
 Configuring the Target Audience for JWT Authorization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -234,7 +233,7 @@ ambient contracts that are consistently being fetched or used for non-consuming 
 use cases where a big pool of contracts rotates through a create -> archive -> create-successor cycle.
 Consider adjusting these parameters explicitly if the performance of your specific workflow depends on large caches.
 
-.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/large-ledger-api-cache.conf
+.. literalinclude:: /canton/includes/mirrored/community/app/src/test/resources/documentation-snippets/large-ledger-api-cache.conf
 
 Max Transactions in the In-Memory Fan-Out
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -247,7 +246,7 @@ set this number to 200. The new default setting of 1000 assumes 100 tx/s.
 Consider adjusting these parameters explicitly if the performance of your workflow foresees transaction rates larger
 than 100 tx/s.
 
-.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/api/large-in-memory-fan-out.conf
+.. literalinclude:: /canton/includes/mirrored/community/app/src/test/resources/documentation-snippets/large-in-memory-fan-out.conf
 
 Domain Configurations
 ---------------------

--- a/docs/2.9.0/docs/canton/usermanual/console.rst
+++ b/docs/2.9.0/docs/canton/usermanual/console.rst
@@ -46,13 +46,13 @@ As an example, you might start Canton in daemon mode using
 Assuming now that you've started a participant, you can access this participant using a ``remote-participant``
 configuration such as:
 
-.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/remote/participant1.conf
+.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/config/remote/participant.conf
 
 Naturally, you can then also use the remote configuration to run a script:
 
 .. code-block:: bash
 
-    ./bin/canton daemon -c remote-participant1.conf --bootstrap <some-script>
+    ./bin/canton daemon -c config/remote/participant.conf --bootstrap <some-script>
 
 Please note that a remote node will support almost all commands except a few that a local node supports.
 

--- a/docs/2.9.0/docs/canton/usermanual/docker.rst
+++ b/docs/2.9.0/docs/canton/usermanual/docker.rst
@@ -11,22 +11,14 @@ Running in Docker
 Obtaining the Docker Images
 ---------------------------
 
-The Canton Open Source edition is published to the `digitalasset/canton-open-source dockerhub repository <https://hub.docker.com/r/digitalasset/canton-open-source>`_.
-You can pull the Docker image using
-
-.. code-block:: bash
-
-    docker pull digitalasset/canton-open-source[:version]
-
-Here, the version is optional and by default, the latest version is used. The version ``dev`` is the the current main build.
-Please note that previous versions were called ``canton-community``, before we renamed the artefact to ``canton-open-source``.
-
-If you want to use the edition included with Daml Enterprise, you can download it using
+The Canton Docker images are available for the Daml Enterprise. You can download them using
 
 .. code-block:: bash
 
     docker login digitalasset-canton-enterprise-docker.jfrog.io
-    docker pull digitalasset-canton-enterprise-docker.jfrog.io/digitalasset/canton-enterprise
+    docker pull digitalasset-canton-enterprise-docker.jfrog.io/digitalasset/canton-enterprise[:version]
+
+The version is optional, and the latest version is used by default. The version ``dev`` is the the current main build.
 
 Starting Canton
 ---------------
@@ -37,17 +29,17 @@ For example, to run with our simple topology configuration in interactive consol
 
 .. code-block:: bash
 
-   docker run --rm -it digitalasset/canton-open-source:latest --config simple-topology.conf
+   docker run --rm -it digitalasset-canton-enterprise-docker.jfrog.io/digitalasset/canton-enterprise:latest \
+        --config simple-topology.conf
 
 The ``--rm`` option ensures that the container is removed when the canton process exits.
 The ``-it`` options start the container interactively and provide a TTY for running our console.
 
 The default working directory of the container is ``/canton``.
 
-By default docker will pull the ``latest`` tag containing the latest Canton release.
-As docker will only automatically pull ``latest`` once, ensure you have the latest version by  periodically running ``docker pull digitalasset/canton-open-source``.
-
-Previous releases can be run by specifying their tag ``digitalasset/canton-open-source:2.4.0``.
+By default Docker will pull the ``latest`` tag containing the latest Canton release.
+As Docker will only automatically pull ``latest`` once, ensure you have the latest version by
+periodically running ``docker pull digitalasset-canton-enterprise-docker.jfrog.io/digitalasset/canton-enterprise``.
 
 Configuring Logging
 -------------------
@@ -64,7 +56,8 @@ For example, if you have the local directory ``my-application`` containing your 
 
    docker run --rm -it \
       --volume "$PWD/my-application:/canton/my-application" \
-      digitalasset/canton-open-source --config /canton/my-application/my-config.conf
+      digitalasset-canton-enterprise-docker.jfrog.io/digitalasset/canton-enterprise \
+      --config /canton/my-application/my-config.conf
 
 DARs can be loaded using the same container local path.
 
@@ -75,13 +68,13 @@ Applications using Canton will typically need access to the ledger-api to read f
 Each participant binds the ledger-api to the port specified at the configuration key: ``ledger-api.port``.
 For ``participant1`` in the simple topology example this is set to port 5011.
 
-To expose the ledger-api to port 5011 on the host machine, run docker with the following options:
+To expose the ledger-api to port 5011 on the host machine, run Docker with the following options:
 
 .. code-block:: bash
 
    docker run --rm -it \
       -p 5011:5011 \
-      digitalasset/canton-open-source \
+      digitalasset-canton-enterprise-docker.jfrog.io/digitalasset/canton-enterprise \
       -C canton.participants.participant1.ledger-api.address=0.0.0.0 \
       --config examples/01-simple-topology/simple-topology.conf \
       --bootstrap examples/01-simple-topology/simple-ping.canton
@@ -91,7 +84,7 @@ The ledger-api port for each participant will need to be mapped separately.
 Running Postgres in Docker
 --------------------------
 
-Canton requires an appropriate database to persist data. For this purpose, such a database can also be run in a docker
+Canton requires an appropriate database to persist data. For this purpose, such a database can also be run in a Docker
 container using the following, helpful command:
 
 .. code-block:: bash
@@ -100,7 +93,7 @@ container using the following, helpful command:
         -e POSTGRES_PASSWORD=test-password postgres:14.8-bullseye postgres -c max_connections=500
 
 Please note that the ``--publish`` command allows us to pick the target port which we have to define in the
-Canton configuration file. The ``--rm`` will delete the data store once the docker container is killed. This is
+Canton configuration file. The ``--rm`` will delete the data store once the Docker container is killed. This is
 useful for short-term tests. The ``--shm-size 256mb`` is necessary as Docker will allocate only 64mb of shared memory by
 default which is insufficient for the way Canton uses Postgres.
 
@@ -116,4 +109,4 @@ Postgres you can do using ``psql``
 
 The tables will be managed automatically by Canton. The ``psql`` solution works also if you run multiple nodes on one
 Postgres database which all require separate databases. If you run just one node against one database, you can avoid
-using ``psql`` by adding ``--POSTGRES_DB=participant1`` to above docker command.
+using ``psql`` by adding ``--POSTGRES_DB=participant1`` to above Docker command.

--- a/docs/2.9.0/docs/canton/usermanual/identity_management.rst
+++ b/docs/2.9.0/docs/canton/usermanual/identity_management.rst
@@ -595,7 +595,7 @@ Finally, purge the active contract set on the origin participant:
 .. snippet:: party_migration
     .. success:: participant1.domains.disconnect("mydomain")
     .. success:: repair.party_migration.step4_clean_up_source(alice, participant1, "alice.acs.gz")
-    .. assert:: { Thread.sleep(1000); true // Make sure that pruning timestamp is in the past. }
+    .. assert:: { Thread.sleep(1000); true }
     .. assert:: { participant1.domains.reconnect("mydomain"); true }
     .. assert:: participant1.ledger_api.acs.of_party(alice).isEmpty
 

--- a/docs/2.9.0/docs/canton/usermanual/installation.rst
+++ b/docs/2.9.0/docs/canton/usermanual/installation.rst
@@ -9,42 +9,30 @@ Installing Canton
 =================
 
 This guide will guide you through the process of setting up your Canton nodes to build a distributed Daml
-ledger. You will learn
+ledger. You will learn the following:
 
-#. How to setup and configure a domain
-#. How to setup and configure one or more participant nodes
+#. How to set up and configure a participant node
+#. How to set up and configure an embedded or distributed synchronization domain
+#. How to connect a participant node to a domain
 
-.. note::
+A single Canton process can run multiple nodes, which is very useful for testing and demonstration. In a
+production environment, you typically run one node per process.
 
-    As no topology is the same, this guide will point out different configuration options as notes
-    wherever possible.
-
-
-This guide uses the example configurations you can find in the release bundle under ``example/03-advanced-configuration``
+This guide uses the reference configurations you can find in the release bundle under ``config``
 and explains you how to leverage these examples for your purposes. Therefore, any file named in this guide
-will refer to subdirectories of the advanced configuration example.
-
-If you are using Oracle JVM and testing security provider signatures, note
-that the Canton JAR file embeds the Bouncy Castle provider as a dependency. To
-enable the JVM to verify the signature, put the ``bcprov`` JAR on the
-classpath before the Canton standalone JAR. For example: 
-
-.. code-block:: java
-
-    java -cp bcprov-jdk15on-1.70.jar:canton-with-drivers-2.7.4-all.jar com.digitalasset.canton.CantonEnterpriseApp
-
+refers to subdirectories of the reference configuration example.
 
 Downloading Canton
 ------------------
 
-The Canton Open Source code is available from `Github <https://github.com/digital-asset/daml/releases>`__.
-You can also use our Canton Docker images by following our :ref:`Docker instructions <docker-instructions>`.
+The Canton Open Source version is available from `Github <https://github.com/digital-asset/daml/releases>`__.
 
 Daml Enterprise includes an enterprise version of the Canton ledger. If you have entitlement to Daml Enterprise
 you can download the enterprise version of Canton by following the `Installing Daml Enterprise instructions
 <https://docs.daml.com/getting-started/installation.html#installing-the-enterprise-edition>`__ and downloading the
 appropriate Canton artifact.
 
+You can also use the Daml Enterprise Canton Docker images by following our :ref:`Docker instructions <docker-instructions>`.
 
 Your Topology
 -------------
@@ -65,27 +53,46 @@ every organisation runs only one participant node, except for scaling purposes.
 
 If you want to build up a test-network for yourself, you need at least a participant node and a domain.
 
-..
-   You can either use your own domain or leverage the :ref:`global domain <connect-global-domain>`.
-
-.. todo::
-   `Mention the global domain <https://github.com/DACH-NY/canton/issues/7564>`_
-
-Environment Variables
----------------------
-For our convenience in this guide, we will use a few environment variables to refer to a set of directions.
-Please set the environment variable "CANTON" to point to the place where you have unpacked the canton release bundle.
+The following instructions assume that you are running all commands in the root directory of the release bundle:
 
 .. code-block:: bash
 
-    cd ./canton-X.Y.Z
-    export CANTON=`pwd`
+    cd ./canton-<type>-X.Y.Z
 
-And then set another variable that points to the advanced example directory
+The Config Directory Contents
+-----------------------------
 
-.. code-block:: bash
+The config directory contains a set of reference configuration files, one per node type:
 
-    export CONF="$CANTON/examples/03-advanced-configuration"
+.. code-block:: none
+
+  .
+  └── config
+        ├── shared.conf, sandbox.conf, participant.conf, domain.conf, sequencer.conf, mediator.conf
+        ├── jwt
+        ├── misc
+        ├── monitoring
+        ├── remote
+        ├── storage
+        ├── tls
+        └── utils
+
+- ``participant.conf``: a participant node configuration
+- ``sequencer.conf``, ``mediator.conf``, ``manager.conf``: a sequencer, mediator, and manager node configuration for a Daml
+  Enterprise synchronization domain deployment.
+- ``domain.conf``: an embedded domain, which runs all the three domain processes in one node (the only open source domain option).
+- ``sandbox.conf``: a simple setup for a single participant node connected to a single domain node, using in-memory stores for testing.
+
+In addition, you'll find the following files and directories:
+
+- ``shared.conf``: a shared configuration file that is included by all other configurations.
+- ``jwt``: contains JWT configuration files for the Ledger API.
+- ``misc``: contains miscellaneous configuration files useful for debugging and development.
+- ``monitoring``: contains configuration files to enable metrics and tracing.
+- ``remote``: contains configuration files to connect Canton console to remote nodes.
+- ``storage``: a directory containing storage configuration files for the various storage options.
+- ``tls``: contains TLS configuration files for the various APIs and a script to generate test certificates.
+- ``utils``: contains utility scripts, mainly to set up the database.
 
 Selecting your Storage Layer
 ----------------------------
@@ -94,17 +101,19 @@ In order to run any kind of node, you need to decide how and if you want to pers
 data. You can choose not to persist data and instead use in-memory stores that are deleted on node restart,
 or you can persist data using ``Postgres`` or ``Oracle`` databases.
 
-For this purpose, there are some storage :ref:`mixin configurations <configuration-mixin>` (``storage/``) defined.
-These storage mixins can be used with any of the node configurations. The in-memory configurations just work out of the
-box without further configuration. The database based persistence will be explained in a subsequent section,
-as you first need to initialise the database.
+For this purpose, there are some storage :ref:`mixin configurations <configuration-mixin>` (``config/storage/``) defined.
 
-The mixins work by defining a shared variable which can be referenced by any node configuration
+These storage mixins can be used with any of the node configurations. All the reference examples include the ``config/shared.conf``,
+which in turn by default includes ``postgres.conf``. Alternatively, the in-memory configurations just work out of the
+box without further configuration, but won't persist any data. You can change the include within
+``config/shared.conf``.
+
+The mixins work by defining a shared variable, which can be referenced by any node configuration
 
 ::
 
     storage = ${_shared.storage}
-    storage.parameters.databaseName = "participant1"
+    storage.parameters.databaseName = "canton_participant"
 
 If you ever see the following error: ``Could not resolve substitution to a value: ${_shared.storage}``, then
 you forgot to add the persistence mixin configuration file.
@@ -113,111 +122,96 @@ you forgot to add the persistence mixin configuration file.
 
     Please also consult the more :ref:`detailed section on persistence configurations <persistence-config>`.
 
+Canton will manage the database schema for you. You don't need to create any tables or indexes.
+
 .. _persistence_using_postgres:
 
 Persistence using Postgres
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-While in-memory is great for testing and demos, for more serious tasks, you need to use a database as a persistence layer.
+While in-memory is great for testing and demos, for any production use, you'll need to use a database as a persistence layer.
 Both the community version and the enterprise version support `Postgres <https://www.postgresql.org/>`__ as a persistence
-layer. Make sure you have a running Postgres server and create one database per node.
+layer. Daml Enterprise also supports :ref:`Oracle as the persistence backend <persistence-oracle>`, but Postgres is recommended, which
+is used in the following instructions.
+
+Make sure you have a running Postgres server. Create one database per node.
 
 Canton is tested on a selection of the `currently supported Postgres versions <https://www.postgresql.org/support/versioning/>`__.
 See the `Canton release notes <https://github.com/digital-asset/canton/releases>`__ for the specific Postgres version
 used to test a particular Canton release.
 
-The Postgres storage mixin is provided by the file ``storage/postgres.conf``.
+.. _postgres_helper:
 
-If you just want to experiment, you can use `Docker <https://www.docker.com/>`__ to get a Postgres database up and
-running quickly. For best results, choose a  `Docker Postgres image <https://hub.docker.com/_/postgres/>`__ that matches
-the `tested Postgres version <https://github.com/digital-asset/canton/releases>`__.
+Creating the Database and the User
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Here are a few illustrative commands that come in handy.
-
-First, pull Postgres and start it up.
-
-.. code-block:: bash
-
-    docker pull postgres:14.8-bullseye
-    docker run --rm --name pg-docker -e POSTGRES_PASSWORD=docker -d -p 5432:5432 postgres:14.8-bullseye
-
-Then, you can run ``psql`` using:
+In `util/postgres` you can find a script ``db.sh`` which helps configure the database, and optionally
+start a Docker based Postgres instance. Assuming you have `Docker <https://www.docker.com/>`__ installed, you
+can run:
 
 .. code-block:: bash
 
-    docker exec -it pg-docker psql -U postgres -d postgres
+    cd ./config/util/postgres
+    ./db.sh start [durable]
+    ./db.sh setup
 
-This will invoke ``psql`` interactively. You can exit the prompt with Ctrl-D. If you want to just cat commands, change ``-it`` to ``-i`` in
-above command.
+The db.sh will read the connection settings from ``config/util/postgres/db.env`` if they aren't already set by environment variables.
+The script will start a non-durable Postgres instance (use ``start durable`` if you want to keep the data between restarts),
+and create the databases defined in ``config/util/postgres/databases``.
 
-Then, create a user for the database using the following SQL command
+Other useful commands are:
 
-.. code-block:: sql
+- ``create-user``: To create the user as defined in ``db.env``.
+- ``resume``: To resume a previously stopped Docker-based Postgres instance.
+- ``drop``: Drop the created databases.
 
-    create user canton with encrypted password 'supersafe';
+Configure the Connectivity
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-and create a new database for each node, granting the newly created user appropriate permissions
+You can provide the connectivity settings either by editing the file ``config/storage/postgres.conf`` or by setting
+respective environment variables (see the file for which ones need to be set):
 
-.. code-block:: sql
+.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/config/utils/postgres/db.env
+    :start-after: user-manual-entry-begin: PostgresDbEnvConfiguration
+    :end-before: user-manual-entry-end: PostgresDbEnvConfiguration
 
-    create database participant1;
-    grant all privileges on database participant1 to canton;
+Tuning the Database
+^^^^^^^^^^^^^^^^^^^
 
-These commands create a database named ``participant1`` and grant the user named ``canton`` access to it using the
-password ``supersafe``. Needless to say, you should use your own, secure password.
+Please note that Canton requires a properly sized and correctly configured database. Please consult
+the :ref:`Postgres performance guide <postgres-performance-tuning>` for further information.
 
-In order to use the storage mixin, you need to either write these settings into the configuration file, or
-pass them using environment variables:
+Generate the TLS Certificates
+-----------------------------
 
-.. code-block:: bash
+The reference example configurations use TLS to secure the APIs. You can find the configuration files in
+``config/tls``. The configuration files are split by different APIs. The configuration files are:
 
-    export POSTGRES_USER=canton
-    export POSTGRES_PASSWORD=supersafe
+- ``tls-ledger-api.conf``: TLS configuration for the Ledger API, exposed by the participant node.
+- ``mtls-admin-api.conf``: TLS configuration for the Administration API, exposed by all node types.
+- ``tls-public-api.conf``: TLS configuration for the Public API, exposed by the sequencer and domain node.
 
-If you want to run also other nodes with Postgres, you need to create additional databases, one for each.
+The client authentication on the Public API is built in and cannot be disabled. It uses specific signing keys
+associated with the node's identity. The Ledger API supports :ref:`JWT based authentication <ledger-api-jwt-configuration>`.
+On the Admin API, you can enable mTLS. Please consult the :ref:`TLS documentation section <tls-configuration>` for
+further information.
 
-You can reset the database by dropping then re-creating it:
+If you want to start with a simple setup, you can use the provided script ``config/tls/gen-test-certs.sh`` to generate
+a set of self-signed certificates (which must include the correct SAN entries for the address the node will bind to).
 
-.. code-block:: sql
-
-    drop database participant1;
-    create database participant1;
-    grant all privileges on database participant1 to canton;
-
-.. note::
-
-    The storage mixin provides you with an initial configuration. Please consult the more :ref:`extended documentation <persistence-config>`
-    for further options.
-
-If you are setting up a few nodes for a test network, you can use a little helper script to create the SQL commands
-to setup users and databases:
-
-.. code-block:: bash
-
-   python3 examples/03-advanced-configuration/storage/dbinit.py \
-      --type=postgres --user=canton --password=<choose-wisely> --participants=2 --domains=1 --drop
-
-The command will just create the SQL commands for your convenience. You can pipe the output directly into the
-``psql`` command
-
-.. code-block:: bash
-
-   python3 examples/03-advanced-configuration/storage/dbinit.py ... | psql -p 5432 -h localhost ...
+Alternatively, you can also skip this step by commenting out the TLS includes in the respective configuration files.
 
 Setting up a Participant
 ------------------------
 
-Now that you have made your persistence choice (assuming Postgres hereafter, for
-Oracle refer to :ref:`Oracle Persistence <persistence-oracle>`), you could start
-your participant just by using one of the example files such as
-``$CONF/nodes/participant1.conf`` and start the Canton process using the
-``Postgres`` persistence mixin:
+Start your participant by using the reference example ``config/participant.conf``:
 
 .. code-block:: bash
 
-    $CANTON/bin/canton -c $CONF/storage/postgres.conf -c $CONF/nodes/participant1.conf
+    ./bin/canton [daemon] -c config/participant.conf
 
-While this would work, we recommend that you rename your node by changing the configuration file appropriately.
+The argument ``daemon`` is optional. If omitted, the node will start with an interactive console. There are
+various command line options available, for example to further tune the :ref:`logging configuration <logging>`.
 
 .. note::
 
@@ -234,21 +228,15 @@ Secure the APIs
 
 #. By default, all APIs in Canton are only accessible from localhost. If you want to connect to your node from other
    machines, you need to bind to ``0.0.0.0`` instead of localhost. You can do this by setting
-   ``address = 0.0.0.0`` within the respective API configuration sections or include the ``api/public.conf``
-   configuration mixin.
+   ``address = 0.0.0.0`` or to the desired network name within the respective API configuration sections.
 
-#. The participant node is managed through the administration API. If you use the console, almost all requests will
-   go through the administration API. We recommend that you setup mutual TLS authentication as described in
+#. All nodes are managed through the administration API. Whenever you use the console, almost all requests will
+   go through the administration API. It is recommended that you set up mutual TLS authentication as described in
    the :ref:`TLS documentation section <tls-configuration>`.
 
 #. Applications and users will interact with the participant node using the ledger API. We recommend that you secure your
-   API by using TLS. You should also authorize your clients using either JWT or TLS client certificates. The TLS configuration
-   is the same as on the administration API.
-
-#. In the example set, there are a set of additional configuration options which allow you to define various
-   `JWT <https://jwt.io>`__ based authorizations checks, enforced by the ledger API server. The settings map exactly to the
-   options documented as part of the `Daml SDK <https://docs.daml.com/tools/sandbox.html#running-with-authentication>`__.
-   There are a few configuration mix-ins defined in ``api/jwt`` for your convenience.
+   API by using TLS. You should also :ref:`authorize your clients using JWT tokens <ledger-api-jwt-configuration>`.
+   The reference configuration contains a set of configuration files in ``config/jwt``, which you can use as a starting point.
 
 Configure Applications, Users and Connection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -263,54 +251,89 @@ Canton distinguishes static from dynamic configuration.
 If you don't know how to connect to domains, onboard parties or provision Daml code, please read the
 :ref:`getting started guide <canton-getting-started>`.
 
-.. todo::
-   `Mention the global domain <https://github.com/DACH-NY/canton/issues/7564>`_
+Setting up a Synchronization Domain
+-----------------------------------
 
-..
-  .. _connect-global-domain:
-  Connect to the Global Domain
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  We are currently operating a global domain. Right now, it is still a testnet, which we reset from time to time. You can
-  connect to it using
-  ::
-      participant1.domains.connect("global", "https://canton.global")
+Your participant node is now ready to connect to other participants to form a distributed ledger. The connection
+is facilitated by a synchronization domain, which is formed by three separate processes:
 
+- a sequencer, which is responsible for ordering encrypted messages
+- a mediator, which is responsible for aggregating validation responses by the individual participants
+- a domain manager, which is responsible to verify the validity of topology changes (distributed configuration changes)
+  before they are distributed on the domain
 
-Setting up a Domain
--------------------
-In order to setup a domain, you need to decide what kind of domain you want to run. We provide integrations for
-different domain infrastructures. These integrations have different levels of maturity. Your current options are
+These nodes don't store any ledger data, but just facilitate the communication between the participants.
 
-#. Postgres based domain (simplest choice)
-#. :ref:`Oracle based domain <oracle-domain>`
-#. Hyperledger Fabric based domain
-#. Ethereum based domain (demo)
+In order to set up a synchronization domain, you need to decide what kind of driver you want to use for the sequencer.
+Drivers are provided for different infrastructures types. These drivers have different levels of fidelity in terms of
+trust and performance. Your current options are the following:
 
-This section will explain how to setup an in-process based domain using Postgres. All other domains are a set of
-microservices and part of the Enterprise edition. In any case, you will need to operate the main domain
-process which is the point of contact where participants connect to for the initial handshake and parameter download.
-The details of how to set this up for other domains than the in-process based Postgres domain are covered by the individual documentations.
+#. Postgres-based domain
+#. :ref:`Oracle-based domain <oracle-domain>`
+#. Hyperledger Fabric-based domain
+#. Ethereum-based domain
 
-.. note::
+In the near future, there will also be a native Canton BFT driver (which will be used for the `Canton Network <https://canton.network/>`__).
 
-   Please contact us at sales@digitalasset.com to get access to the Fabric or Ethereum based integration.
+This section explains how to set up a Postgres-based synchronization domain. Please consult :ref:`the Enterprise driver section <canton-enterprise-drivers>`
+with respect to the other drivers.
 
+Using an Embedded Synchronization Domain
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The domain requires independent of the underlying ledger a place to store some governance data (or also the messages in
-transit in the case of Postgres based domains). The configuration settings for this storage are equivalent to the
-settings used for the participant node.
-
-Once you have picked the storage type, you can start the domain using
+The simplest way to run a synchronization domain is to use the embedded configuration which runs all three processes
+in a single node. Using the same storage (but different database name) as configured for the participant node,
+you can start the domain using:
 
 .. code-block:: bash
 
-    $CANTON/bin/canton -c $CONF/storage/postgres.conf -c $CONF/nodes/domain1.conf
+    ./bin/canton -c config/domain.conf
+
+The embedded domain is your only choice if you are using the community version of Canton. It supports crash recovery,
+but not high availability.
+
+Using Microservices
+~~~~~~~~~~~~~~~~~~~
+
+If you are using Daml Enterprise, you can start the domain processes as separate microservices:
+
+.. code-block:: bash
+
+    ./bin/canton daemon -c config/[mediator|sequencer|manager].conf
+
+Before the nodes work together, they need to be initialized and connected. Consult the
+detailed guide :ref:`on how to bootstrap a domain <domain_bootstrapping>`.
+
+Generally, you can connect the nodes using either the embedded console (if they run in the same process)
+or through the remote console:
+
+.. code-block:: bash
+
+    ./bin/canton -c config/remote/mediator.conf,config/remote/manager.conf,config/remote/sequencer.conf
+
+Subsequently, just run the boostrap command:
+
+.. code-block:: scala
+
+    manager.setup.bootstrap_domain(sequencers.all, mediators.all)
+
+Connect the Participant
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The final step is to connect the participant to the domain. Refer to :ref:`the connectivity guide <sequencer_connections>`
+for detailed instructions. In the simplest case, you just need to run the following command in the participant's' console:
+
+.. code-block:: scala
+
+    participant.domains.connect("domain", "https://localhost:10018", certificatesPath = "config/tls/root-ca.crt")
+
+The certificate is explicitly provided, as the self-signed test certificates are not trusted by default.
 
 Secure the APIs
 ~~~~~~~~~~~~~~~
 
-#. As with the participant node, all APIs bind by default to localhost. You need to bind to ``0.0.0.0`` if you want to
-   access the APIs from other machines. Again, you can use the appropriate mixin ``api/public.conf``.
+#. As with the participant node, all APIs bind by default to localhost. If you want to connect to your node from other
+   machines, you need to bind to the right interface or to ``0.0.0.0``.
 #. The administration API should be secured using client certificates as described in :ref:`TLS documentation section <tls-configuration>`.
 #. The public API needs to be properly secured using TLS. Please follow the :ref:`corresponding instructions <public-api-configuration>`.
 
@@ -318,10 +341,8 @@ Next Steps
 ~~~~~~~~~~
 The above configuration provides you with an initial setup. Without going into details, the next steps would be:
 
-#. Configure who can join the domain by setting an appropriate permissioning strategy (default is "everyone can join").
-#. Configure domain parameters
-#. Setup a service agreements which any client connecting has to sign before using the domain.
-
+#. Control who can join the domain by :ref:`configuring the domain to be permissioned<permissioned-domains>` (default is "everyone can join").
+#. Create high availability setups for :ref:`your synchronization domain <components-for-ha>` or :ref:`your participants <ha_participant_arch>`.
 
 Multi-Node Setup
 ----------------
@@ -332,4 +353,4 @@ with several separate configuration files (which get merged together).
 
 .. code-block:: bash
 
-    $CANTON/bin/canton -c $CONF/storage/postgres.conf -c $CONF/nodes/domain1.conf,$CONF/nodes/participant1.conf
+    ./bin/canton -c config/participant.conf -c config/sequencer.conf,config/mediator.conf -c config/manager.conf

--- a/docs/2.9.0/docs/canton/usermanual/monitoring.rst
+++ b/docs/2.9.0/docs/canton/usermanual/monitoring.rst
@@ -80,8 +80,6 @@ The following other key metrics are monitored:
 
 This list is not exhaustive. It highlights the most important metrics.
 
-.. _logging:
-
 Set Up Metrics Scraping
 -----------------------
 
@@ -457,6 +455,8 @@ runtime_jvm_memory_pool
   - **pool**: Defined pool name.
   - **type**: Can be ``committed``, ``used`` or ``max``
 
+
+.. _logging:
 
 Logging
 -------

--- a/docs/2.9.0/docs/canton/usermanual/repairing.rst
+++ b/docs/2.9.0/docs/canton/usermanual/repairing.rst
@@ -98,7 +98,7 @@ Finally, run the following commands from the "canton-X.Y.Z" directory to set up 
 .. code-block:: bash
 
     export CANTON=`pwd`
-    export CONF="$CANTON/examples/03-advanced-configuration"
+    export CONF="$CANTON/config"
     export IMPORT="$CANTON/examples/07-repair"
     bin/canton \
       -c $IMPORT/participant1.conf,$IMPORT/participant2.conf,$IMPORT/participant3.conf,$IMPORT/participant4.conf \
@@ -212,7 +212,7 @@ and run the following commands from the "canton-X.Y.Z" directory to set up the i
 .. code-block:: bash
 
     export CANTON=`pwd`
-    export CONF="$CANTON/examples/03-advanced-configuration"
+    export CONF="$CANTON/config"
     export REPAIR="$CANTON/examples/07-repair"
     bin/canton \
       -c $REPAIR/participant1.conf,$REPAIR/participant2.conf,$REPAIR/domain-repair-lost.conf,$REPAIR/domain-repair-new.conf \

--- a/docs/2.9.0/docs/canton/usermanual/static_conf.rst
+++ b/docs/2.9.0/docs/canton/usermanual/static_conf.rst
@@ -100,7 +100,7 @@ to create shared configuration items that refer to environment variables.
 A handy example is the following, which allows to share database
 configuration settings in a setup involving several participant or domain nodes:
 
-.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/examples/03-advanced-configuration/storage/postgres.conf
+.. literalinclude:: /canton/includes/mirrored/community/app/src/pack/config/storage/postgres.conf
 
 Such a definition can subsequently be referenced in the actual node definition:
 

--- a/docs/2.9.0/docs/tools/sandbox.rst
+++ b/docs/2.9.0/docs/tools/sandbox.rst
@@ -124,9 +124,9 @@ Below, you can see an example config. For more details on TLS, refer to
    canton.participants.sandbox.ledger-api {
      tls {
        // the certificate to be used by the server
-       cert-chain-file = "./tls/participant.crt"
+       cert-chain-file = "./tls/ledger-api.crt"
        // private key of the server
-       private-key-file = "./tls/participant.pem"
+       private-key-file = "./tls/ledger-api.pem"
        // trust collection, which means that all client certificates will be verified using the trusted
        // certificates in this store. if omitted, the JVM default trust store is used.
        trust-collection-file = "./tls/root-ca.crt"

--- a/docs/2.9.0/docs/tools/trigger-service/index.rst
+++ b/docs/2.9.0/docs/tools/trigger-service/index.rst
@@ -160,10 +160,10 @@ alongside a few annotations with regards to the meaning of the configuration key
       //   enabled = "true"
       //
       //   // the certificate to be used by the server
-      //   cert-chain-file = "/path/to/participant.crt"
+      //   cert-chain-file = "/path/to/ledger-api.crt"
       //
       //   // private key of the server
-      //   private-key-file = "/path/to/participant.pem"
+      //   private-key-file = "/path/to/ledger-api.pem"
       //
       //   // trust collection, which means that all client certificates that will be verified using the trusted
       //   // certificates in this store. If omitted, the JVM default trust store is used.

--- a/docs/2.9.0/versions.json
+++ b/docs/2.9.0/versions.json
@@ -1,6 +1,6 @@
 {
   "daml": "2.8.0-snapshot.20231118.12382.0.v86cb8054",
-  "canton": "2.8.0-snapshot.20231120.11569.0.v2461ac9b",
+  "canton": "2.9.0-snapshot.20231219.11655.0.v11e7e1e8",
   "daml_finance": "1.4.0",
   "canton_drivers": "0.1.9"
 }


### PR DESCRIPTION
Before, the installation guide was based on the advanced config example, which was guiding people through the process by starting with the simplest example and then calling out options.

Now, we start with a full example that comes with TLS, JWT, Storage etc, where a client can then decide to incrementally remove configurations instead.

The docs changes are related to https://github.com/DACH-NY/canton/pull/15882