### PR TITLE
fix 2.3 snapshots

### DIFF
--- a/docs/2.3.17/bin/clean
+++ b/docs/2.3.17/bin/clean
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eou pipefail
+
+DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+rm -rf "$DIR"/../workdir
+rm -rf "$DIR"/../docs/workdir


### PR DESCRIPTION
The snapshot script expects `clean` to exist.