### PR TITLE
Copy minor doc updates from 3.1 to 2.10

### DIFF
--- a/docs/2.10.0/README.md
+++ b/docs/2.10.0/README.md
@@ -30,6 +30,8 @@ The html files are in `workdir/build/gen`. Rerun the script to view any edits to
 
 :warning: If you do make a change to the TOCs in this repo, you then have to duplicate the change in the relevant satellite repo (except for the daml repo, which does not have a local ToC).
 
+Note that the `live-preview` script takes a few shortcuts. This is fine most of the time, but sometimes the final result can be a bit different.
+
 ### Theme
 
 Live preview doesn't reflect changes to the theme. That's because it would

--- a/docs/2.10.0/docs/app-dev/explicit-contract-disclosure.rst
+++ b/docs/2.10.0/docs/app-dev/explicit-contract-disclosure.rst
@@ -17,7 +17,7 @@ This supports efficient, scalable data sharing on the ledger.
 
 Here are some use cases that illustrate how you might benefit from explicit contract disclosure:
 
-- You want to provide proof of the price data for a stock transaction. Instead of subscribing to price updates and potentially being inundated with thousands of price updates every minute, you could serve the price data though a traditional Web 2.0 API. You can then use that API to feed only the current price back into the ledger at the time of use. You still get the same validation and security, but reduce the amount of data being transferred manyfold.
+- You want to provide proof of the price data for a stock transaction. Instead of subscribing to price updates and potentially being inundated with thousands of price updates every minute, you could serve the price data through a traditional Web 2.0 API. You can then use that API to feed only the current price back into the ledger at the time of use. You still get the same validation and security, but reduce the amount of data being transferred manyfold.
 - You want to run an open market on ledger. Rather than making all bids and asks explicitly visible to all marketplace users, you serve market data though standard Web 2.0 APIs. At the point of use, the available bids and asks are fed back into the transactions to get the same activeness and correctness guarantees that would be provided had they been shared though the observer mechanism.
 
 Contract Read Delegation

--- a/docs/2.10.0/docs/app-dev/explicit-contract-disclosure.rst
+++ b/docs/2.10.0/docs/app-dev/explicit-contract-disclosure.rst
@@ -17,7 +17,7 @@ This supports efficient, scalable data sharing on the ledger.
 
 Here are some use cases that illustrate how you might benefit from explicit contract disclosure:
 
-- You want to provide proof of the price data for a stock transaction. Instead of subscribing to price updates and potentially being inundated with thousands of price updates every minute, you could serve the price data through a traditional Web 2.0 API. You can then use that API to feed only the current price back into the ledger at the time of use. You still get the same validation and security, but reduce the amount of data being transferred manyfold.
+- You want to provide proof of the price data for a stock transaction. Instead of subscribing to price updates and potentially being inundated with thousands of price updates every minute, you could serve the price data through a traditional Web 2.0 API. You could then use that API to feed only the current price back into the ledger at the time of use. You get the same validation and security, but reduce the amount of transferred data manyfold.
 - You want to run an open market on ledger. Rather than making all bids and asks explicitly visible to all marketplace users, you serve market data though standard Web 2.0 APIs. At the point of use, the available bids and asks are fed back into the transactions to get the same activeness and correctness guarantees that would be provided had they been shared though the observer mechanism.
 
 Contract Read Delegation

--- a/docs/2.10.0/docs/canton/architecture/domains/domains.rst
+++ b/docs/2.10.0/docs/canton/architecture/domains/domains.rst
@@ -36,12 +36,12 @@ The sync domain contributes to the high-level functional requirements in terms o
 facilitating the synchronization of changes. As the sync domain can only see
 encrypted transactions, refer to transaction privacy in the non-functional
 requirements, the functional requirements are satisfied on a lower level than
-the Daml transaction level.
+the Daml transaction.
 
   .. _synchronization-domain-req:
 
 * **Synchronization:** The sync domain must facilitate the synchronization of the
-  shared ledger among participants by establishing a total-order of
+  shared ledger among participants by establishing a total order of
   transactions.
 
   .. _transparency-domain-req:
@@ -74,8 +74,8 @@ Reliability
   .. _fail-over-domain-req:
 
 * **Seamless fail-over for sync domain entities:** All sync domain entities must be able
-  to tolerate crash faults up to a certain failure rate, e.g., 1 sequencer node
-  out of 3 can fail without interruption.
+  to tolerate crash faults up to a certain failure rate, e.g., one sequencer node
+  out of three can fail without interruption.
 
   .. _resilience-domain-req:
 
@@ -145,12 +145,12 @@ Security
   .. _distributed-trust-domain-req:
 
 * **Distributed Trust:** The sync domain should be able to be operated by a
-  consortium in order to distribute the trust of the participants in the sync domain
+  consortium to distribute the trust of the participants in the sync domain
   among many organizations.
 
   .. _transaction-privacy-domain-req:
 
-* **Transaction Metadata Privacy:** The sync domains entities must never learn the
+* **Transaction Metadata Privacy:** The sync domain entities must never learn the
   content of the transactions. The sync domain entities should learn a limited amount
   of transaction metadata, such as structural properties of a transaction and
   involved stakeholders.


### PR DESCRIPTION
Add some styling improvement and missing updates taken from 3.1, while I was comparing diffs between 2.10 and 3.1.