### PR TITLE
Added a sentence on the impact of cloud resources

### DIFF
--- a/docs/2.10.0/docs/canton/usermanual/persistence.rst
+++ b/docs/2.10.0/docs/canton/usermanual/persistence.rst
@@ -84,6 +84,22 @@ It might make sense to start with 128GB, run a long-running scale & performance 
 Most Canton indexes are contract-id based, which means that the index lookups are randomly distributed. Solid state drives with
 high throughput perform much better than spinning disks for this purpose.
 
+.. _shared_env_performance:
+
+Predictability of Shared Environments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The throughput and latency of a Canton node is highly dependent on the performance of the database. 
+Sharing hardware or software is an efficient method to save cost and better utilize available resources, but comes 
+with some drawbacks: If the database is operated in a shared environment such as the Cloud, where other applications are either using the same 
+database or are operated on the same hardware, the performance of the Canton node will vary due to 
+contention on shared resources. This is a natural effect of shared environments and cannot be fundamentally 
+avoided, but can be difficult to diagnose as a user of the shared environment due to lack of visibility into 
+the other applications.
+
+If you are operating in a shared environment, you should monitor the performance of the database and expect
+a higher variance in latency and throughput. 
+
 .. _postgres-configuration:
 
 Postgres Configuration

--- a/docs/2.10.0/docs/canton/usermanual/persistence.rst
+++ b/docs/2.10.0/docs/canton/usermanual/persistence.rst
@@ -89,13 +89,13 @@ high throughput perform much better than spinning disks for this purpose.
 Predictability of Shared Environments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The throughput and latency of a Canton node is highly dependent on the performance of the database. 
-Sharing hardware or software is an efficient method to save cost and better utilize available resources, but comes 
-with some drawbacks: If the database is operated in a shared environment such as the Cloud, where other applications are either using the same 
-database or are operated on the same hardware, the performance of the Canton node will vary due to 
-contention on shared resources. This is a natural effect of shared environments and cannot be fundamentally 
-avoided, but can be difficult to diagnose as a user of the shared environment due to lack of visibility into 
-the other applications.
+The throughput and latency of a Canton node depends on the performance of the database.
+Sharing hardware or software saves cost and better utilizes available resources, but it comes
+with some drawbacks: If the database is operated in a shared environment such as the Cloud, where other applications are using the same
+database or are operated on the same hardware, the performance of the Canton node varies due to
+contention on shared resources. This is a natural effect of shared environments and cannot be entirely
+avoided. It can be difficult to diagnose as a user of the shared environment due to lack of visibility into
+the other applications and the host system.
 
 If you are operating in a shared environment, you should monitor the performance of the database and expect
 a higher variance in latency and throughput. 

--- a/docs/2.10.0/docs/canton/usermanual/troubleshooting_guide.rst
+++ b/docs/2.10.0/docs/canton/usermanual/troubleshooting_guide.rst
@@ -408,6 +408,8 @@ Now, you do the following analysis:
 
      * all the queries should normally take between 5-15ms. If you see queries taking consistently longer (e.g. all of them 60 - 70ms), then your database system is overloaded, queuing too many database requests on the database. You might want to increase the database resources (CPUs) or reduce the number of connections. While seeming counter intuitive, but giving too many db connections to a node will reduce the throughput, not increase it.
 
+     * verify whether you might be affected by :ref:`contention on shared resources in a shared environment<shared_env_performance>`.
+
 How to find the Bottleneck
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/2.9.5/docs/canton/usermanual/persistence.rst
+++ b/docs/2.9.5/docs/canton/usermanual/persistence.rst
@@ -84,6 +84,22 @@ It might make sense to start with 128GB, run a long-running scale & performance 
 Most Canton indexes are contract-id based, which means that the index lookups are randomly distributed. Solid state drives with
 high throughput perform much better than spinning disks for this purpose.
 
+.. _shared_env_performance:
+
+Predictability of Shared Environments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The throughput and latency of a Canton node depends on the performance of the database.
+Sharing hardware or software saves cost and better utilizes available resources, but it comes
+with some drawbacks: If the database is operated in a shared environment such as the Cloud, where other applications are using the same
+database or are operated on the same hardware, the performance of the Canton node varies due to
+contention on shared resources. This is a natural effect of shared environments and cannot be entirely
+avoided. It can be difficult to diagnose as a user of the shared environment due to lack of visibility into
+the other applications and the host system.
+
+If you are operating in a shared environment, you should monitor the performance of the database and expect
+a higher variance in latency and throughput.
+
 .. _postgres-configuration:
 
 Postgres Configuration

--- a/docs/3.1/docs/canton/usermanual/persistence.rst
+++ b/docs/3.1/docs/canton/usermanual/persistence.rst
@@ -84,6 +84,22 @@ It might make sense to start with 128GB, run a long-running scale & performance 
 Most Canton indexes are contract-id based, which means that the index lookups are randomly distributed. Solid state drives with
 high throughput perform much better than spinning disks for this purpose.
 
+.. _shared_env_performance:
+
+Predictability of Shared Environments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The throughput and latency of a Canton node depends on the performance of the database.
+Sharing hardware or software saves cost and better utilizes available resources, but it comes
+with some drawbacks: If the database is operated in a shared environment such as the Cloud, where other applications are using the same
+database or are operated on the same hardware, the performance of the Canton node varies due to
+contention on shared resources. This is a natural effect of shared environments and cannot be entirely
+avoided. It can be difficult to diagnose as a user of the shared environment due to lack of visibility into
+the other applications and the host system.
+
+If you are operating in a shared environment, you should monitor the performance of the database and expect
+a higher variance in latency and throughput.
+
 .. _postgres-configuration:
 
 Postgres Configuration


### PR DESCRIPTION
Before this change, we didn't have a section in the manual saying that cloud resources are going to give you less predictable behaviour. Now, we have one.

I will copy it to the other versions after the review here. 