### PR TITLE
Deprecate `daml navigator`

### DIFF
--- a/docs/2.9.0/_toc.yml
+++ b/docs/2.9.0/_toc.yml
@@ -274,7 +274,7 @@ subtrees:
       - file: tools/sandbox
         title: "Test: Daml Sandbox"
       - file: tools/navigator/index
-        title: "Visualize: Daml Navigator"
+        title: "Visualize: Daml Navigator (Deprecated)"
       - file: tools/profiler
         title: "Measure: Daml Profiler"
       - file: tools/codegen

--- a/docs/2.9.0/docs/app-dev/bindings-java/quickstart.rst
+++ b/docs/2.9.0/docs/app-dev/bindings-java/quickstart.rst
@@ -61,7 +61,7 @@ The project contains the following files:
 - ``daml.yaml`` is a Daml project config file used by the SDK to find out how to build the Daml project and how to run it.
 - ``daml`` contains the :ref:`Daml code <quickstart-daml>` specifying the contract model for the ledger.
 - ``daml/Tests`` contains :ref:`test scripts <quickstart-scripts>` for the Daml model.
-- ``frontend-config.js`` is a configuration file for the :ref:`Navigator <quickstart-navigator>` frontend.
+- ``frontend-config.js`` is a configuration file for the :ref:`Navigator (Deprecated) <quickstart-navigator>` frontend.
 - ``pom.xml`` and ``src/main/java`` constitute a :ref:`Java application <quickstart-application>` that provides REST services to interact with the ledger.
 
 You will explore these in more detail through the rest of this guide.
@@ -144,7 +144,7 @@ In this section, you will run the quickstart application and get introduced to t
 
 .. _quickstart-navigator:
 
-- Start the :doc:`Navigator </tools/navigator/index>`, a browser-based ledger front-end, by running::
+- Start the :doc:`Navigator (Deprecated) </tools/navigator/index>`, a browser-based ledger front-end, by running::
 
     daml navigator server localhost 6865 --port 7500
 

--- a/docs/2.9.0/docs/app-dev/parties-users.rst
+++ b/docs/2.9.0/docs/app-dev/parties-users.rst
@@ -57,8 +57,8 @@ Daml Triggers
 
 To start a trigger via the trigger service, you still have to supply the party ids for the actAs and readAs claims for your trigger. This could, e.g., come from a party allocation in a Daml script that you wrote to a file via Daml Script’s --output-file. Within your trigger, you get access to those parties via getActAs and getReadAs. To refer to other parties, for example when creating a contract, reference them from an existing contract. If there is no contract, consider creating a special configuration template that lists the parties your trigger should interact with outside of your trigger, and query for that template in your trigger to get access to the parties.
 
-Navigator
-=========
+Navigator (Deprecated)
+======================
 
 Navigator presents you with a list of user ids on the participant as login options. Once logged in, you will interact with the ledger as the primary party of that user. Any field that expects a party provides autocompletion, so if you know the prefix (by having chosen the hint), you don’t have to remember the suffix. In addition, party ids have been shortened in the Navigator UI so that not all of the id is shown. Clicking on a party identifier will copy the full identifier to the system clipboard, making it easier to use elsewhere.
 

--- a/docs/2.9.0/docs/canton/tutorials/getting_started.rst
+++ b/docs/2.9.0/docs/canton/tutorials/getting_started.rst
@@ -542,8 +542,8 @@ Your Development Choices
 While the ``ledger_api`` functions in the Console can be handy for educational purposes, the Daml SDK provides you with much more
 convenient tools to inspect and manipulate the ledger content:
 
-- The browser based `Navigator <https://docs.daml.com/tools/navigator/index.html>`__
-- The console version  `Navigator <https://docs.daml.com/tools/navigator/console.html>`__
+- The browser based `Navigator (Deprecated) <https://docs.daml.com/tools/navigator/index.html>`__
+- The console version  `Navigator (Deprecated) <https://docs.daml.com/tools/navigator/console.html>`__
 - `Daml script <https://docs.daml.com/daml-script>`__ for scripting
 - `Daml triggers <https://docs.daml.com/triggers>`__ for reactive operations
 - `Daml REPL (Deprecated) <https://docs.daml.com/daml-repl>`__ for interactive manipulations
@@ -582,7 +582,7 @@ we recommend the following resources:
    on Canton.
 #. Follow the `Daml documentation <https://docs.daml.com/>`__ to learn how to program new contracts, or check out the
    `Daml Examples <https://daml.com/examples/>`__ to find existing ones for your needs.
-#. Use the `Navigator <https://docs.daml.com/tools/navigator/index.html>`__ for easy Web-based access and manipulation
+#. Use the `Navigator (Deprecated) <https://docs.daml.com/tools/navigator/index.html>`__ for easy Web-based access and manipulation
    of your contracts.
 
 If you want to understand more about Canton:

--- a/docs/2.9.0/docs/concepts/glossary.rst
+++ b/docs/2.9.0/docs/concepts/glossary.rst
@@ -324,8 +324,8 @@ You can also run the Sandbox connected to a PostgreSQL back end, which gives you
 
 See :doc:`/tools/sandbox`.
 
-Navigator
-=========
+Navigator (Deprecated)
+======================
 
 **Navigator** is a tool for exploring what's on the ledger. You can use it to see what contracts can be seen by different parties, and `submit commands <#submitting-commands-writing-to-the-ledger>`__ on behalf of those parties.
 

--- a/docs/2.9.0/docs/daml/intro/12_Testing.rst
+++ b/docs/2.9.0/docs/daml/intro/12_Testing.rst
@@ -29,7 +29,7 @@ There are three primary tools available in the SDK to test and interact with Dam
    3. Start a Sandbox and run against that for regression testing against an actual Ledger API.
    4. Run against any other already running Ledger.
 
-:doc:`Daml Navigator </tools/navigator/index>`
+:doc:`Daml Navigator (Deprecated) </tools/navigator/index>`
 
   Daml Navigator is a UI that runs against a Ledger API and allows interaction with contracts.
 

--- a/docs/2.9.0/docs/support/component-statuses.rst
+++ b/docs/2.9.0/docs/support/component-statuses.rst
@@ -308,13 +308,13 @@ Developer Tools
      -
      -
    * - :doc:`Daml Navigator Development UI </tools/navigator/index>` (``daml navigator server``)
-     - Stable
+     - Deprecated
      -
    * - Navigator Config File Creation (``daml navigator create-config``)
-     - Stable
+     - Deprecated
      -
    * - Navigator graphQL Schema (``daml navigator dump-graphql-schema``)
-     - Labs
+     - Labs, Deprecated
      -
    * - **Daml REPL Interactive Shell (Deprecated)**
      -

--- a/docs/2.9.0/docs/tools/assistant.rst
+++ b/docs/2.9.0/docs/tools/assistant.rst
@@ -23,7 +23,7 @@ Daml Assistant (``daml``)
     To specify additional options for sandbox/navigator/the HTTP JSON API you can use
     ``--sandbox-option=opt``, ``--navigator-option=opt`` and ``--json-api-option=opt``.
   - Launch Sandbox: ``daml sandbox``
-  - Launch Navigator: ``daml navigator``
+  - Launch Navigator (Deprecated): ``daml navigator``
   - Launch the :doc:`/json-api/index`: ``daml json-api``
   - Run :doc:`Daml codegen </tools/codegen>`: ``daml codegen``
 

--- a/docs/2.9.0/docs/tools/navigator/index.rst
+++ b/docs/2.9.0/docs/tools/navigator/index.rst
@@ -1,8 +1,11 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Navigator
-#########
+Navigator (Deprecated)
+######################
+
+.. warning::
+   Since Daml 2.9.0, ``daml navigator`` is deprecated. It will be removed in Daml 3.0.
 
 The Navigator is a front-end that you can use to connect to any Daml Ledger and inspect and modify the ledger. You can use it during Daml development to explore the flow and implications of the Daml models.
 

--- a/docs/2.9.0/docs/tools/sandbox.rst
+++ b/docs/2.9.0/docs/tools/sandbox.rst
@@ -8,7 +8,7 @@ Daml Sandbox
 
 The Daml Sandbox, or Sandbox for short, is a simple ledger implementation that enables rapid application prototyping by simulating a Daml Ledger.
 
-You can start Sandbox together with :doc:`Navigator </tools/navigator/index>` using the ``daml start`` command in a Daml project. This command will compile the Daml file and its dependencies as specified in the ``daml.yaml``. It will then launch Sandbox passing the just obtained DAR packages. The script specified in the ``init-script`` field in ``daml.yaml`` will be loaded into the ledger. Finally, it launches the navigator connecting it to the running Sandbox.
+You can start Sandbox together with :doc:`Navigator (Deprecated) </tools/navigator/index>` using the ``daml start`` command in a Daml project. This command will compile the Daml file and its dependencies as specified in the ``daml.yaml``. It will then launch Sandbox passing the just obtained DAR packages. The script specified in the ``init-script`` field in ``daml.yaml`` will be loaded into the ledger. Finally, it launches the navigator connecting it to the running Sandbox.
 
 It is possible to execute the Sandbox launching step in isolation by typing ``daml sandbox``.
 


### PR DESCRIPTION
Part of https://github.com/digital-asset/daml/issues/18650

Daml PR: https://github.com/digital-asset/daml/pull/18748
docs.daml.com PR: https://github.com/digital-asset/docs.daml.com/pull/658

Originally, this PR also removed `daml navigator` from the 3.0.0 docs. However, that's a larger piece of work since the navigator is heavily referenced from a few tutorials so they will need to be reworked. I've thus split that off as https://github.com/digital-asset/docs.daml.com/pull/659.