### PR TITLE
Daml Finance: Update version

### DIFF
--- a/docs/2.9.0/versions.json
+++ b/docs/2.9.0/versions.json
@@ -1,6 +1,6 @@
 {
   "daml": "2.8.0-snapshot.20231118.12382.0.v86cb8054",
   "canton": "2.8.0-snapshot.20231120.11569.0.v2461ac9b",
-  "daml_finance": "1.3.11",
+  "daml_finance": "1.4.0",
   "canton_drivers": "0.1.9"
 }

--- a/docs/3.0.0/versions.json
+++ b/docs/3.0.0/versions.json
@@ -1,6 +1,6 @@
 {
   "daml": "2.8.0-snapshot.20231103.12304.0.v6af384a8",
   "canton": "3.0.0-snapshot.20231214.12034.0.v58d298aa",
-  "daml_finance": "1.3.11",
+  "daml_finance": "1.4.0",
   "canton_drivers": "0.1.9"
 }


### PR DESCRIPTION
Updates daml finance version for `2.9.0` and `3.0.0`.