### PR TITLE
Fix scroll position for cross references links

### DIFF
--- a/theme/js/theme.js
+++ b/theme/js/theme.js
@@ -607,6 +607,11 @@ $(document).ready(function () {
             });
     }
     setHighlighterWidth();
+    
+    // Assign the CSS class "section" for Ledger API reference doc spans.
+    // This fixes a problem with clicking on internal links in the Ledger API reference docs.
+    // The scroll position, after clicking a link, was behind the nav bar.
+    $("span[id^=com-daml-ledger-api-v]").addClass("section");
 });
 
 $(window).resize(function () {

--- a/theme/js/theme.js
+++ b/theme/js/theme.js
@@ -608,10 +608,11 @@ $(document).ready(function () {
     }
     setHighlighterWidth();
     
-    // Assign the CSS class "section" for Ledger API reference doc spans.
-    // This fixes a problem with clicking on internal links in the Ledger API reference docs.
+    // Assign the CSS class "section" to any span that is a direct child of a div of class section.
+    // This fixes a problem with clicking on links to RST cross-references.
     // The scroll position, after clicking a link, was behind the nav bar.
-    $("span[id^=com-daml-ledger-api-v]").addClass("section");
+    // https://github.com/digital-asset/docs.daml.com/issues/722
+    $('div.section > span').addClass('section');
 });
 
 $(window).resize(function () {


### PR DESCRIPTION
You may have noticed a very annoying behavior when clicking on links within the Ledger API reference docs. For example, if you click on the link for the [GetActiveContractsResponse message](https://docs.daml.com/app-dev/grpc/proto-docs.html#com-daml-ledger-api-v1-getactivecontractsresponse), the heading for that message is _behind_ the navbar. It is very confusing for new users.

This PR makes a small CSS tweak to address that issue. Using jQuery, it dynamically adds the `section` CSS class to the `span`s which serve as the anchor for internal links.

I did look at trying to add that CSS class to the RST source file, but without success. I have also [asked on StackOverflow](https://stackoverflow.com/questions/79091778/add-css-class-to-sphinx-generated-anchor-span).

Attached are videos showing _before_ and _after_.

https://github.com/user-attachments/assets/a3963573-f321-499f-8dd7-3a13adaa8987

https://github.com/user-attachments/assets/66f9c6b1-a31c-4c1c-8e4b-73703a0550fd



