### PR TITLE
Updated SC upgrading limitations

### DIFF
--- a/docs/2.10.0/docs/upgrade/upgrade-scopes.csv
+++ b/docs/2.10.0/docs/upgrade/upgrade-scopes.csv
@@ -18,8 +18,6 @@ Change of Ensure Predicate,Template Definition,Yes,Note that the Ensure is recal
 "Addition of New Definition Fields, Enum, and Variant Constructors",Template Definition,"Yes, but they they must be optional",
 Deletion of Fields from Template,Template Definition,No,
 Change of Choice Implementation,Template Definition,Yes,
-Deletion of Interface Choice or Template Choice,Choice,No,Workaround is to make the choice fail.
-Addition of Interface Choice,Choice,Yes,
 Change in Choice Controller,Choice,Yes,
 Addition of Choice Parameters,Choice,"Yes, but they must be optional",
 Deletion of Choice Parameters,Choice,No,
@@ -28,6 +26,7 @@ Change of Choice Body,Choice,Yes,
 Change of Choice Return Type,Choice,"Yes, except for Tuple or scalar types","You can change a user data type (Record, Variant, Enum) contained in the return type. In this case you can add a field to the record or a new case to the Variant/Enum."
 ,,,
 ,,,"In particular: you cannot change a collection, Optional, List, or Map; you can change Tuple, (to a triple) if you define your own type."
-Deletion of Interface Implementation,Interface,No,Workaround is to make the view fail.
-Addition of Interface Implementation,Interface,No,
-Change of Interface Implementation,Interface,Yes,
+Change of Interface Definition,Interface Definition, No,Interfaces are static and cannot be changed. Separate interface definition and keep the implementation in the template code.
+Addition of Interface Implementations (Retroactive Interfaces),Interface Definition,No,
+Adding or Removing Interfaces from Templates, Template Definition, No, Interfaces cannot be changed.
+Change or Deletion of Exception,Exception Definition,No,"Keep the exception definition separate. Exceptions cannot be upgraded."


### PR DESCRIPTION
Before this change, we still had interfaces as being upgradable. Now, we are explicit about that interfaces and exceptions are static.