### PR TITLE
make Timestamp parsing consistent across Java versions

### DIFF
--- a/docs/2.8.5/docs/json-api/lf-value-specification.rst
+++ b/docs/2.8.5/docs/json-api/lf-value-specification.rst
@@ -181,6 +181,13 @@ risk that users pass in local times. Valid examples::
 The timestamp must be between the bounds specified by Daml-LF and ISO
 8601, [0001-01-01T00:00:00Z, 9999-12-31T23:59:59.999999Z].
 
+Notes:
+
+* Due to `JDK-8166138: DateTimeFormatter.ISO_INSTANT should handle offsets <https://bugs.openjdk.org/browse/JDK-8166138>`_, when using
+  Java 11, valid ISO 8601 timestamp strings with a TimeZone offset (e.g. ``2016-09-12T16:45:51+01:00``) will be rejected
+* When using Java 17+, all valid ISO 8601 timestamp strings can be parsed and so
+  accepted.
+
 JavaScript
 
 ::

--- a/docs/2.8.5/docs/json-api/lf-value-specification.rst
+++ b/docs/2.8.5/docs/json-api/lf-value-specification.rst
@@ -184,7 +184,7 @@ The timestamp must be between the bounds specified by Daml-LF and ISO
 Notes:
 
 * Due to `JDK-8166138: DateTimeFormatter.ISO_INSTANT should handle offsets <https://bugs.openjdk.org/browse/JDK-8166138>`_, when using
-  Java 11, valid ISO 8601 timestamp strings with a TimeZone offset (e.g. ``2016-09-12T16:45:51+01:00``) will be rejected
+  Java 11, valid ISO 8601 timestamp strings with a TimeZone offset (e.g. ``2016-09-12T16:45:51+01:00``) are rejected
 * When using Java 17+, all valid ISO 8601 timestamp strings can be parsed and so
   accepted.
 


### PR DESCRIPTION
Fixes [#1919](https://github.com/digital-asset/daml/issues/19195)

For 2.x, document the difference in Java 11/17 `Timestamp` parsing for the JSON API.