### PR TITLE
Add 2.10.0-snapshot.20241120.0 to known broken releases

### DIFF
--- a/bin/publish-snapshots
+++ b/bin/publish-snapshots
@@ -69,6 +69,7 @@ broken() (
 2.9.0-rc1
 2.10.0-snapshot.20241002.0
 2.10.0-snapshot.20241016.0
+2.10.0-snapshot.20241120.0
 EOF
   echo "$known_broken" | grep $version >/dev/null
 )


### PR DESCRIPTION
Because it refers to canton 2.10.0-snapshot.20241118.12344.0.v7d331e04 which does not include a required source file from Canton that is referenced by the decommissioning.rst RST file.

Details:
https://app.circleci.com/pipelines/github/digital-asset/docs.daml.com/26865/workflows/234a748c-937b-4af2-a317-49b3d2dd0041/jobs/27706