### PR TITLE
Add 2.9.0-rc1 to known broken snapshots

### DIFF
--- a/bin/publish-snapshots
+++ b/bin/publish-snapshots
@@ -66,6 +66,7 @@ broken() (
 2.9.0-snapshot.20231220.0
 2.8.2
 2.9.0-snapshot.20240604.0
+2.9.0-rc1
 EOF
   echo "$known_broken" | grep $version >/dev/null
 )


### PR DESCRIPTION
Publishing snapshots job fails because `2.9.0-rc1` because it points to a canton artefact  which does not include the `preview-version-support.conf`. 
```
Warning, treated as error:
/home/circleci/project/docs/2.9.0/workdir/build/source/source/canton/usermanual/FAQ.rst:176:Include file '/home/circleci/project/docs/2.9.0/workdir/build/source/source/canton/includes/mirrored/community/app/src/test/resources/documentation-snippets/preview-version-support.conf' not found or reading it failed
```

This adds it to the known broken releases.

CI job: https://app.circleci.com/pipelines/github/digital-asset/docs.daml.com/22688/workflows/0d2fabfa-2f04-442a-ba68-ef5f98156ab9/jobs/23438