### PR TITLE
pin Sphinx deps

### DIFF
--- a/docs/2.6.5/requirements.txt
+++ b/docs/2.6.5/requirements.txt
@@ -3,5 +3,8 @@ sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-qthelp==1.0.3
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/2.6.5/requirements.txt
+++ b/docs/2.6.5/requirements.txt
@@ -2,5 +2,6 @@ Sphinx==4.3.1
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
 sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/2.6.5/requirements.txt
+++ b/docs/2.6.5/requirements.txt
@@ -1,5 +1,6 @@
 Sphinx==4.3.1
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
+sphinxcontrib-applehelp==1.0.4
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/2.7.6/requirements.txt
+++ b/docs/2.7.6/requirements.txt
@@ -3,5 +3,8 @@ sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-qthelp==1.0.3
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/2.7.6/requirements.txt
+++ b/docs/2.7.6/requirements.txt
@@ -2,5 +2,6 @@ Sphinx==4.3.1
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
 sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/2.7.6/requirements.txt
+++ b/docs/2.7.6/requirements.txt
@@ -1,5 +1,6 @@
 Sphinx==4.3.1
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
+sphinxcontrib-applehelp==1.0.4
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/2.8.0/requirements.txt
+++ b/docs/2.8.0/requirements.txt
@@ -3,5 +3,8 @@ sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-qthelp==1.0.3
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/2.8.0/requirements.txt
+++ b/docs/2.8.0/requirements.txt
@@ -2,5 +2,6 @@ Sphinx==4.3.1
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
 sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/2.8.0/requirements.txt
+++ b/docs/2.8.0/requirements.txt
@@ -1,5 +1,6 @@
 Sphinx==4.3.1
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
+sphinxcontrib-applehelp==1.0.4
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/2.9.0/requirements.txt
+++ b/docs/2.9.0/requirements.txt
@@ -3,5 +3,8 @@ sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-qthelp==1.0.3
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/2.9.0/requirements.txt
+++ b/docs/2.9.0/requirements.txt
@@ -2,5 +2,6 @@ Sphinx==4.3.1
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
 sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/2.9.0/requirements.txt
+++ b/docs/2.9.0/requirements.txt
@@ -1,5 +1,6 @@
 Sphinx==4.3.1
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
+sphinxcontrib-applehelp==1.0.4
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/3.0.0/requirements.txt
+++ b/docs/3.0.0/requirements.txt
@@ -4,5 +4,8 @@ sphinx-copybutton==0.5.1
 sphinx-tabs==3.4.0
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-qthelp==1.0.3
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/3.0.0/requirements.txt
+++ b/docs/3.0.0/requirements.txt
@@ -3,5 +3,6 @@ sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
 sphinx-tabs==3.4.0
 sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/3.0.0/requirements.txt
+++ b/docs/3.0.0/requirements.txt
@@ -2,5 +2,6 @@ Sphinx==4.3.1
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
 sphinx-tabs==3.4.0
+sphinxcontrib-applehelp==1.0.4
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/draft/requirements.txt
+++ b/docs/draft/requirements.txt
@@ -3,5 +3,8 @@ sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-qthelp==1.0.3
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/draft/requirements.txt
+++ b/docs/draft/requirements.txt
@@ -2,5 +2,6 @@ Sphinx==4.3.1
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
 sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0

--- a/docs/draft/requirements.txt
+++ b/docs/draft/requirements.txt
@@ -1,5 +1,6 @@
 Sphinx==4.3.1
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.1
+sphinxcontrib-applehelp==1.0.4
 sphinxext-remoteliteralinclude==0.4.0
 flit==3.8.0


### PR DESCRIPTION
Sphinx 4.3.1 depends on "most recent applehelp", which since Aug 2023 requires Sphinx 5, so our current install is broken. (Same applies to a handful of other Sphinx deps.)

It took some time to surface as the old install was cached by CircleCI (and, likely, it's not affected anyone's local builds either for the same reason).