### PR TITLE
Remove "N times" from the Postgres tuning guidance

### DIFF
--- a/docs/2.10.0/docs/canton/usermanual/persistence.rst
+++ b/docs/2.10.0/docs/canton/usermanual/persistence.rst
@@ -102,7 +102,7 @@ operations.
 Configuring the ``shared_buffers`` setting to hold 60-70% of the host memory is recommended, rather than the default
 suggestion of 25%, as the Postgres caching appears to be more effective than the host-based file access caching.
 
-Also increase the following variables ``N`` times beyond their default: Increase the ``checkpoint_timeout`` so that
+Also increase the following variables beyond their default: Increase the ``checkpoint_timeout`` so that
 the flushing to disk includes several writes and not just one per page, accumulated over time, together with
 a higher ``max_wal_size`` to ensure that the system does not prematurely flush before reaching the ``checkpoint_timeout``.
 Monitor your system during load testing and tune the parameters accordingly to your use case.

--- a/docs/2.8.9/docs/canton/usermanual/persistence.rst
+++ b/docs/2.8.9/docs/canton/usermanual/persistence.rst
@@ -102,7 +102,7 @@ operations.
 Configuring the ``shared_buffers`` setting to hold 60-70% of the host memory is recommended, rather than the default
 suggestion of 25%, as the Postgres caching appears to be more effective than the host-based file access caching.
 
-Also increase the following variables ``N`` times beyond their default: Increase the ``checkpoint_timeout`` so that
+Also increase the following variables beyond their default: Increase the ``checkpoint_timeout`` so that
 the flushing to disk includes several writes and not just one per page, accumulated over time, together with
 a higher ``max_wal_size`` to ensure that the system does not prematurely flush before reaching the ``checkpoint_timeout``.
 Monitor your system during load testing and tune the parameters accordingly to your use case.

--- a/docs/2.9.4/docs/canton/usermanual/persistence.rst
+++ b/docs/2.9.4/docs/canton/usermanual/persistence.rst
@@ -102,7 +102,7 @@ operations.
 Configuring the ``shared_buffers`` setting to hold 60-70% of the host memory is recommended, rather than the default
 suggestion of 25%, as the Postgres caching appears to be more effective than the host-based file access caching.
 
-Also increase the following variables ``N`` times beyond their default: Increase the ``checkpoint_timeout`` so that
+Also increase the following variables beyond their default: Increase the ``checkpoint_timeout`` so that
 the flushing to disk includes several writes and not just one per page, accumulated over time, together with
 a higher ``max_wal_size`` to ensure that the system does not prematurely flush before reaching the ``checkpoint_timeout``.
 Monitor your system during load testing and tune the parameters accordingly to your use case.

--- a/docs/3.1/docs/canton/usermanual/persistence.rst
+++ b/docs/3.1/docs/canton/usermanual/persistence.rst
@@ -102,7 +102,7 @@ operations.
 Configuring the ``shared_buffers`` setting to hold 60-70% of the host memory is recommended, rather than the default
 suggestion of 25%, as the Postgres caching appears to be more effective than the host-based file access caching.
 
-Also increase the following variables ``N`` times beyond their default: Increase the ``checkpoint_timeout`` so that
+Also increase the following variables beyond their default: Increase the ``checkpoint_timeout`` so that
 the flushing to disk includes several writes and not just one per page, accumulated over time, together with
 a higher ``max_wal_size`` to ensure that the system does not prematurely flush before reaching the ``checkpoint_timeout``.
 Monitor your system during load testing and tune the parameters accordingly to your use case.


### PR DESCRIPTION
In the guidance about tuning Postgres performance, the following phrase appears:

```
Also increase the following variables N times beyond their default
```

That has been (incorrectly) understood to mean there is some specific value of `N` to target. Later, the paragraph explains that one must "Monitor your system during load testing and tune the parameters accordingly to your use case."

I propose removing `N times` to avoid misunderstanding.