### PR TITLE
Update Daml 2.10.0-snapshot dependency to update the LAPI reference docs

### DIFF
--- a/docs/2.10.0/versions.json
+++ b/docs/2.10.0/versions.json
@@ -1,6 +1,6 @@
 {
-  "daml": "2.10.0-snapshot.20240911.12955.0.vee1ef999",
-  "canton": "2.10.0-snapshot.20240911.12239.0.v0a7b34ce",
+  "daml": "2.10.0-snapshot.20241004.12994.0.v3991c94d",
+  "canton": "2.10.0-snapshot.20241004.12271.0.vbaedaf71",
   "daml_finance": "1.5.0",
   "canton_drivers": "2.10.0-snapshot.20240708.12144.0.v22fb89b5"
 }


### PR DESCRIPTION
Updates the 'Ledger API Reference' page content presentation: https://docs.daml.com/2.10.0/app-dev/grpc/proto-docs.html

This also updates the Canton 2.10.0-snapshot dependency.