### PR TITLE
Add a script for listing outdated files

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,26 @@ When there is a change to the root website, the entire site needs to be reindexe
 5. When that has completed, click the blue button for **Re-index All Configured Sources**. This may take about a half hour.
 6. When this has completed, the site search should work as expected.
 
+## Auditing outdated files
+
+Use the following bash script for searching pages that have not been updated for a long time (default: 1 year) as candidates for audit. 
+Occasionally we have outdated material that persists because there hasn't been a PR that explicitly removes it.
+
+Simple usage:
+```
+./bin/list-outdated-files
+```
+
+Customized usage:
+```
+./bin/list-outdated-files -l 3.months -d docs/3.1/docs -e json -o gitlog -r
+```
+
+Help:
+```
+./bin/list-outdated-files -h
+```
+
 ## Questions
 
 If you have questions or comments about these instructions, please reach out to the `#product-docs` channel on Slack.

--- a/bin/list-outdated-files
+++ b/bin/list-outdated-files
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Use the following bash script for searching pages that have not been updated for a long time (default: 1 year) as candidates for audit.
+# Occasionally we have outdated material that persists because there hasn't been a PR that explicitly removes it.
+
 set -euo pipefail
 
 directory=docs
@@ -47,11 +50,42 @@ while getopts "d:e:l:o:h" arg; do
   esac
 done
 
-encoded_extensions=$(IFS="|" ; echo "${extensions[*]}")
+list_unchanged_files() (
+  local revision=$(git rev-list -1 --before "$limit.ago" origin/main)
 
-revision=$(git rev-list -1 --before ".$limit.ago" origin/main)
+  # List all files and filter out the changed ones
+  comm -23 <(git ls-files | sort) <(git diff --name-only  --stat $revision | sort)
+)
 
-comm -23 <(git ls-files | sort) <(git diff --name-only --stat $revision | sort) \
- | if [ "$directory" != "" ]; then grep "^$directory/"; else cat; fi \
- | if [ "$encoded_extensions" != "" ]; then grep -E ".[$encoded_extensions]+\$"; else cat; fi \
- | if [ "$output_format" == "gitlog" ]; then while read filename ; do echo "File: ${bold}$filename"; git log -1 $filename; echo ""; echo ""; done; else cat; fi
+filter_directory() (
+  if [ "$directory" != "" ]
+    then grep "^$directory/"
+    else cat
+  fi
+)
+
+filter_extensions() (
+  local encoded_extensions=$(IFS="|" ; echo "${extensions[*]}")
+
+  if [ "$encoded_extensions" != "" ]
+    then grep -E ".[$encoded_extensions]+\$"
+    else cat
+  fi
+)
+
+produce_output() (
+  if [ "$output_format" == "gitlog" ]
+  then
+    while read filename
+      do
+        echo "File: ${bold}$filename"
+        git log -1 $filename
+        # git log has a longer output, so let's add 2 empty lines to separate the info visually
+        echo ""
+        echo ""
+      done
+    else cat
+  fi
+)
+
+list_unchanged_files | filter_directory | filter_extensions | produce_output

--- a/bin/list-outdated-files
+++ b/bin/list-outdated-files
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+directory=docs
+extensions=(rst md)
+limit=1.year
+output_format="simple"
+
+__usage="
+usage: list-outdated-files [ -d directory | -e extensions | -l limit | -o output]
+Options :
+-d directory :  Directory to search, 'docs' by default.
+                For more specific directory, use the 'docs/3.1' format.
+                Use '' to search all directories.
+-e extensions : List of file extensions separated by comma, 'rst,md' by default.
+                Use '' to search all extensions.
+-l limit :      Time limit to search, '1.year' by default.
+                Must be in relative format supported by git.
+                Examples: '1.week', '3.months'
+-o output :     Output format.
+                - 'plain' for just the file names (default)
+                - 'gitlog' for additional git log info
+"
+
+bold=$(tput bold)
+
+while getopts "d:e:l:o:h" arg; do
+  case $arg in
+    l)
+      limit=$OPTARG
+      ;;
+    d)
+      directory=$OPTARG
+      ;;
+    e)
+      IFS="," read -r -a extensions <<< $OPTARG
+      ;;
+    o)
+      output_format=$OPTARG
+      ;;
+    h)
+      echo "$__usage"
+      exit 1
+      ;;
+  esac
+done
+
+encoded_extensions=$(IFS="|" ; echo "${extensions[*]}")
+
+revision=$(git rev-list -1 --before ".$limit.ago" origin/main)
+
+comm -23 <(git ls-files | sort) <(git diff --name-only --stat $revision | sort) \
+ | if [ "$directory" != "" ]; then grep "^$directory/"; else cat; fi \
+ | if [ "$encoded_extensions" != "" ]; then grep -E ".[$encoded_extensions]+\$"; else cat; fi \
+ | if [ "$output_format" == "gitlog" ]; then while read filename ; do echo "File: ${bold}$filename"; git log -1 $filename; echo ""; echo ""; done; else cat; fi

--- a/bin/list-outdated-files
+++ b/bin/list-outdated-files
@@ -17,7 +17,8 @@ Options :
                 Use '' to search all extensions.
 -l limit :      Time limit to search, '1.year' by default.
                 Must be in relative format supported by git.
-                Examples: '1.week', '3.months'
+                Examples: '1.week', '3.months'.
+                Using large limits makes the script slow.
 -o output :     Output format.
                 - 'plain' for just the file names (default)
                 - 'gitlog' for additional git log info


### PR DESCRIPTION
@carrielaben-da suggested in a discussion:

> A nice-to-have for me: some mechanism that can flag pages that have not been updated within the past year as candidates for audit. Occasionally we have outdated material that persists because there hasn't been a PR that explicitly removes it (e.g. the old docs on supporting Ethereum and Hyperledger Fabric.)

Basic usage:

```
./bin/list-outdated-files
```

Customized usage:

```
./bin/list-outdated-files -l 3.months -d docs/3.1/docs -e json -o gitlog
```

Help:

```
./bin/list-outdated-files -h
```
