### PR TITLE
Add safeguards section to explicit contract disclosure docs for 2.9.1 and 3.1

### DIFF
--- a/docs/2.9.1/docs/app-dev/explicit-contract-disclosure.rst
+++ b/docs/2.9.1/docs/app-dev/explicit-contract-disclosure.rst
@@ -267,7 +267,7 @@ These last two steps are executed using the new Daml Script functions supporting
 
 Safeguards
 ------------------------------------------
-Explicit Contract Disclosure usage should always be accompanied by on-ledger contracts to ensure workflows executed based on the disclosed contract's contents conform to on-ledger agreements between the stakeholders (or trusted parties) involved.
+Explicit Contract Disclosure usage should always be accompanied by on-ledger contracts. This ensures that workflows executed based on the disclosed contract's contents conform to on-ledger agreements between the stakeholders (or trusted parties) involved.
 
 In the above example, ``IOU`` contracts between **Buyer** and **Issuer** (a trusted party on the ledger) ensure that the exercising of the ``Offer_Accept`` choice using disclosed contract results in a contractually agreed-upon outcome.
 

--- a/docs/2.9.1/docs/app-dev/explicit-contract-disclosure.rst
+++ b/docs/2.9.1/docs/app-dev/explicit-contract-disclosure.rst
@@ -264,3 +264,23 @@ These last two steps are executed using the new Daml Script functions supporting
 
 .. note:: For an example using Java bindings for client applications, see the
   `Java Bindings StockExchange example project <https://github.com/digital-asset/ex-java-bindings/blob/f474ae83976b0ad197e2fabfce9842fb9b3de907/StockExchange/README.rst>`_.
+
+Safeguards
+------------------------------------------
+Explicit Contract Disclosure usage should always be accompanied by on-ledger contracts to ensure workflows executed based on the disclosed contract's contents conform to on-ledger agreements between the stakeholders (or trusted parties) involved.
+
+In the above example, ``IOU`` contracts between **Buyer** and **Issuer** (a trusted party on the ledger) ensure that the exercising of the ``Offer_Accept`` choice using disclosed contract results in a contractually agreed-upon outcome.
+
+This works by performing several safety checks in the ``IOU_Transfer`` choice within the ``IOU`` contract, which is called from the ``Offer_Accept`` choice.
+
+The ``IOU`` contract provides several safeguards in the ``Offer_Accept`` workflow:
+
+- **Buyer** exercising the ``Offer_Accept`` choice is defined on the ``IOU`` agreement.
+- Creation of an IOU with an same amount for the **Seller** happens atomically with a deduction of the same amount from the **Buyer'** IOU.
+- **Buyer** cannot be deducted and **Seller** cannot receive more than the stipulated value on the ``IOU`` contract.
+
+By ensuring the **Buyer** party expected to execute the ``Offer_Accept`` choice, a trusted **Issuer** party and required terms of execution are clearly defined on an on-ledger multi-signatory ``IOU`` contract, the **Seller** can disclose the ``Offer`` contract and the **Buyer** can execute the ``Offer_Accept`` choice on the disclosed ``Offer`` contract knowing workflow safety is ensured.
+
+If disclosed contracts contain malicious data or are maliciously executed on, the safeguards will prevent unexpected outcomes outside the bounds of the agreement stated on the ``IOU`` contract from resolving.
+
+Generic variants of the discussed safeguards should be implemented when utilizing explicitly disclosed contracts to ensure workflow safety.

--- a/docs/2.9.1/docs/app-dev/explicit-contract-disclosure.rst
+++ b/docs/2.9.1/docs/app-dev/explicit-contract-disclosure.rst
@@ -269,17 +269,17 @@ Safeguards
 ------------------------------------------
 Explicit Contract Disclosure usage should always be accompanied by on-ledger contracts. This ensures that workflows executed based on the disclosed contract's contents conform to on-ledger agreements between the stakeholders (or trusted parties) involved.
 
-In the above example, ``IOU`` contracts between **Buyer** and **Issuer** (a trusted party on the ledger) ensure that the exercising of the ``Offer_Accept`` choice using disclosed contract results in a contractually agreed-upon outcome.
+In the above example, ``IOU`` contracts between *Buyer* and *Issuer* (a trusted party on the ledger) ensure that the exercising of the ``Offer_Accept`` choice using disclosed contract results in a contractually agreed-upon outcome.
 
 This works by performing several safety checks in the ``IOU_Transfer`` choice within the ``IOU`` contract, which is called from the ``Offer_Accept`` choice.
 
 The ``IOU`` contract provides several safeguards in the ``Offer_Accept`` workflow:
 
-- **Buyer** exercising the ``Offer_Accept`` choice is defined on the ``IOU`` agreement.
-- Creation of an IOU with an same amount for the **Seller** happens atomically with a deduction of the same amount from the **Buyer'** IOU.
-- **Buyer** cannot be deducted and **Seller** cannot receive more than the stipulated value on the ``IOU`` contract.
+- *Buyer* exercising the ``Offer_Accept`` choice is defined on the ``IOU`` agreement.
+- Creation of an IOU with the same amount for the *Seller* happens atomically with a deduction of the same amount from the *Buyer'* IOU.
+- *Buyer* cannot be deducted and *Seller* cannot receive more than the stipulated value on the ``IOU`` contract.
 
-By ensuring the **Buyer** party expected to execute the ``Offer_Accept`` choice, a trusted **Issuer** party and required terms of execution are clearly defined on an on-ledger multi-signatory ``IOU`` contract, the **Seller** can disclose the ``Offer`` contract and the **Buyer** can execute the ``Offer_Accept`` choice on the disclosed ``Offer`` contract knowing workflow safety is ensured.
+By ensuring the *Buyer* party expected to execute the ``Offer_Accept`` choice, a trusted **Issuer** party and required terms of execution are clearly defined on an on-ledger ``IOU`` contract with a trusted *Issuer* party as a signatory, the *Seller* can disclose the ``Offer`` contract and the *Buyer* can execute the ``Offer_Accept`` choice on the disclosed ``Offer`` contract knowing workflow safety is ensured.
 
 If disclosed contracts contain malicious data or are maliciously executed on, the safeguards prevent unexpected outcomes.
 

--- a/docs/2.9.1/docs/app-dev/explicit-contract-disclosure.rst
+++ b/docs/2.9.1/docs/app-dev/explicit-contract-disclosure.rst
@@ -281,6 +281,6 @@ The ``IOU`` contract provides several safeguards in the ``Offer_Accept`` workflo
 
 By ensuring the **Buyer** party expected to execute the ``Offer_Accept`` choice, a trusted **Issuer** party and required terms of execution are clearly defined on an on-ledger multi-signatory ``IOU`` contract, the **Seller** can disclose the ``Offer`` contract and the **Buyer** can execute the ``Offer_Accept`` choice on the disclosed ``Offer`` contract knowing workflow safety is ensured.
 
-If disclosed contracts contain malicious data or are maliciously executed on, the safeguards will prevent unexpected outcomes outside the bounds of the agreement stated on the ``IOU`` contract from resolving.
+If disclosed contracts contain malicious data or are maliciously executed on, the safeguards prevent unexpected outcomes.
 
 Generic variants of the discussed safeguards should be implemented when utilizing explicitly disclosed contracts to ensure workflow safety.

--- a/docs/3.1/docs/app-dev/explicit-contract-disclosure.rst
+++ b/docs/3.1/docs/app-dev/explicit-contract-disclosure.rst
@@ -267,7 +267,7 @@ These last two steps are executed using the new Daml Script functions supporting
 
 Safeguards
 ------------------------------------------
-Explicit Contract Disclosure usage should always be accompanied by on-ledger contracts to ensure workflows executed based on the disclosed contract's contents conform to on-ledger agreements between the stakeholders (or trusted parties) involved.
+Explicit Contract Disclosure usage should always be accompanied by on-ledger contracts. This ensures that workflows executed based on the disclosed contract's contents conform to on-ledger agreements between the stakeholders (or trusted parties) involved.
 
 In the above example, ``IOU`` contracts between **Buyer** and **Issuer** (a trusted party on the ledger) ensure that the exercising of the ``Offer_Accept`` choice using disclosed contract results in a contractually agreed-upon outcome.
 

--- a/docs/3.1/docs/app-dev/explicit-contract-disclosure.rst
+++ b/docs/3.1/docs/app-dev/explicit-contract-disclosure.rst
@@ -264,3 +264,23 @@ These last two steps are executed using the new Daml Script functions supporting
 
 .. note:: For an example using Java bindings for client applications, see the
   `Java Bindings StockExchange example project <https://github.com/digital-asset/ex-java-bindings/blob/f474ae83976b0ad197e2fabfce9842fb9b3de907/StockExchange/README.rst>`_.
+
+Safeguards
+------------------------------------------
+Explicit Contract Disclosure usage should always be accompanied by on-ledger contracts to ensure workflows executed based on the disclosed contract's contents conform to on-ledger agreements between the stakeholders (or trusted parties) involved.
+
+In the above example, ``IOU`` contracts between **Buyer** and **Issuer** (a trusted party on the ledger) ensure that the exercising of the ``Offer_Accept`` choice using disclosed contract results in a contractually agreed-upon outcome.
+
+This works by performing several safety checks in the ``IOU_Transfer`` choice within the ``IOU`` contract, which is called from the ``Offer_Accept`` choice.
+
+The ``IOU`` contract provides several safeguards in the ``Offer_Accept`` workflow:
+
+- **Buyer** exercising the ``Offer_Accept`` choice is defined on the ``IOU`` agreement.
+- Creation of an IOU with an same amount for the **Seller** happens atomically with a deduction of the same amount from the **Buyer'** IOU.
+- **Buyer** cannot be deducted and **Seller** cannot receive more than the stipulated value on the ``IOU`` contract.
+
+By ensuring the **Buyer** party expected to execute the ``Offer_Accept`` choice, a trusted **Issuer** party and required terms of execution are clearly defined on an on-ledger multi-signatory ``IOU`` contract, the **Seller** can disclose the ``Offer`` contract and the **Buyer** can execute the ``Offer_Accept`` choice on the disclosed ``Offer`` contract knowing workflow safety is ensured.
+
+If disclosed contracts contain malicious data or are maliciously executed on, the safeguards will prevent unexpected outcomes outside the bounds of the agreement stated on the ``IOU`` contract from resolving.
+
+Generic variants of the discussed safeguards should be implemented when utilizing explicitly disclosed contracts to ensure workflow safety.

--- a/docs/3.1/docs/app-dev/explicit-contract-disclosure.rst
+++ b/docs/3.1/docs/app-dev/explicit-contract-disclosure.rst
@@ -281,6 +281,6 @@ The ``IOU`` contract provides several safeguards in the ``Offer_Accept`` workflo
 
 By ensuring the **Buyer** party expected to execute the ``Offer_Accept`` choice, a trusted **Issuer** party and required terms of execution are clearly defined on an on-ledger multi-signatory ``IOU`` contract, the **Seller** can disclose the ``Offer`` contract and the **Buyer** can execute the ``Offer_Accept`` choice on the disclosed ``Offer`` contract knowing workflow safety is ensured.
 
-If disclosed contracts contain malicious data or are maliciously executed on, the safeguards will prevent unexpected outcomes outside the bounds of the agreement stated on the ``IOU`` contract from resolving.
+If disclosed contracts contain malicious data or are maliciously executed on, the safeguards prevent unexpected outcomes.
 
 Generic variants of the discussed safeguards should be implemented when utilizing explicitly disclosed contracts to ensure workflow safety.

--- a/docs/3.1/docs/app-dev/explicit-contract-disclosure.rst
+++ b/docs/3.1/docs/app-dev/explicit-contract-disclosure.rst
@@ -269,17 +269,17 @@ Safeguards
 ------------------------------------------
 Explicit Contract Disclosure usage should always be accompanied by on-ledger contracts. This ensures that workflows executed based on the disclosed contract's contents conform to on-ledger agreements between the stakeholders (or trusted parties) involved.
 
-In the above example, ``IOU`` contracts between **Buyer** and **Issuer** (a trusted party on the ledger) ensure that the exercising of the ``Offer_Accept`` choice using disclosed contract results in a contractually agreed-upon outcome.
+In the above example, ``IOU`` contracts between *Buyer* and *Issuer* (a trusted party on the ledger) ensure that the exercising of the ``Offer_Accept`` choice using disclosed contract results in a contractually agreed-upon outcome.
 
 This works by performing several safety checks in the ``IOU_Transfer`` choice within the ``IOU`` contract, which is called from the ``Offer_Accept`` choice.
 
 The ``IOU`` contract provides several safeguards in the ``Offer_Accept`` workflow:
 
-- **Buyer** exercising the ``Offer_Accept`` choice is defined on the ``IOU`` agreement.
-- Creation of an IOU with an same amount for the **Seller** happens atomically with a deduction of the same amount from the **Buyer'** IOU.
-- **Buyer** cannot be deducted and **Seller** cannot receive more than the stipulated value on the ``IOU`` contract.
+- *Buyer* exercising the ``Offer_Accept`` choice is defined on the ``IOU`` agreement.
+- Creation of an IOU with the same amount for the *Seller* happens atomically with a deduction of the same amount from the *Buyer'* IOU.
+- *Buyer* cannot be deducted and *Seller* cannot receive more than the stipulated value on the ``IOU`` contract.
 
-By ensuring the **Buyer** party expected to execute the ``Offer_Accept`` choice, a trusted **Issuer** party and required terms of execution are clearly defined on an on-ledger multi-signatory ``IOU`` contract, the **Seller** can disclose the ``Offer`` contract and the **Buyer** can execute the ``Offer_Accept`` choice on the disclosed ``Offer`` contract knowing workflow safety is ensured.
+By ensuring the *Buyer* party expected to execute the ``Offer_Accept`` choice, a trusted *Issuer* party and required terms of execution are clearly defined on an trusted on-ledger ``IOU`` contract with a trusted *Issuer* party as a signatory, the *Seller* can disclose the ``Offer`` contract and the **Buyer** can execute the ``Offer_Accept`` choice on the disclosed ``Offer`` contract knowing workflow safety is ensured.
 
 If disclosed contracts contain malicious data or are maliciously executed on, the safeguards prevent unexpected outcomes.
 


### PR DESCRIPTION
This proposed section aims to convey the importance of workflow safeguards when working with ECD and reminds the user to include variants of these safeguards when working with ECD.

It specifically calls out the inclusion of workflow safeguards included in the ECD example code and why they are important.