### PR TITLE
Make H2 sentence case

### DIFF
--- a/docs/2.9.0/docs/tools/daml-shell/index.rst
+++ b/docs/2.9.0/docs/tools/daml-shell/index.rst
@@ -6,7 +6,7 @@
 Daml Shell
 ##########
 
-Getting Started
+Getting started
 ***************
 
 Prerequisites


### PR DESCRIPTION
Daml docs style is to use sentence case for all headings except H1/page title
([item 13 in style quick ref](https://docs.google.com/document/d/153D6-gI0blsAvlrzReHVyz8RCHUQzzdKnxnpcADlt6c/edit#heading=h.74n7maw54ixb))