### PR TITLE
Add docs for Multi-Package Daml Studio support

### DIFF
--- a/docs/2.10.0/docs/daml/daml-studio.rst
+++ b/docs/2.10.0/docs/daml/daml-studio.rst
@@ -443,7 +443,8 @@ These limtations are for the Release Candidate only, and will be fixed for 2.10 
 - Jumping to non-local dependencies does not currently retain the build-options and module-prefixes
 for that package. This means that if you jump to a dependency that requires either of these to build,
 the editor will show errors on the source code.
-- Some links in the Script Results tab may not resolve correctly cross-package
+- Some links in the Script Results tab may not resolve correctly cross-package.
+- Packages with symlinks between the daml.yaml and source files may not give correct intelligence.
 
 Setting Multi-IDE SDK Version
 =============================

--- a/docs/2.10.0/docs/daml/daml-studio.rst
+++ b/docs/2.10.0/docs/daml/daml-studio.rst
@@ -372,7 +372,7 @@ Multi-Package Support
 
 Following the Multi-Package support added to ``daml build`` (:ref:`see here <multi-package-build>`),
 Daml Studio also supports projects that utilise the ``multi-package.yaml`` file.
-It is recommended that you are familiar with the Multi-Package build support
+It is recommended that you are familiar with multi-package builds
 before continuing in this section.
 The Daml Studio Multi-IDE feature will run separate package environments for
 each package in your project, and allows cross-package jump-to-definition for
@@ -381,29 +381,28 @@ any packages listed in a top level ``multi-package.yaml`` file.
 Multi-package.yaml Location
 ===========================
 The ``multi-package.yaml`` file will only be used by Daml Studio if it sits at the
-Workspace Root, i.e. in the root directory that Daml Studio was opened in.
+VS Code Workspace Root, i.e. in the root directory that Daml Studio was opened in.
 If no ``multi-package.yaml`` is found, the cross-package jump-to-definition feature
 will not jump to the real on-disk source code, however other Multi-IDE features will
 still work as normal.
 
 Package Environments and Hot-Loading
 ====================================
-The Multi-IDE runs separate package environments for each package in the project,
+The Multi-IDE runs a separate package environment for each package in the project,
 allowing the IDE to replicate properties such as dependencies, module-prefixes and build-options
 of each package individually, without clashing with other packages in the project.
-These enrivonments will automatically reload if the relevant ``daml.yaml`` file changes,
+A package's environment will automatically reload if its ``daml.yaml`` file changes,
 or any of the dependency DAR files change.  
 
 Note, however, that the Multi-IDE does not hold "live" copies of DARs, therefore any changes
-to a package that affects another package will not be visible in that second package until
+to a package that is a dependency of another package will not be visible in that second package until
 running ``daml build``.  
 You can run ``daml build --all`` to rebuild all relevant DARs, and the IDE will account for this
 and reload environments as necessary.  
 
 Jumping to definition on non-local dependencies (i.e. those not listed in ``multi-package.yaml``)
 will also use the correct environment, giving correct diagnostics for that package, and allowing
-further jumps down the stack. This can only jump to package to which the source code is available
-though, i.e. packages to which the DAR can be found in any of the following places:
+further jumps down the stack. However, this can only jump to a package for which the source code is available, i.e. packages to which the DAR can be found in any of the following places:
 - The ``data-dependencies`` field of the current package or any other packages known to the ``multi-package.yaml``
 - Under the added ``dars`` field in the ``multi-package.yaml``, which is shown below:
 
@@ -428,14 +427,14 @@ cancellation within a notification.
 
 Directory Envrionment Tools (direnv)
 ====================================
-It is common to use tools like ``direnv`` to setup dependencies and import enrivonment variables
-for use with :ref:`enrivonment variable interpolation support <environment-variable-interpolation>`. In order to have this working in Daml Studio,
+It is common to use tools like ``direnv`` to set up dependencies and import environment variables
+for use with :ref:`environment variable interpolation support <environment-variable-interpolation>`. In order to have this working in Daml Studio,
 you will need a VSCode extension that sets this up for other extensions.
 In the case of ``direnv`` specifically (i.e. you have a ``.envrc`` file), we
 recommend using `this direnv extension by Martin Kühl <https://marketplace.visualstudio.com/items?itemName=mkhl.direnv>`__, which we have verified is compatible.
 Other direnv extensions may not correctly pass environment information to the Daml Studio extension.
 If the Daml extension detects a ``.envrc`` file, it will recommend this extension within the IDE,
-providing a link to the marketplace.
+providing a link to the extension on the VS Code extension marketplace.
 
 Limitations in 2.10.0-rc
 ========================
@@ -448,8 +447,8 @@ the editor will show errors on the source code.
 
 Setting Multi-IDE SDK Version
 =============================
-The Multi-IDE will select the correct SDK Version for each package you interact with, however the
-Multi-IDE itself will run from your most recent installed SDK Version. You can override this using
+The Multi-IDE will select the correct SDK version for each package you interact with, however the
+Multi-IDE itself will run from your most recent installed SDK version. You can override this using
 an additional ``daml.yaml`` file at the root of your project (next to the ``multi-package.yaml``)
 containing only an SDK Version, as follows:
 

--- a/docs/2.10.0/docs/daml/daml-studio.rst
+++ b/docs/2.10.0/docs/daml/daml-studio.rst
@@ -396,8 +396,8 @@ or any of the dependency DAR files change.
 Note, however, that the Multi-IDE does not hold "live" copies of DARs, therefore any changes
 to a package that is a dependency of another package are not visible in that second package until
 you run ``daml build``.  
-You can run ``daml build --all`` to rebuild all relevant DARs, and the IDE will account for this
-and reload environments as necessary.  
+You can run ``daml build --all`` to rebuild all relevant DARs. The IDE accounts for this
+and reloads environments as necessary.  
 
 Jumping to definition on non-local dependencies (those not listed in ``multi-package.yaml``)
 also uses the correct environment, giving correct diagnostics for that package, and allowing

--- a/docs/2.10.0/docs/daml/daml-studio.rst
+++ b/docs/2.10.0/docs/daml/daml-studio.rst
@@ -371,38 +371,37 @@ Multi-Package Support
 *********************
 
 Following the Multi-Package support added to ``daml build`` (:ref:`see here <multi-package-build>`),
-Daml Studio also supports projects that utilise the ``multi-package.yaml`` file.
-It is recommended that you are familiar with multi-package builds
+Daml Studio also supports projects that utilize the ``multi-package.yaml`` file.
+You should become familiar with multi-package builds
 before continuing in this section.
-The Daml Studio Multi-IDE feature will run separate package environments for
+The Daml Studio Multi-IDE feature runs separate package environments for
 each package in your project, and allows cross-package jump-to-definition for
 any packages listed in a top level ``multi-package.yaml`` file.
 
 Multi-package.yaml Location
 ===========================
-The ``multi-package.yaml`` file will only be used by Daml Studio if it sits at the
-VS Code Workspace Root, i.e. in the root directory that Daml Studio was opened in.
+Daml Studio only uses the ``multi-package.yaml`` file if it sits at the
+VS Code Workspace Root, that is, in the root directory in which Daml Studio was opened.
 If no ``multi-package.yaml`` is found, the cross-package jump-to-definition feature
-will not jump to the real on-disk source code, however other Multi-IDE features will
-still work as normal.
+cannot jump to the real on-disk source code, however, other Multi-IDE features still work as normal.
 
 Package Environments and Hot-Loading
 ====================================
 The Multi-IDE runs a separate package environment for each package in the project,
-allowing the IDE to replicate properties such as dependencies, module-prefixes and build-options
+allowing the IDE to replicate properties such as dependencies, module-prefixes, and build-options
 of each package individually, without clashing with other packages in the project.
-A package's environment will automatically reload if its ``daml.yaml`` file changes,
+A package's environment automatically reloads if its ``daml.yaml`` file changes,
 or any of the dependency DAR files change.  
 
 Note, however, that the Multi-IDE does not hold "live" copies of DARs, therefore any changes
-to a package that is a dependency of another package will not be visible in that second package until
-running ``daml build``.  
+to a package that is a dependency of another package are not visible in that second package until
+you run ``daml build``.  
 You can run ``daml build --all`` to rebuild all relevant DARs, and the IDE will account for this
 and reload environments as necessary.  
 
-Jumping to definition on non-local dependencies (i.e. those not listed in ``multi-package.yaml``)
-will also use the correct environment, giving correct diagnostics for that package, and allowing
-further jumps down the stack. However, this can only jump to a package for which the source code is available, i.e. packages to which the DAR can be found in any of the following places:
+Jumping to definition on non-local dependencies (those not listed in ``multi-package.yaml``)
+also uses the correct environment, giving correct diagnostics for that package, and allowing
+further jumps down the stack. However, this can only jump to a package for which the source code is available, that is packages to which the DAR can be found in any of the following places:
 - The ``data-dependencies`` field of the current package or any other packages known to the ``multi-package.yaml``
 - Under the added ``dars`` field in the ``multi-package.yaml``, which is shown below:
 
@@ -415,26 +414,26 @@ further jumps down the stack. However, this can only jump to a package for which
   # Given my-package depends on some DAR, which then depends on my-transitive-dependency
   - ./dars/my-transitive-dependency-1.0.0.dar
 
-Adding DAR paths to this field will have no effect on building, serving only for the IDE to jump to.
+Adding DAR paths to this field has no effect on building, serving only for the IDE to jump to.
 
 Multiple Daml SDK Versions
 ==========================
 Separate package environments can run in different Daml SDK versions (though some features may
 not work correctly in versions <= 2.8). When opening a file, or jumping to a location
-in a package running a Daml version that is not currently installed, Daml Studio will prompt
-you to install the missing Daml SDK, and handle the installation, progress reporting and
+in a package running a Daml version that is not currently installed, Daml Studio prompts
+you to install the missing Daml SDK, and then handles the installation, progress reporting, and
 cancellation within a notification.
 
 Directory Envrionment Tools (direnv)
 ====================================
-It is common to use tools like ``direnv`` to set up dependencies and import environment variables
-for use with :ref:`environment variable interpolation support <environment-variable-interpolation>`. In order to have this working in Daml Studio,
-you will need a VSCode extension that sets this up for other extensions.
+Tools like ``direnv`` are commonly used to set up dependencies and import environment variables
+for use with :ref:`environment variable interpolation support <environment-variable-interpolation>`. To make this work in Daml Studio,
+you need a VSCode extension that sets this up for other extensions.
 In the case of ``direnv`` specifically (i.e. you have a ``.envrc`` file), we
 recommend using `this direnv extension by Martin Kühl <https://marketplace.visualstudio.com/items?itemName=mkhl.direnv>`__, which we have verified is compatible.
 Other direnv extensions may not correctly pass environment information to the Daml Studio extension.
 
-If the Daml extension detects a ``.envrc`` file, it will recommend this extension within the IDE with the
+If the Daml extension detects a ``.envrc`` file, it recommends this extension within the IDE with the
 following message:
 
 ..code::
@@ -442,22 +441,22 @@ following message:
   Found an .envrc file but the recommended direnv VSCode extension is not installed. Daml IDE may fail to start due to missing environment variables.
   Would you like to install the recommended direnv extension or attempt to continue without it?
 
-It will also provide a link to the extension on the VS Code extension marketplace.
+It also provides a link to the extension on the VS Code extension marketplace.
 
 Limitations in 2.10.0-rc
 ========================
-These limtations are for the Release Candidate only, and will be fixed for 2.10 full release.
+These limitations are for the Release Candidate only, not for the 2.10 full release.
 
 * Jumping to non-local dependencies does not currently retain the build-options and module-prefixes
   for that package. This means that if you jump to a dependency that requires either of these to build,
-  the editor will show errors on the source code.
+  the editor shows errors in the source code.
 * Some links in the Script Results tab may not resolve correctly cross-package.
 * Packages with symlinks between the daml.yaml and source files may not give correct intelligence.
 
 Setting Multi-IDE SDK Version
 =============================
-The Multi-IDE will select the correct SDK version for each package you interact with, however the
-Multi-IDE itself will run from your most recent installed SDK version. You can override this using
+The Multi-IDE selects the correct SDK version for each package you interact with. However the
+Multi-IDE itself runs from your most recently installed SDK version. You can override this using
 an additional ``daml.yaml`` file at the root of your project (next to the ``multi-package.yaml``)
 containing only an SDK Version, as follows:
 
@@ -482,10 +481,10 @@ Note that Multi-IDE is only supported in 2.10+.
 
   sdk-version: 2.10.0
 
-This feature can also be used when Multi-IDE is disabled, as below.
+This feature can also be used when Multi-IDE is inactive, as described below.
 
-Disabling Multi-IDE
-===================
-The Multi-IDE feature can be disabled by going to VSCode settings (``ctrl + ,``), searching for 
+Deactivating Multi-IDE
+======================
+The Multi-IDE feature can be deactivated by going to VSCode settings (``ctrl + ,``), searching for 
 ``Daml: Multi Package Ide Support``, and unticking the box. You do not need to restart your editor.
-If you are disabling this feature due to a bug, please report it on the `forums <https://discuss.daml.com/>`__.
+If you are deactivating this feature due to a bug, please report it on the `forums <https://discuss.daml.com/>`__.

--- a/docs/2.10.0/docs/daml/daml-studio.rst
+++ b/docs/2.10.0/docs/daml/daml-studio.rst
@@ -420,7 +420,7 @@ Adding DAR paths to this field will have no effect on building, serving only for
 Multiple Daml SDK Versions
 ==========================
 Separate package environments can run in different Daml SDK versions (though some features may
-not work correctly in versions older than 2.9). When opening a file, or jumping to a location
+not work correctly in versions <= 2.8). When opening a file, or jumping to a location
 in a package running a Daml version that is not currently installed, Daml Studio will prompt
 you to install the missing Daml SDK, and handle the installation, progress reporting and
 cancellation within a notification.
@@ -439,11 +439,12 @@ providing a link to the extension on the VS Code extension marketplace.
 Limitations in 2.10.0-rc
 ========================
 These limtations are for the Release Candidate only, and will be fixed for 2.10 full release.
-- Jumping to non-local dependencies does not currently retain the build-options and module-prefixes
-for that package. This means that if you jump to a dependency that requires either of these to build,
-the editor will show errors on the source code.
-- Some links in the Script Results tab may not resolve correctly cross-package.
-- Packages with symlinks between the daml.yaml and source files may not give correct intelligence.
+
+* Jumping to non-local dependencies does not currently retain the build-options and module-prefixes
+  for that package. This means that if you jump to a dependency that requires either of these to build,
+  the editor will show errors on the source code.
+* Some links in the Script Results tab may not resolve correctly cross-package.
+* Packages with symlinks between the daml.yaml and source files may not give correct intelligence.
 
 Setting Multi-IDE SDK Version
 =============================

--- a/docs/2.10.0/docs/daml/daml-studio.rst
+++ b/docs/2.10.0/docs/daml/daml-studio.rst
@@ -433,8 +433,16 @@ you will need a VSCode extension that sets this up for other extensions.
 In the case of ``direnv`` specifically (i.e. you have a ``.envrc`` file), we
 recommend using `this direnv extension by Martin Kühl <https://marketplace.visualstudio.com/items?itemName=mkhl.direnv>`__, which we have verified is compatible.
 Other direnv extensions may not correctly pass environment information to the Daml Studio extension.
-If the Daml extension detects a ``.envrc`` file, it will recommend this extension within the IDE,
-providing a link to the extension on the VS Code extension marketplace.
+
+If the Daml extension detects a ``.envrc`` file, it will recommend this extension within the IDE with the
+following message:
+
+..code::
+
+  Found an .envrc file but the recommended direnv VSCode extension is not installed. Daml IDE may fail to start due to missing environment variables.
+  Would you like to install the recommended direnv extension or attempt to continue without it?
+
+It will also provide a link to the extension on the VS Code extension marketplace.
 
 Limitations in 2.10.0-rc
 ========================

--- a/docs/2.10.0/docs/tools/assistant-build.rst
+++ b/docs/2.10.0/docs/tools/assistant-build.rst
@@ -47,8 +47,8 @@ You can use multi-package builds to:
 -  Build all of the packages in a project simultaneously, using ``daml build --all``
 -  Clean all build artifacts in a project, using ``daml clean --all``
 
-Daml Studio also supports multi-package projects, which you are recommended to read
-about :ref:`here <daml-studio-packages>` after this page.
+Daml Studio also supports multi-package projects, which is covered
+:ref:`here <daml-studio-packages>`.
 
 Overview
 ========

--- a/docs/2.10.0/docs/tools/assistant-build.rst
+++ b/docs/2.10.0/docs/tools/assistant-build.rst
@@ -47,6 +47,9 @@ You can use multi-package builds to:
 -  Build all of the packages in a project simultaneously, using ``daml build --all``
 -  Clean all build artifacts in a project, using ``daml clean --all``
 
+Daml Studio also supports multi-package projects, which you are recommended to read
+about :ref:`here <daml-studio-packages>` after this page.
+
 Overview
 ========
 

--- a/docs/2.10.0/docs/tools/assistant.rst
+++ b/docs/2.10.0/docs/tools/assistant.rst
@@ -148,7 +148,7 @@ Here is what each field means:
   say ``daml start --start-navigator=true``, the CLI argument takes precedence over
   the value in ``daml.yaml``.
 
-The ``daml.yaml`` file supports `Environment Variable Interpolation <#environment-variable-interpolation>`__.
+The ``daml.yaml`` file supports :ref:`Environment Variable Interpolation <environment-variable-interpolation>`.
 
 Recommended ``build-options``
 =============================
@@ -205,7 +205,9 @@ Here is what each field means:
 - ``projects``: an optional list of directories containing ``multi-package.yaml`` config files, which will extend the above package set for resolving
   the build order. These exist to allow separation of your project into sub-projects which can still be built when removed from the surrounding environment.
 
-The ``multi-package.yaml`` file supports `Environment Variable Interpolation <#environment-variable-interpolation>`__.
+The ``multi-package.yaml`` file supports :ref:`Environment Variable Interpolation <environment-variable-interpolation>`.
+
+.. _environment-variable-interpolation:
 
 Environment Variable Interpolation
 ==================================

--- a/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
+++ b/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
@@ -308,7 +308,7 @@ PQS & Daml Shell
 ~~~~~~~~~~~~~~~~
 
 As of 2.9, PQS only supports querying contracts via package-name, 
-dropping support for direct pacakge-id queries. See
+dropping support for direct package-id queries. See
 `Limitations <#limitations>`__ for more information and a work-around.
 
 Daml Shell builds on top of PQS, so inherits this behavior.


### PR DESCRIPTION
There is a note about 2.10rc limitations, we will fix them in the 2.10 full release, but assuming we'll give these docs to the testers of the rc, its worth noting there.

I've mostly replaced the sdk-version only daml.yaml, as its main purpose is replaced by multi-ide. It still has use, but we may replace that too.