### PR TITLE
Remove BETA marking from event query service

### DIFF
--- a/docs/2.10.0/docs/app-dev/services.rst
+++ b/docs/2.10.0/docs/app-dev/services.rst
@@ -214,7 +214,7 @@ See :ref:`transaction-filter` above.
 
 .. event-query-service:
 
-Event Query Service (BETA)
+Event Query Service
 ==================================
 
 Use the **event query service** to obtain a party-specific view of contract events.

--- a/docs/2.9.4/docs/app-dev/services.rst
+++ b/docs/2.9.4/docs/app-dev/services.rst
@@ -212,7 +212,7 @@ See :ref:`transaction-filter` above.
 
 .. event-query-service:
 
-Event Query Service (BETA)
+Event Query Service
 ==================================
 
 Use the **event query service** to obtain a party-specific view of contract events.

--- a/docs/3.1/docs/app-dev/services.rst
+++ b/docs/3.1/docs/app-dev/services.rst
@@ -212,7 +212,7 @@ See :ref:`transaction-filter` above.
 
 .. event-query-service:
 
-Event Query Service (BETA)
+Event Query Service
 ==================================
 
 Use the **event query service** to obtain a party-specific view of contract events.


### PR DESCRIPTION
EQS has been marked as GA in version 2.9.x:

https://blog.digitalasset.com/developers/release-notes/2.9.1#:~:text=EventsByX%20is%20promoted%20to%20General%20Availability