### PR TITLE
Fix broken release links for 2.8.7 (#719)

### DIFF
--- a/docs/2.8.7/bin/setup-sphinx-source-tree
+++ b/docs/2.8.7/bin/setup-sphinx-source-tree
@@ -87,3 +87,13 @@ ln $DIR/../_toc.yml $SPHINX_DIR/source/_toc.yml
 
 # Process canton snippet directives
 python $DIR/canton/snippet_directive.py $SPHINX_DIR/source/canton/includes/snippet_data $SPHINX_DIR/source/canton
+
+# Patch 2.8.7 version to fix download links because artefacts are versioned with 2.8.6
+if [[ "$prefix" == "2.8.7" ]]; then
+    for file in pdf html; do
+      sed -i "s|daml-sdk-{release}-windows.exe|daml-sdk-2.8.6-windows.exe|" $SPHINX_DIR/configs/$file/conf.py
+      sed -i "s|protobufs-{release}.zip|protobufs-2.8.6.zip|" $SPHINX_DIR/configs/$file/conf.py
+      sed -i "s|{release}/ledger-api-test-tool-{release}.jar|2.8.6/ledger-api-test-tool-2.8.6.jar|" $SPHINX_DIR/configs/$file/conf.py
+    done
+fi
+


### PR DESCRIPTION
Details, see #719 

Fixes two release specific links for 2.8.7:
* [Windows download link](https://docs.daml.com/getting-started/installation.html#windows-10)
* [Use the Ledger API With gRPC – Get Started - protobuf download link](https://docs.daml.com/app-dev/grpc/#get-started)