### PR TITLE
Remove duplicated lualatex lines from the build command

### DIFF
--- a/docs/2.10.0/bin/build
+++ b/docs/2.10.0/bin/build
@@ -39,7 +39,6 @@ done
 tar xf $SOURCE_DIR/pdf-fonts-$RELEASE_TAG.tar.gz -C $BUILD_DIR/sphinx-target/pdf
 cd $BUILD_DIR/sphinx-target/pdf
 lualatex -halt-on-error -interaction=batchmode --shell-escape *.tex
-lualatex -halt-on-error -interaction=batchmode --shell-escape *.tex
 cd -
 mv $BUILD_DIR/sphinx-target/pdf/DigitalAssetSDK.pdf $TARGET_DIR/pdf-docs-$RELEASE_TAG.pdf
 

--- a/docs/2.3.20/docs/build.sh
+++ b/docs/2.3.20/docs/build.sh
@@ -39,7 +39,6 @@ done
 tar xf $SOURCE_DIR/pdf-fonts-$RELEASE_TAG.tar.gz -C $BUILD_DIR/sphinx-target/pdf
 cd $BUILD_DIR/sphinx-target/pdf
 lualatex -halt-on-error -interaction=batchmode --shell-escape *.tex
-lualatex -halt-on-error -interaction=batchmode --shell-escape *.tex
 cd -
 mv $BUILD_DIR/sphinx-target/pdf/DigitalAssetSDK.pdf $TARGET_DIR/pdf-docs-$RELEASE_TAG.pdf
 

--- a/docs/2.7.9/bin/build
+++ b/docs/2.7.9/bin/build
@@ -39,7 +39,6 @@ done
 tar xf $SOURCE_DIR/pdf-fonts-$RELEASE_TAG.tar.gz -C $BUILD_DIR/sphinx-target/pdf
 cd $BUILD_DIR/sphinx-target/pdf
 lualatex -halt-on-error -interaction=batchmode --shell-escape *.tex
-lualatex -halt-on-error -interaction=batchmode --shell-escape *.tex
 cd -
 mv $BUILD_DIR/sphinx-target/pdf/DigitalAssetSDK.pdf $TARGET_DIR/pdf-docs-$RELEASE_TAG.pdf
 

--- a/docs/2.8.10/bin/build
+++ b/docs/2.8.10/bin/build
@@ -39,7 +39,6 @@ done
 tar xf $SOURCE_DIR/pdf-fonts-$RELEASE_TAG.tar.gz -C $BUILD_DIR/sphinx-target/pdf
 cd $BUILD_DIR/sphinx-target/pdf
 lualatex -halt-on-error -interaction=batchmode --shell-escape *.tex
-lualatex -halt-on-error -interaction=batchmode --shell-escape *.tex
 cd -
 mv $BUILD_DIR/sphinx-target/pdf/DigitalAssetSDK.pdf $TARGET_DIR/pdf-docs-$RELEASE_TAG.pdf
 

--- a/docs/2.9.5/bin/build
+++ b/docs/2.9.5/bin/build
@@ -39,7 +39,6 @@ done
 tar xf $SOURCE_DIR/pdf-fonts-$RELEASE_TAG.tar.gz -C $BUILD_DIR/sphinx-target/pdf
 cd $BUILD_DIR/sphinx-target/pdf
 lualatex -halt-on-error -interaction=batchmode --shell-escape *.tex
-lualatex -halt-on-error -interaction=batchmode --shell-escape *.tex
 cd -
 mv $BUILD_DIR/sphinx-target/pdf/DigitalAssetSDK.pdf $TARGET_DIR/pdf-docs-$RELEASE_TAG.pdf
 

--- a/docs/3.1/bin/build
+++ b/docs/3.1/bin/build
@@ -39,7 +39,6 @@ done
 tar xf $SOURCE_DIR/pdf-fonts-$RELEASE_TAG.tar.gz -C $BUILD_DIR/sphinx-target/pdf
 cd $BUILD_DIR/sphinx-target/pdf
 lualatex -halt-on-error -interaction=batchmode --shell-escape *.tex
-lualatex -halt-on-error -interaction=batchmode --shell-escape *.tex
 cd -
 mv $BUILD_DIR/sphinx-target/pdf/DigitalAssetSDK.pdf $TARGET_DIR/pdf-docs-$RELEASE_TAG.pdf
 


### PR DESCRIPTION
Remove the duplicated lualatex lines from the build command. It saves about 1,5 minutes locally.