### PR TITLE
Bump docs/2.9.0 versions

### DIFF
--- a/docs/2.9.0/versions.json
+++ b/docs/2.9.0/versions.json
@@ -1,6 +1,6 @@
 {
-  "daml": "2.8.0-snapshot.20231118.12382.0.v86cb8054",
-  "canton": "2.9.0-adhoc.20240603.12092.0.vaccd5673",
+  "daml": "2.9.0-snapshot.20240606.12826.0.v3d5f2a19",
+  "canton": "2.9.0-snapshot.20240606.12076.0.v93b6022d",
   "daml_finance": "1.4.1",
-  "canton_drivers": "0.1.9"
+  "canton_drivers": "2.9.0-snapshot.20240429.11985.0.vce2948f3"
 }


### PR DESCRIPTION
In preparation for the upcoming `2.9.0` release we should update the `versions.json` to more recent version of the dependencies.