### PR TITLE
Update Daml/Canton dependencies for 2.10.0

### DIFF
--- a/bin/publish-snapshots
+++ b/bin/publish-snapshots
@@ -68,6 +68,7 @@ broken() (
 2.9.0-snapshot.20240604.0
 2.9.0-rc1
 2.10.0-snapshot.20241002.0
+2.10.0-snapshot.20241016.0
 EOF
   echo "$known_broken" | grep $version >/dev/null
 )

--- a/docs/2.10.0/versions.json
+++ b/docs/2.10.0/versions.json
@@ -1,6 +1,6 @@
 {
-  "daml": "2.10.0-snapshot.20241004.12994.0.v3991c94d",
-  "canton": "2.10.0-snapshot.20241004.12271.0.vbaedaf71",
+  "daml": "2.10.0-snapshot.20241015.13009.0.v19d1b665",
+  "canton": "2.10.0-snapshot.20241014.12288.0.vda147111",
   "daml_finance": "1.5.0",
   "canton_drivers": "2.10.0-snapshot.20240708.12144.0.v22fb89b5"
 }


### PR DESCRIPTION
This also adds 2.10.0-snapshot.20241016.0 to the known broken releases because it refers to a Daml SDK version which contains a LAPI Reference Doc version that breaks the docs.daml.com build.