### PR TITLE
Added inconsistent snapshot release to list of broken snapshots

### DIFF
--- a/bin/publish-snapshots
+++ b/bin/publish-snapshots
@@ -62,6 +62,7 @@ broken() (
 2.8.0-snapshot.20231129.0
 2.8.0-snapshot.20231206.0
 2.8.0-snapshot.20231213.0
+2.9.0-snapshot.20231220.0
 EOF
   echo "$known_broken" | grep $version >/dev/null
 )


### PR DESCRIPTION
Publishing the snapshot 2.9.0-snapshot.20231220.0 docs failed because the docs in the repository can not be built with canton 2023-12-15, but require at least 2023-12-19.