### PR TITLE
Fix upgrade table formatting

### DIFF
--- a/docs/2.10.0/docs/upgrade/upgrade-scopes.csv
+++ b/docs/2.10.0/docs/upgrade/upgrade-scopes.csv
@@ -6,12 +6,12 @@ Rename of Template,Template Definition,No,
 Change of Field Type,Template Definition,No,
 Change of Field Ordering,Template Definition,No,
 Change of Field Name,Template Definition,No,
-Change of Signatories,Template Definition,No,"A new template version needs to return the same signatory result for a persisted contract, otherwise the contracts cannot be used by an upgraded package (this fails at runtime)."
-,,,
-,,,One can change the function that computes the signatories (for example to take into account new fields) when creating contracts.
-Change of,Template,No,"The key's type cannot be changed, like adding a new field in the record it contains."
-,,,
-,,,One can change the function that computes the key in the same way the function computing the signatories can be changed. A persisted contract can be used by an upgrade only if the result of the function does not change.
+Change of Signatories,Template Definition,No,"| A new template version needs to return the same signatory result for a persisted contract, otherwise the contracts cannot be used by an upgraded package (this fails at runtime).
+|
+| One can change the function that computes the signatories (for example to take into account new fields) when creating contracts."
+Change of,Template,No,"| The key's type cannot be changed, like adding a new field in the record it contains.
+|
+| One can change the function that computes the key in the same way the function computing the signatories can be changed. A persisted contract can be used by an upgrade only if the result of the function does not change."
 Change of Observers,Template Definition,No,Same as template signatories
 Change of Key Maintainers,Template Definition,No,Same as template signatories
 Change of Ensure Predicate,Template Definition,Yes,Note that the Ensure is recalculated just before usage so any changes need to ensure that a V1 contract is still valid as a V2 contract.
@@ -23,10 +23,10 @@ Addition of Choice Parameters,Choice,"Yes, but they must be optional",
 Deletion of Choice Parameters,Choice,No,
 "Change of Consuming Choice to Non-Consuming Choice, or Vice-versa",Choice,No,
 Change of Choice Body,Choice,Yes,
-Change of Choice Return Type,Choice,"Yes, except for Tuple or scalar types","You can change a user data type (Record, Variant, Enum) contained in the return type. In this case you can add a field to the record or a new case to the Variant/Enum."
-,,,
-,,,"In particular: you cannot change a collection, Optional, List, or Map; you can change Tuple, (to a triple) if you define your own type."
-Change of Interface Definition,Interface Definition, No,Interfaces are static and cannot be changed. Separate interface definition and keep the implementation in the template code.
+Change of Choice Return Type,Choice,"Yes, except for Tuple or scalar types","| You can change a user data type (Record, Variant, Enum) contained in the return type. In this case you can add a field to the record or a new case to the Variant/Enum.
+|
+| In particular: you cannot change a collection, Optional, List, or Map; you can change Tuple, (to a triple) if you define your own type."
+Change of Interface Definition,Interface Definition,No,Interfaces are static and cannot be changed. Separate interface definition and keep the implementation in the template code.
 Addition of Interface Implementations (Retroactive Interfaces),Interface Definition,No,
-Adding or Removing Interfaces from Templates, Template Definition, No, Interfaces cannot be changed.
-Change or Deletion of Exception,Exception Definition,No,"Keep the exception definition separate. Exceptions cannot be upgraded."
+Adding or Removing Interfaces from Templates,Template Definition,No,Interfaces cannot be changed.
+Change or Deletion of Exception,Exception Definition,No,Keep the exception definition separate. Exceptions cannot be upgraded.


### PR DESCRIPTION
Used to look like this:
![image](https://github.com/user-attachments/assets/84ded46d-8f0b-43c7-bbc2-e447ce67ed0f)

Now looks like this:
![image](https://github.com/user-attachments/assets/9d8ceb47-bab9-4990-ac2a-398263a81857)
