### PR TITLE
Add 2.10.0-snapshot.20241002.0 to the broken snapshot releases

### DIFF
--- a/bin/publish-snapshots
+++ b/bin/publish-snapshots
@@ -67,6 +67,7 @@ broken() (
 2.8.2
 2.9.0-snapshot.20240604.0
 2.9.0-rc1
+2.10.0-snapshot.20241002.0
 EOF
   echo "$known_broken" | grep $version >/dev/null
 )


### PR DESCRIPTION
Snapshot 2.10.0-snapshot.20241002.0 fails the docs.daml.com build because it refers to a Daml SDK snapshot which contains a broken proto-docs.rst.

This has been fixed with https://github.com/DACH-NY/canton/pull/21568 but it has not found its way into a new Daml SDK snapshot build yet.