### PR TITLE
Clarify description of the log-profile container option

### DIFF
--- a/docs/2.7.9/docs/canton/usermanual/monitoring.rst
+++ b/docs/2.7.9/docs/canton/usermanual/monitoring.rst
@@ -475,7 +475,7 @@ How Canton produces log files can be configured extensively on the command line 
 - ``--log-file-rolling-history=12`` configures the number of historical files to keep when using the rolling appender.
 - ``--log-file-rolling-pattern=YYYY-mm-dd`` configures the rolling file suffix (and therefore the frequency) of how files should be rolled.
 - ``--log-truncate`` configures whether the log file should be truncated on startup.
-- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to STDOUT. It turns off flat file logging to avoid storage leaks due to log files within a container.
+- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to both STDOUT and rolling log files.
 - ``--log-immediate-flush=false`` turns off immediate flushing of the log output to the log file.
 
 Note that if you use ``--log-profile``, the order of the command line arguments matters. The profile settings can be overridden on the command line by placing adjustments after the profile has been selected.

--- a/docs/2.7.9/docs/canton/usermanual/monitoring.rst
+++ b/docs/2.7.9/docs/canton/usermanual/monitoring.rst
@@ -475,7 +475,7 @@ How Canton produces log files can be configured extensively on the command line 
 - ``--log-file-rolling-history=12`` configures the number of historical files to keep when using the rolling appender.
 - ``--log-file-rolling-pattern=YYYY-mm-dd`` configures the rolling file suffix (and therefore the frequency) of how files should be rolled.
 - ``--log-truncate`` configures whether the log file should be truncated on startup.
-- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to both STDOUT and rolling log files.
+- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to both STDOUT and to 10-hour limited rolling log files history (to avoid storage leaks).
 - ``--log-immediate-flush=false`` turns off immediate flushing of the log output to the log file.
 
 Note that if you use ``--log-profile``, the order of the command line arguments matters. The profile settings can be overridden on the command line by placing adjustments after the profile has been selected.

--- a/docs/2.8.3/docs/canton/usermanual/monitoring.rst
+++ b/docs/2.8.3/docs/canton/usermanual/monitoring.rst
@@ -392,7 +392,7 @@ How Canton produces log files can be configured extensively on the command line 
 - ``--log-file-rolling-history=12`` configures the number of historical files to keep when using the rolling appender.
 - ``--log-file-rolling-pattern=YYYY-mm-dd`` configures the rolling file suffix (and therefore the frequency) of how files should be rolled.
 - ``--log-truncate`` configures whether the log file should be truncated on startup.
-- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to STDOUT. It turns off flat file logging to avoid storage leaks due to log files within a container.
+- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to both STDOUT and rolling log files.
 - ``--log-immediate-flush=false`` turns off immediate flushing of the log output to the log file.
 
 Note that if you use ``--log-profile``, the order of the command line arguments matters. The profile settings can be overridden on the command line by placing adjustments after the profile has been selected.

--- a/docs/2.8.3/docs/canton/usermanual/monitoring.rst
+++ b/docs/2.8.3/docs/canton/usermanual/monitoring.rst
@@ -392,7 +392,7 @@ How Canton produces log files can be configured extensively on the command line 
 - ``--log-file-rolling-history=12`` configures the number of historical files to keep when using the rolling appender.
 - ``--log-file-rolling-pattern=YYYY-mm-dd`` configures the rolling file suffix (and therefore the frequency) of how files should be rolled.
 - ``--log-truncate`` configures whether the log file should be truncated on startup.
-- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to both STDOUT and rolling log files.
+- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to both STDOUT and to 10-hour limited rolling log files history (to avoid storage leaks).
 - ``--log-immediate-flush=false`` turns off immediate flushing of the log output to the log file.
 
 Note that if you use ``--log-profile``, the order of the command line arguments matters. The profile settings can be overridden on the command line by placing adjustments after the profile has been selected.

--- a/docs/2.9.0/docs/canton/usermanual/monitoring.rst
+++ b/docs/2.9.0/docs/canton/usermanual/monitoring.rst
@@ -392,7 +392,7 @@ How Canton produces log files can be configured extensively on the command line 
 - ``--log-file-rolling-history=12`` configures the number of historical files to keep when using the rolling appender.
 - ``--log-file-rolling-pattern=YYYY-mm-dd`` configures the rolling file suffix (and therefore the frequency) of how files should be rolled.
 - ``--log-truncate`` configures whether the log file should be truncated on startup.
-- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to STDOUT. It turns off flat file logging to avoid storage leaks due to log files within a container.
+- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to both STDOUT and rolling log files.
 - ``--log-immediate-flush=false`` turns off immediate flushing of the log output to the log file.
 
 Note that if you use ``--log-profile``, the order of the command line arguments matters. The profile settings can be overridden on the command line by placing adjustments after the profile has been selected.

--- a/docs/2.9.0/docs/canton/usermanual/monitoring.rst
+++ b/docs/2.9.0/docs/canton/usermanual/monitoring.rst
@@ -392,7 +392,7 @@ How Canton produces log files can be configured extensively on the command line 
 - ``--log-file-rolling-history=12`` configures the number of historical files to keep when using the rolling appender.
 - ``--log-file-rolling-pattern=YYYY-mm-dd`` configures the rolling file suffix (and therefore the frequency) of how files should be rolled.
 - ``--log-truncate`` configures whether the log file should be truncated on startup.
-- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to both STDOUT and rolling log files.
+- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to both STDOUT and to 10-hour limited rolling log files history (to avoid storage leaks).
 - ``--log-immediate-flush=false`` turns off immediate flushing of the log output to the log file.
 
 Note that if you use ``--log-profile``, the order of the command line arguments matters. The profile settings can be overridden on the command line by placing adjustments after the profile has been selected.

--- a/docs/3.0.0/docs/canton/usermanual/monitoring.rst
+++ b/docs/3.0.0/docs/canton/usermanual/monitoring.rst
@@ -392,7 +392,7 @@ How Canton produces log files can be configured extensively on the command line 
 - ``--log-file-rolling-history=12`` configures the number of historical files to keep when using the rolling appender.
 - ``--log-file-rolling-pattern=YYYY-mm-dd`` configures the rolling file suffix (and therefore the frequency) of how files should be rolled.
 - ``--log-truncate`` configures whether the log file should be truncated on startup.
-- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to STDOUT. It turns off flat file logging to avoid storage leaks due to log files within a container.
+- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to both STDOUT and rolling log files.
 - ``--log-immediate-flush=false`` turns off immediate flushing of the log output to the log file.
 
 Note that if you use ``--log-profile``, the order of the command line arguments matters. The profile settings can be overridden on the command line by placing adjustments after the profile has been selected.

--- a/docs/3.0.0/docs/canton/usermanual/monitoring.rst
+++ b/docs/3.0.0/docs/canton/usermanual/monitoring.rst
@@ -392,7 +392,7 @@ How Canton produces log files can be configured extensively on the command line 
 - ``--log-file-rolling-history=12`` configures the number of historical files to keep when using the rolling appender.
 - ``--log-file-rolling-pattern=YYYY-mm-dd`` configures the rolling file suffix (and therefore the frequency) of how files should be rolled.
 - ``--log-truncate`` configures whether the log file should be truncated on startup.
-- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to both STDOUT and rolling log files.
+- ``--log-profile=container`` provides a default set of logging settings for a particular setup. Only the ``container`` profile is supported, which logs to both STDOUT and to 10-hour limited rolling log files history (to avoid storage leaks).
 - ``--log-immediate-flush=false`` turns off immediate flushing of the log output to the log file.
 
 Note that if you use ``--log-profile``, the order of the command line arguments matters. The profile settings can be overridden on the command line by placing adjustments after the profile has been selected.


### PR DESCRIPTION
The docs at https://docs.daml.com/canton/usermanual/monitoring.html#logging say:

> `--log-profile=container` ...turns off flat file logging
> to avoid storage leaks due to log files within a container.

The wording, "turns off flat file logging" is ambiguous, since it could be interpreted as turning off logging to files. However, that is not the case. You can confirm with the following:

```
docker run --rm -it --volume ./log:/home/nonroot/log digitalasset-docker.jfrog.io/canton-enterprise:2.8.3 --no-tty -C canton.participants.participant1.ledger-api.address=0.0.0.0 -C canton.participants.participant1.ledger-api.port=5011 --log-profile container

exit()

more log/canton.log
```

This PR updates the docs to clarify the actual behavior.