### PR TITLE
Add 2.10.0-snapshot.20241016.0 to known broken releases

### DIFF
--- a/bin/publish-snapshots
+++ b/bin/publish-snapshots
@@ -68,6 +68,7 @@ broken() (
 2.9.0-snapshot.20240604.0
 2.9.0-rc1
 2.10.0-snapshot.20241002.0
+2.10.0-snapshot.20241016.0
 EOF
   echo "$known_broken" | grep $version >/dev/null
 )


### PR DESCRIPTION
Because it refers to Daml SDK which contains a LAPI Reference Documentation RST that contains invalid RST, and thus breaks the build.