### PR TITLE
expand technical ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # https://help.github.com/articles/about-codeowners/
 # Note that accounts or teams mentioned must have WRITE access to the repository.
 
-* @digital-asset/daml-docs @garyverhaegen-da
+* @digital-asset/daml-docs @digital-asset/re


### PR DESCRIPTION
@dylant-da has volunteered to get more involved in the maintenance of the technical side of this repo. I've created the @digital-asset/re team to provide us with a bit of flexibility should other people get involved in the future.