### PR TITLE
ignore daml3 snapshots

### DIFF
--- a/bin/publish-snapshots
+++ b/bin/publish-snapshots
@@ -21,7 +21,8 @@ snapshots=$(bin/list-hidden-versions \
                     | select(
                               # first element of second element: major version number
                               # converted to number so we can make a numeric comparison
-                             (.[1][0] | tonumber) > 1
+                              ### For now, we ignore daml3 snapshots
+                             (.[1][0] | tonumber) = 2
                             )
                     # we keep just the version number, we do not need the vector of
                     # elements anymore


### PR DESCRIPTION
The canton project is not pushing its docs sources anymore.