### PR TITLE
ignore 2.8.2

### DIFF
--- a/bin/publish-snapshots
+++ b/bin/publish-snapshots
@@ -64,6 +64,7 @@ broken() (
 2.8.0-snapshot.20231206.0
 2.8.0-snapshot.20231213.0
 2.9.0-snapshot.20231220.0
+2.8.2
 EOF
   echo "$known_broken" | grep $version >/dev/null
 )


### PR DESCRIPTION
We discovered a last-minute bug and will jump to 2.8.3 directly.