### PR TITLE
Remover "syncrhonizer" typo

### DIFF
--- a/docs/3.1/docs/canton/usermanual/identity_management.rst
+++ b/docs/3.1/docs/canton/usermanual/identity_management.rst
@@ -148,7 +148,7 @@ directly by having the namespace key or through delegation (via ``NamespaceDeleg
 
 Participant Onboarding
 ~~~~~~~~~~~~~~~~~~~~~~
-Key to supporting topological flexibility is that participants can easily be added to new syncrhonizers. Therefore, the
+Key to supporting topological flexibility is that participants can easily be added to new synchronizers. Therefore, the
 on-boarding of new participants to sync domains needs to be secure but convenient. Looking at the console command, we note
 that in most examples, we are using the ``connect`` command to connect a participant to a sync domain. The connect command
 just wraps a set of admin-api commands:

--- a/docs/3.1/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/implementing-ha.rst
+++ b/docs/3.1/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/implementing-ha.rst
@@ -210,7 +210,7 @@ The sync domain manager service also has no client-facing ingest point. Like the
    :align: center
    :width: 80%
 
-As of `v2.5.0 <https://blog.digitalasset.com/developers/release-notes/2.5.0>`__, the syncrhonizer manager uses PostgreSQL in an HA configuration for HA support.
+As of `v2.5.0 <https://blog.digitalasset.com/developers/release-notes/2.5.0>`__, the synchronizer manager uses PostgreSQL in an HA configuration for HA support.
 
 Trigger Service
 ***************

--- a/docs/3.1/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/introduction.rst
+++ b/docs/3.1/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/introduction.rst
@@ -11,7 +11,7 @@ Introduction
 
 This section describes how to deploy a complete Daml solution in an HA configuration with horizontal scaling characteristics. 
 
-The distributed solution uses Daml v2.x Enterprise with Canton services, HTTP JSON API server, Trigger services, and OAuth 2.0 middleware components. In this document we primarily discuss a SQL sync domain that uses PostgreSQL as the synchronization mechanism for the sequencer backend. We also describe a blockchain syncrhonizer. 
+The distributed solution uses Daml v2.x Enterprise with Canton services, HTTP JSON API server, Trigger services, and OAuth 2.0 middleware components. In this document we primarily discuss a SQL sync domain that uses PostgreSQL as the synchronization mechanism for the sequencer backend. We also describe a blockchain synchronizer. 
 
 Information in this section is useful for the following:
 

--- a/docs/3.1/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/use-cases.rst
+++ b/docs/3.1/docs/deploy-daml/infrastructure-architecture/high-availability/ha-and-scaling/use-cases.rst
@@ -68,8 +68,8 @@ The distributed application provider communicates specific information to a new 
 5. Bob passes Alice the following information, which allows her to connect to the sync domain:
     a. One, or more, sequencer endpoints - https URLs.
     b. Certificate root public cert, if it's not a publicly signed CA.
-6. Alice picks a unique name for the syncrhonizer that is local to her participant. This will be used in the connection command.
-7. Alice enters the information into the connection command ``connect_multi`` and connects to Bob's syncrhonizer - not shown.
+6. Alice picks a unique name for the synchronizer that is local to her participant. This will be used in the connection command.
+7. Alice enters the information into the connection command ``connect_multi`` and connects to Bob's synchronizer - not shown.
 
 .. code-block:: sh
 


### PR DESCRIPTION
Fixes five instances of synchronizer being spelled wrong.