### PR TITLE
Daml Finance / Update docs for SDK release 2.10.0

### DIFF
--- a/docs/2.10.0/_toc.yml
+++ b/docs/2.10.0/_toc.yml
@@ -352,7 +352,7 @@ subtrees:
           maxdepth: 1
           entries:
           - file: daml-finance/packages/interfaces/daml-finance-interface-holding
-            title: "Daml.Finance.Interface.Holding"
+            title: "Daml.Finance.Interface.Holding.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -361,7 +361,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-holding.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-account
-            title: "Daml.Finance.Interface.Account"
+            title: "Daml.Finance.Interface.Account.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -370,7 +370,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-account.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-settlement
-            title: "Daml.Finance.Interface.Settlement"
+            title: "Daml.Finance.Interface.Settlement.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -379,7 +379,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-settlement.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-lifecycle
-            title: "Daml.Finance.Interface.Lifecycle"
+            title: "Daml.Finance.Interface.Lifecycle.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -388,7 +388,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-lifecycle.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-base
-            title: "Daml.Finance.Interface.Instrument.Base"
+            title: "Daml.Finance.Interface.Instrument.Base.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -397,7 +397,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-base.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-claims
-            title: "Daml.Finance.Interface.Claims"
+            title: "Daml.Finance.Interface.Claims.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -406,7 +406,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-claims.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-data
-            title: "Daml.Finance.Interface.Data"
+            title: "Daml.Finance.Interface.Data.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -415,7 +415,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-types-common
-            title: "Daml.Finance.Interface.Types.Common"
+            title: "Daml.Finance.Interface.Types.Common.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -424,7 +424,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-common.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-types-date
-            title: "Daml.Finance.Interface.Types.Date"
+            title: "Daml.Finance.Interface.Types.Date.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -433,7 +433,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-date.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-util
-            title: "Daml.Finance.Interface.Util"
+            title: "Daml.Finance.Interface.Util.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -442,7 +442,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-util.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/contingent-claims-core
-            title: "ContingentClaims.Core"
+            title: "ContingentClaims.Core.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -451,7 +451,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/contingent-claims-core.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-bond
-            title: "Daml.Finance.Interface.Instrument.Bond"
+            title: "Daml.Finance.Interface.Instrument.Bond.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -460,7 +460,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-bond.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-equity
-            title: "Daml.Finance.Interface.Instrument.Equity"
+            title: "Daml.Finance.Interface.Instrument.Equity.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -469,7 +469,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-equity.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-generic
-            title: "Daml.Finance.Interface.Instrument.Generic"
+            title: "Daml.Finance.Interface.Instrument.Generic.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -478,7 +478,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-generic.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-option
-            title: "Daml.Finance.Interface.Instrument.Option"
+            title: "Daml.Finance.Interface.Instrument.Option.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -487,7 +487,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-option.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-structuredproduct
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct"
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -496,7 +496,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-structuredproduct.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-swap
-            title: "Daml.Finance.Interface.Instrument.Swap"
+            title: "Daml.Finance.Interface.Instrument.Swap.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -505,7 +505,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-swap.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-token
-            title: "Daml.Finance.Interface.Instrument.Token"
+            title: "Daml.Finance.Interface.Instrument.Token.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -514,7 +514,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-token.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-types
-            title: "Daml.Finance.Interface.Instrument.Types"
+            title: "Daml.Finance.Interface.Instrument.Types.V2"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -530,7 +530,7 @@ subtrees:
           maxdepth: 1
           entries:
           - file: daml-finance/packages/implementations/daml-finance-holding
-            title: "Daml.Finance.Holding"
+            title: "Daml.Finance.Holding.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -539,7 +539,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-holding.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-account
-            title: "Daml.Finance.Account"
+            title: "Daml.Finance.Account.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -548,7 +548,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-account.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-settlement
-            title: "Daml.Finance.Settlement"
+            title: "Daml.Finance.Settlement.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -557,7 +557,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-settlement.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-lifecycle
-            title: "Daml.Finance.Lifecycle"
+            title: "Daml.Finance.Lifecycle.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -566,7 +566,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-lifecycle.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-data
-            title: "Daml.Finance.Data"
+            title: "Daml.Finance.Data.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -575,7 +575,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-data.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-claims
-            title: "Daml.Finance.Claims"
+            title: "Daml.Finance.Claims.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -584,7 +584,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-claims.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-util
-            title: "Daml.Finance.Util"
+            title: "Daml.Finance.Util.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -593,7 +593,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-util.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/contingent-claims-lifecycle
-            title: "ContingentClaims.Lifecycle"
+            title: "ContingentClaims.Lifecycle.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -602,7 +602,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/contingent-claims-lifecycle.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/contingent-claims-valuation
-            title: "ContingentClaims.Valuation"
+            title: "ContingentClaims.Valuation.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -611,7 +611,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/contingent-claims-valuation.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-instrument-bond
-            title: "Daml.Finance.Instrument.Bond"
+            title: "Daml.Finance.Instrument.Bond.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -620,7 +620,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-instrument-bond.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-instrument-equity
-            title: "Daml.Finance.Instrument.Equity"
+            title: "Daml.Finance.Instrument.Equity.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -629,7 +629,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-instrument-equity.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-instrument-generic
-            title: "Daml.Finance.Instrument.Generic"
+            title: "Daml.Finance.Instrument.Generic.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -638,7 +638,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-instrument-generic.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-instrument-option
-            title: "Daml.Finance.Instrument.Option"
+            title: "Daml.Finance.Instrument.Option.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -647,7 +647,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-instrument-option.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-instrument-structuredproduct
-            title: "Daml.Finance.Instrument.StructuredProduct"
+            title: "Daml.Finance.Instrument.StructuredProduct.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -656,7 +656,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-instrument-structuredproduct.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-instrument-swap
-            title: "Daml.Finance.Instrument.Swap"
+            title: "Daml.Finance.Instrument.Swap.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -665,7 +665,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-instrument-swap.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-instrument-token
-            title: "Daml.Finance.Instrument.Token"
+            title: "Daml.Finance.Instrument.Token.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -749,410 +749,410 @@ subtrees:
           titlesonly: True
           maxdepth: 3
           entries:
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Builders
-            title: "ContingentClaims.Core.Builders"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Claim
-            title: "ContingentClaims.Core.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Internal-Claim
-            title: "ContingentClaims.Core.Internal.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Observation
-            title: "ContingentClaims.Core.Observation"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Util-Recursion
-            title: "ContingentClaims.Core.Util.Recursion"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Lifecycle-Lifecycle
-            title: "ContingentClaims.Lifecycle.Lifecycle"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Lifecycle-Util
-            title: "ContingentClaims.Lifecycle.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Valuation-MathML
-            title: "ContingentClaims.Valuation.MathML"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Valuation-Stochastic
-            title: "ContingentClaims.Valuation.Stochastic"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Account-Account
-            title: "Daml.Finance.Account.Account"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Lifecycle-Rule
-            title: "Daml.Finance.Claims.Lifecycle.Rule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Util
-            title: "Daml.Finance.Claims.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Util-Builders
-            title: "Daml.Finance.Claims.Util.Builders"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Util-Date
-            title: "Daml.Finance.Claims.Util.Date"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Util-Lifecycle
-            title: "Daml.Finance.Claims.Util.Lifecycle"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Numeric-Observation
-            title: "Daml.Finance.Data.Numeric.Observation"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Reference-HolidayCalendar
-            title: "Daml.Finance.Data.Reference.HolidayCalendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-DateClock
-            title: "Daml.Finance.Data.Time.DateClock"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-DateClock-Types
-            title: "Daml.Finance.Data.Time.DateClock.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-DateClockUpdate
-            title: "Daml.Finance.Data.Time.DateClockUpdate"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-LedgerTime
-            title: "Daml.Finance.Data.Time.LedgerTime"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-BaseHolding
-            title: "Daml.Finance.Holding.BaseHolding"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-Factory
-            title: "Daml.Finance.Holding.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-Fungible
-            title: "Daml.Finance.Holding.Fungible"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-Transferable
-            title: "Daml.Finance.Holding.Transferable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-TransferableFungible
-            title: "Daml.Finance.Holding.TransferableFungible"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-Util
-            title: "Daml.Finance.Holding.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-Callable-Factory
-            title: "Daml.Finance.Instrument.Bond.Callable.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-Callable-Instrument
-            title: "Daml.Finance.Instrument.Bond.Callable.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FixedRate-Factory
-            title: "Daml.Finance.Instrument.Bond.FixedRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FixedRate-Instrument
-            title: "Daml.Finance.Instrument.Bond.FixedRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FloatingRate-Factory
-            title: "Daml.Finance.Instrument.Bond.FloatingRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FloatingRate-Instrument
-            title: "Daml.Finance.Instrument.Bond.FloatingRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-InflationLinked-Factory
-            title: "Daml.Finance.Instrument.Bond.InflationLinked.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-InflationLinked-Instrument
-            title: "Daml.Finance.Instrument.Bond.InflationLinked.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-Util
-            title: "Daml.Finance.Instrument.Bond.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-ZeroCoupon-Factory
-            title: "Daml.Finance.Instrument.Bond.ZeroCoupon.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-ZeroCoupon-Instrument
-            title: "Daml.Finance.Instrument.Bond.ZeroCoupon.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Equity-Factory
-            title: "Daml.Finance.Instrument.Equity.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Equity-Instrument
-            title: "Daml.Finance.Instrument.Equity.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-Factory
-            title: "Daml.Finance.Instrument.Generic.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-Instrument
-            title: "Daml.Finance.Instrument.Generic.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-Lifecycle-Rule
-            title: "Daml.Finance.Instrument.Generic.Lifecycle.Rule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-BarrierEuropeanCash-Factory
-            title: "Daml.Finance.Instrument.Option.BarrierEuropeanCash.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-BarrierEuropeanCash-Instrument
-            title: "Daml.Finance.Instrument.Option.BarrierEuropeanCash.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-Dividend-Factory
-            title: "Daml.Finance.Instrument.Option.Dividend.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-Dividend-Instrument
-            title: "Daml.Finance.Instrument.Option.Dividend.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-Dividend-Election
-            title: "Daml.Finance.Instrument.Option.Dividend.Election"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-EuropeanCash-Factory
-            title: "Daml.Finance.Instrument.Option.EuropeanCash.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-EuropeanCash-Instrument
-            title: "Daml.Finance.Instrument.Option.EuropeanCash.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-EuropeanPhysical-Factory
-            title: "Daml.Finance.Instrument.Option.EuropeanPhysical.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-EuropeanPhysical-Instrument
-            title: "Daml.Finance.Instrument.Option.EuropeanPhysical.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-AutoCallable-Factory
-            title: "Daml.Finance.Instrument.StructuredProduct.AutoCallable.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-AutoCallable-Instrument
-            title: "Daml.Finance.Instrument.StructuredProduct.AutoCallable.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-BarrierReverseConvertible-Factory
-            title: "Daml.Finance.Instrument.StructuredProduct.BarrierReverseConvertible.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-BarrierReverseConvertible-Instrument
-            title: "Daml.Finance.Instrument.StructuredProduct.BarrierReverseConvertible.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-Util
-            title: "Daml.Finance.Instrument.StructuredProduct.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Asset-Factory
-            title: "Daml.Finance.Instrument.Swap.Asset.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Asset-Instrument
-            title: "Daml.Finance.Instrument.Swap.Asset.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Asset-DistributionRule
-            title: "Daml.Finance.Instrument.Swap.Asset.DistributionRule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-CreditDefault-Factory
-            title: "Daml.Finance.Instrument.Swap.CreditDefault.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-CreditDefault-Instrument
-            title: "Daml.Finance.Instrument.Swap.CreditDefault.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Currency-Factory
-            title: "Daml.Finance.Instrument.Swap.Currency.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Currency-Instrument
-            title: "Daml.Finance.Instrument.Swap.Currency.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-ForeignExchange-Factory
-            title: "Daml.Finance.Instrument.Swap.ForeignExchange.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-ForeignExchange-Instrument
-            title: "Daml.Finance.Instrument.Swap.ForeignExchange.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Fpml-Factory
-            title: "Daml.Finance.Instrument.Swap.Fpml.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Fpml-Instrument
-            title: "Daml.Finance.Instrument.Swap.Fpml.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Fpml-Util
-            title: "Daml.Finance.Instrument.Swap.Fpml.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-InterestRate-Factory
-            title: "Daml.Finance.Instrument.Swap.InterestRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-InterestRate-Instrument
-            title: "Daml.Finance.Instrument.Swap.InterestRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Token-Factory
-            title: "Daml.Finance.Instrument.Token.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Token-Instrument
-            title: "Daml.Finance.Instrument.Token.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-Account
-            title: "Daml.Finance.Interface.Account.Account"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-Factory
-            title: "Daml.Finance.Interface.Account.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-Util
-            title: "Daml.Finance.Interface.Account.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-Claim
-            title: "Daml.Finance.Interface.Claims.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-Dynamic-Instrument
-            title: "Daml.Finance.Interface.Claims.Dynamic.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-Types
-            title: "Daml.Finance.Interface.Claims.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Numeric-Observation
-            title: "Daml.Finance.Interface.Data.Numeric.Observation"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Numeric-Observation-Factory
-            title: "Daml.Finance.Interface.Data.Numeric.Observation.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Reference-HolidayCalendar
-            title: "Daml.Finance.Interface.Data.Reference.HolidayCalendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Reference-HolidayCalendar-Factory
-            title: "Daml.Finance.Interface.Data.Reference.HolidayCalendar.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Reference-Time
-            title: "Daml.Finance.Interface.Data.Reference.Time"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Factory
-            title: "Daml.Finance.Interface.Holding.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Fungible
-            title: "Daml.Finance.Interface.Holding.Fungible"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Holding
-            title: "Daml.Finance.Interface.Holding.Holding"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Transferable
-            title: "Daml.Finance.Interface.Holding.Transferable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Util
-            title: "Daml.Finance.Interface.Holding.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Base-Instrument
-            title: "Daml.Finance.Interface.Instrument.Base.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-Callable-Factory
-            title: "Daml.Finance.Interface.Instrument.Bond.Callable.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-Callable-Instrument
-            title: "Daml.Finance.Interface.Instrument.Bond.Callable.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-Callable-Types
-            title: "Daml.Finance.Interface.Instrument.Bond.Callable.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FixedRate-Factory
-            title: "Daml.Finance.Interface.Instrument.Bond.FixedRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FixedRate-Instrument
-            title: "Daml.Finance.Interface.Instrument.Bond.FixedRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FixedRate-Types
-            title: "Daml.Finance.Interface.Instrument.Bond.FixedRate.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Factory
-            title: "Daml.Finance.Interface.Instrument.Bond.FloatingRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Instrument
-            title: "Daml.Finance.Interface.Instrument.Bond.FloatingRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Types
-            title: "Daml.Finance.Interface.Instrument.Bond.FloatingRate.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Factory
-            title: "Daml.Finance.Interface.Instrument.Bond.InflationLinked.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Instrument
-            title: "Daml.Finance.Interface.Instrument.Bond.InflationLinked.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Types
-            title: "Daml.Finance.Interface.Instrument.Bond.InflationLinked.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Factory
-            title: "Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Instrument
-            title: "Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Types
-            title: "Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Equity-Factory
-            title: "Daml.Finance.Interface.Instrument.Equity.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Equity-Instrument
-            title: "Daml.Finance.Interface.Instrument.Equity.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-Factory
-            title: "Daml.Finance.Interface.Instrument.Generic.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-Instrument
-            title: "Daml.Finance.Interface.Instrument.Generic.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-BarrierEuropeanCash-Factory
-            title: "Daml.Finance.Interface.Instrument.Option.BarrierEuropeanCash.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-BarrierEuropeanCash-Instrument
-            title: "Daml.Finance.Interface.Instrument.Option.BarrierEuropeanCash.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-BarrierEuropeanCash-Types
-            title: "Daml.Finance.Interface.Instrument.Option.BarrierEuropeanCash.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-Dividend-Factory
-            title: "Daml.Finance.Interface.Instrument.Option.Dividend.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-Dividend-Instrument
-            title: "Daml.Finance.Interface.Instrument.Option.Dividend.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-Dividend-Types
-            title: "Daml.Finance.Interface.Instrument.Option.Dividend.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-Dividend-Election-Factory
-            title: "Daml.Finance.Interface.Instrument.Option.Dividend.Election.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-EuropeanCash-Factory
-            title: "Daml.Finance.Interface.Instrument.Option.EuropeanCash.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-EuropeanCash-Instrument
-            title: "Daml.Finance.Interface.Instrument.Option.EuropeanCash.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-EuropeanCash-Types
-            title: "Daml.Finance.Interface.Instrument.Option.EuropeanCash.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-EuropeanPhysical-Factory
-            title: "Daml.Finance.Interface.Instrument.Option.EuropeanPhysical.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-EuropeanPhysical-Instrument
-            title: "Daml.Finance.Interface.Instrument.Option.EuropeanPhysical.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-EuropeanPhysical-Types
-            title: "Daml.Finance.Interface.Instrument.Option.EuropeanPhysical.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-Types
-            title: "Daml.Finance.Interface.Instrument.Option.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-AutoCallable-Factory
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct.AutoCallable.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-AutoCallable-Instrument
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct.AutoCallable.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-AutoCallable-Types
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct.AutoCallable.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-BarrierReverseConvertible-Factory
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvertible.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-BarrierReverseConvertible-Instrument
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvertible.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-BarrierReverseConvertible-Types
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvertible.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-Types
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Asset-Factory
-            title: "Daml.Finance.Interface.Instrument.Swap.Asset.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Asset-Instrument
-            title: "Daml.Finance.Interface.Instrument.Swap.Asset.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Asset-Types
-            title: "Daml.Finance.Interface.Instrument.Swap.Asset.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Factory
-            title: "Daml.Finance.Interface.Instrument.Swap.CreditDefault.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Instrument
-            title: "Daml.Finance.Interface.Instrument.Swap.CreditDefault.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Types
-            title: "Daml.Finance.Interface.Instrument.Swap.CreditDefault.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Currency-Factory
-            title: "Daml.Finance.Interface.Instrument.Swap.Currency.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Currency-Instrument
-            title: "Daml.Finance.Interface.Instrument.Swap.Currency.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Currency-Types
-            title: "Daml.Finance.Interface.Instrument.Swap.Currency.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Factory
-            title: "Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Instrument
-            title: "Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Types
-            title: "Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-Factory
-            title: "Daml.Finance.Interface.Instrument.Swap.Fpml.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-FpmlTypes
-            title: "Daml.Finance.Interface.Instrument.Swap.Fpml.FpmlTypes"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-Instrument
-            title: "Daml.Finance.Interface.Instrument.Swap.Fpml.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-Types
-            title: "Daml.Finance.Interface.Instrument.Swap.Fpml.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-InterestRate-Factory
-            title: "Daml.Finance.Interface.Instrument.Swap.InterestRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-InterestRate-Instrument
-            title: "Daml.Finance.Interface.Instrument.Swap.InterestRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-InterestRate-Types
-            title: "Daml.Finance.Interface.Instrument.Swap.InterestRate.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-Factory
-            title: "Daml.Finance.Interface.Instrument.Token.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-Instrument
-            title: "Daml.Finance.Interface.Instrument.Token.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-Types
-            title: "Daml.Finance.Interface.Instrument.Token.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Types-FloatingRate
-            title: "Daml.Finance.Interface.Instrument.Types.FloatingRate"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Effect
-            title: "Daml.Finance.Interface.Lifecycle.Effect"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Election
-            title: "Daml.Finance.Interface.Lifecycle.Election"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Election-Factory
-            title: "Daml.Finance.Interface.Lifecycle.Election.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event
-            title: "Daml.Finance.Interface.Lifecycle.Event"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event-Distribution
-            title: "Daml.Finance.Interface.Lifecycle.Event.Distribution"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event-Replacement
-            title: "Daml.Finance.Interface.Lifecycle.Event.Replacement"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event-Time
-            title: "Daml.Finance.Interface.Lifecycle.Event.Time"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Observable-NumericObservable
-            title: "Daml.Finance.Interface.Lifecycle.Observable.NumericObservable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Observable-TimeObservable
-            title: "Daml.Finance.Interface.Lifecycle.Observable.TimeObservable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Rule-Claim
-            title: "Daml.Finance.Interface.Lifecycle.Rule.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Rule-Lifecycle
-            title: "Daml.Finance.Interface.Lifecycle.Rule.Lifecycle"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Batch
-            title: "Daml.Finance.Interface.Settlement.Batch"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Factory
-            title: "Daml.Finance.Interface.Settlement.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Instruction
-            title: "Daml.Finance.Interface.Settlement.Instruction"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-RouteProvider
-            title: "Daml.Finance.Interface.Settlement.RouteProvider"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Types
-            title: "Daml.Finance.Interface.Settlement.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Common-Types
-            title: "Daml.Finance.Interface.Types.Common.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-Calendar
-            title: "Daml.Finance.Interface.Types.Date.Calendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-Classes
-            title: "Daml.Finance.Interface.Types.Date.Classes"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-DateOffset
-            title: "Daml.Finance.Interface.Types.Date.DateOffset"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-DayCount
-            title: "Daml.Finance.Interface.Types.Date.DayCount"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-RollConvention
-            title: "Daml.Finance.Interface.Types.Date.RollConvention"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-Schedule
-            title: "Daml.Finance.Interface.Types.Date.Schedule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-Common
-            title: "Daml.Finance.Interface.Util.Common"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-Disclosure
-            title: "Daml.Finance.Interface.Util.Disclosure"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-InterfaceKey
-            title: "Daml.Finance.Interface.Util.InterfaceKey"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-Lockable
-            title: "Daml.Finance.Interface.Util.Lockable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Effect
-            title: "Daml.Finance.Lifecycle.Effect"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Election
-            title: "Daml.Finance.Lifecycle.Election"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-ElectionEffect
-            title: "Daml.Finance.Lifecycle.ElectionEffect"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Event-Distribution
-            title: "Daml.Finance.Lifecycle.Event.Distribution"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Event-Replacement
-            title: "Daml.Finance.Lifecycle.Event.Replacement"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Claim
-            title: "Daml.Finance.Lifecycle.Rule.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Distribution
-            title: "Daml.Finance.Lifecycle.Rule.Distribution"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Replacement
-            title: "Daml.Finance.Lifecycle.Rule.Replacement"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Util
-            title: "Daml.Finance.Lifecycle.Rule.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Batch
-            title: "Daml.Finance.Settlement.Batch"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Factory
-            title: "Daml.Finance.Settlement.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Hierarchy
-            title: "Daml.Finance.Settlement.Hierarchy"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Instruction
-            title: "Daml.Finance.Settlement.Instruction"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-RouteProvider-IntermediatedStatic
-            title: "Daml.Finance.Settlement.RouteProvider.IntermediatedStatic"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-RouteProvider-SingleCustodian
-            title: "Daml.Finance.Settlement.RouteProvider.SingleCustodian"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Common
-            title: "Daml.Finance.Util.Common"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-Calendar
-            title: "Daml.Finance.Util.Date.Calendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-DayCount
-            title: "Daml.Finance.Util.Date.DayCount"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-RollConvention
-            title: "Daml.Finance.Util.Date.RollConvention"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-Schedule
-            title: "Daml.Finance.Util.Date.Schedule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Disclosure
-            title: "Daml.Finance.Util.Disclosure"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Lockable
-            title: "Daml.Finance.Util.Lockable"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-V3-Builders
+            title: "ContingentClaims.Core.V3.Builders"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-V3-Claim
+            title: "ContingentClaims.Core.V3.Claim"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-V3-Internal-Claim
+            title: "ContingentClaims.Core.V3.Internal.Claim"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-V3-Observation
+            title: "ContingentClaims.Core.V3.Observation"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-V3-Util-Recursion
+            title: "ContingentClaims.Core.V3.Util.Recursion"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Lifecycle-V3-Lifecycle
+            title: "ContingentClaims.Lifecycle.V3.Lifecycle"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Lifecycle-V3-Util
+            title: "ContingentClaims.Lifecycle.V3.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Valuation-V1-MathML
+            title: "ContingentClaims.Valuation.V1.MathML"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Valuation-V1-Stochastic
+            title: "ContingentClaims.Valuation.V1.Stochastic"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Account-V4-Account
+            title: "Daml.Finance.Account.V4.Account"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-V3-Lifecycle-Rule
+            title: "Daml.Finance.Claims.V3.Lifecycle.Rule"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-V3-Util
+            title: "Daml.Finance.Claims.V3.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-V3-Util-Builders
+            title: "Daml.Finance.Claims.V3.Util.Builders"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-V3-Util-Date
+            title: "Daml.Finance.Claims.V3.Util.Date"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-V3-Util-Lifecycle
+            title: "Daml.Finance.Claims.V3.Util.Lifecycle"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-V4-Numeric-Observation
+            title: "Daml.Finance.Data.V4.Numeric.Observation"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-V4-Reference-HolidayCalendar
+            title: "Daml.Finance.Data.V4.Reference.HolidayCalendar"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-V4-Time-DateClock
+            title: "Daml.Finance.Data.V4.Time.DateClock"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-V4-Time-DateClock-Types
+            title: "Daml.Finance.Data.V4.Time.DateClock.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-V4-Time-DateClockUpdate
+            title: "Daml.Finance.Data.V4.Time.DateClockUpdate"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-V4-Time-LedgerTime
+            title: "Daml.Finance.Data.V4.Time.LedgerTime"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-V4-BaseHolding
+            title: "Daml.Finance.Holding.V4.BaseHolding"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-V4-Factory
+            title: "Daml.Finance.Holding.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-V4-Fungible
+            title: "Daml.Finance.Holding.V4.Fungible"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-V4-Transferable
+            title: "Daml.Finance.Holding.V4.Transferable"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-V4-TransferableFungible
+            title: "Daml.Finance.Holding.V4.TransferableFungible"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-V4-Util
+            title: "Daml.Finance.Holding.V4.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-Callable-Factory
+            title: "Daml.Finance.Instrument.Bond.V3.Callable.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-Callable-Instrument
+            title: "Daml.Finance.Instrument.Bond.V3.Callable.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-FixedRate-Factory
+            title: "Daml.Finance.Instrument.Bond.V3.FixedRate.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-FixedRate-Instrument
+            title: "Daml.Finance.Instrument.Bond.V3.FixedRate.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-FloatingRate-Factory
+            title: "Daml.Finance.Instrument.Bond.V3.FloatingRate.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-FloatingRate-Instrument
+            title: "Daml.Finance.Instrument.Bond.V3.FloatingRate.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-InflationLinked-Factory
+            title: "Daml.Finance.Instrument.Bond.V3.InflationLinked.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-InflationLinked-Instrument
+            title: "Daml.Finance.Instrument.Bond.V3.InflationLinked.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-Util
+            title: "Daml.Finance.Instrument.Bond.V3.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-ZeroCoupon-Factory
+            title: "Daml.Finance.Instrument.Bond.V3.ZeroCoupon.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-ZeroCoupon-Instrument
+            title: "Daml.Finance.Instrument.Bond.V3.ZeroCoupon.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Equity-V1-Factory
+            title: "Daml.Finance.Instrument.Equity.V1.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Equity-V1-Instrument
+            title: "Daml.Finance.Instrument.Equity.V1.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-V4-Factory
+            title: "Daml.Finance.Instrument.Generic.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-V4-Instrument
+            title: "Daml.Finance.Instrument.Generic.V4.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-V4-Lifecycle-Rule
+            title: "Daml.Finance.Instrument.Generic.V4.Lifecycle.Rule"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-BarrierEuropeanCash-Factory
+            title: "Daml.Finance.Instrument.Option.V1.BarrierEuropeanCash.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-BarrierEuropeanCash-Instrument
+            title: "Daml.Finance.Instrument.Option.V1.BarrierEuropeanCash.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-Dividend-Factory
+            title: "Daml.Finance.Instrument.Option.V1.Dividend.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-Dividend-Instrument
+            title: "Daml.Finance.Instrument.Option.V1.Dividend.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-Dividend-Election
+            title: "Daml.Finance.Instrument.Option.V1.Dividend.Election"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-EuropeanCash-Factory
+            title: "Daml.Finance.Instrument.Option.V1.EuropeanCash.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-EuropeanCash-Instrument
+            title: "Daml.Finance.Instrument.Option.V1.EuropeanCash.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-EuropeanPhysical-Factory
+            title: "Daml.Finance.Instrument.Option.V1.EuropeanPhysical.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-EuropeanPhysical-Instrument
+            title: "Daml.Finance.Instrument.Option.V1.EuropeanPhysical.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-V1-AutoCallable-Factory
+            title: "Daml.Finance.Instrument.StructuredProduct.V1.AutoCallable.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-V1-AutoCallable-Instrument
+            title: "Daml.Finance.Instrument.StructuredProduct.V1.AutoCallable.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-V1-BarrierReverseConvertible-Factory
+            title: "Daml.Finance.Instrument.StructuredProduct.V1.BarrierReverseConvertible.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-V1-BarrierReverseConvertible-Instrument
+            title: "Daml.Finance.Instrument.StructuredProduct.V1.BarrierReverseConvertible.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-V1-Util
+            title: "Daml.Finance.Instrument.StructuredProduct.V1.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Asset-Factory
+            title: "Daml.Finance.Instrument.Swap.V1.Asset.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Asset-Instrument
+            title: "Daml.Finance.Instrument.Swap.V1.Asset.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Asset-DistributionRule
+            title: "Daml.Finance.Instrument.Swap.V1.Asset.DistributionRule"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-CreditDefault-Factory
+            title: "Daml.Finance.Instrument.Swap.V1.CreditDefault.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-CreditDefault-Instrument
+            title: "Daml.Finance.Instrument.Swap.V1.CreditDefault.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Currency-Factory
+            title: "Daml.Finance.Instrument.Swap.V1.Currency.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Currency-Instrument
+            title: "Daml.Finance.Instrument.Swap.V1.Currency.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-ForeignExchange-Factory
+            title: "Daml.Finance.Instrument.Swap.V1.ForeignExchange.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-ForeignExchange-Instrument
+            title: "Daml.Finance.Instrument.Swap.V1.ForeignExchange.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Fpml-Factory
+            title: "Daml.Finance.Instrument.Swap.V1.Fpml.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Fpml-Instrument
+            title: "Daml.Finance.Instrument.Swap.V1.Fpml.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Fpml-Util
+            title: "Daml.Finance.Instrument.Swap.V1.Fpml.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-InterestRate-Factory
+            title: "Daml.Finance.Instrument.Swap.V1.InterestRate.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-InterestRate-Instrument
+            title: "Daml.Finance.Instrument.Swap.V1.InterestRate.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Token-V4-Factory
+            title: "Daml.Finance.Instrument.Token.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Token-V4-Instrument
+            title: "Daml.Finance.Instrument.Token.V4.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-V4-Account
+            title: "Daml.Finance.Interface.Account.V4.Account"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-V4-Factory
+            title: "Daml.Finance.Interface.Account.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-V4-Util
+            title: "Daml.Finance.Interface.Account.V4.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-V4-Claim
+            title: "Daml.Finance.Interface.Claims.V4.Claim"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-V4-Dynamic-Instrument
+            title: "Daml.Finance.Interface.Claims.V4.Dynamic.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-V4-Types
+            title: "Daml.Finance.Interface.Claims.V4.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-V4-Numeric-Observation
+            title: "Daml.Finance.Interface.Data.V4.Numeric.Observation"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-V4-Numeric-Observation-Factory
+            title: "Daml.Finance.Interface.Data.V4.Numeric.Observation.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-V4-Reference-HolidayCalendar
+            title: "Daml.Finance.Interface.Data.V4.Reference.HolidayCalendar"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-V4-Reference-HolidayCalendar-Factory
+            title: "Daml.Finance.Interface.Data.V4.Reference.HolidayCalendar.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-V4-Reference-Time
+            title: "Daml.Finance.Interface.Data.V4.Reference.Time"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-V4-Factory
+            title: "Daml.Finance.Interface.Holding.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-V4-Fungible
+            title: "Daml.Finance.Interface.Holding.V4.Fungible"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-V4-Holding
+            title: "Daml.Finance.Interface.Holding.V4.Holding"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-V4-Transferable
+            title: "Daml.Finance.Interface.Holding.V4.Transferable"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-V4-Util
+            title: "Daml.Finance.Interface.Holding.V4.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Base-V4-Instrument
+            title: "Daml.Finance.Interface.Instrument.Base.V4.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-Callable-Factory
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.Callable.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-Callable-Instrument
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.Callable.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-Callable-Types
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.Callable.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-FixedRate-Factory
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.FixedRate.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-FixedRate-Instrument
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.FixedRate.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-FixedRate-Types
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.FixedRate.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-FloatingRate-Factory
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.FloatingRate.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-FloatingRate-Instrument
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.FloatingRate.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-FloatingRate-Types
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.FloatingRate.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-InflationLinked-Factory
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.InflationLinked.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-InflationLinked-Instrument
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.InflationLinked.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-InflationLinked-Types
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.InflationLinked.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-ZeroCoupon-Factory
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.ZeroCoupon.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-ZeroCoupon-Instrument
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.ZeroCoupon.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-ZeroCoupon-Types
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.ZeroCoupon.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Equity-V1-Factory
+            title: "Daml.Finance.Interface.Instrument.Equity.V1.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Equity-V1-Instrument
+            title: "Daml.Finance.Interface.Instrument.Equity.V1.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-V4-Factory
+            title: "Daml.Finance.Interface.Instrument.Generic.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-V4-Instrument
+            title: "Daml.Finance.Interface.Instrument.Generic.V4.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-BarrierEuropeanCash-Factory
+            title: "Daml.Finance.Interface.Instrument.Option.V1.BarrierEuropeanCash.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-BarrierEuropeanCash-Instrument
+            title: "Daml.Finance.Interface.Instrument.Option.V1.BarrierEuropeanCash.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-BarrierEuropeanCash-Types
+            title: "Daml.Finance.Interface.Instrument.Option.V1.BarrierEuropeanCash.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-Dividend-Factory
+            title: "Daml.Finance.Interface.Instrument.Option.V1.Dividend.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-Dividend-Instrument
+            title: "Daml.Finance.Interface.Instrument.Option.V1.Dividend.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-Dividend-Types
+            title: "Daml.Finance.Interface.Instrument.Option.V1.Dividend.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-Dividend-Election-Factory
+            title: "Daml.Finance.Interface.Instrument.Option.V1.Dividend.Election.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-EuropeanCash-Factory
+            title: "Daml.Finance.Interface.Instrument.Option.V1.EuropeanCash.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-EuropeanCash-Instrument
+            title: "Daml.Finance.Interface.Instrument.Option.V1.EuropeanCash.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-EuropeanCash-Types
+            title: "Daml.Finance.Interface.Instrument.Option.V1.EuropeanCash.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-EuropeanPhysical-Factory
+            title: "Daml.Finance.Interface.Instrument.Option.V1.EuropeanPhysical.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-EuropeanPhysical-Instrument
+            title: "Daml.Finance.Interface.Instrument.Option.V1.EuropeanPhysical.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-EuropeanPhysical-Types
+            title: "Daml.Finance.Interface.Instrument.Option.V1.EuropeanPhysical.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-Types
+            title: "Daml.Finance.Interface.Instrument.Option.V1.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-V1-AutoCallable-Factory
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1.AutoCallable.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-V1-AutoCallable-Instrument
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1.AutoCallable.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-V1-AutoCallable-Types
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1.AutoCallable.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-V1-BarrierReverseConvertible-Factory
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1.BarrierReverseConvertible.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-V1-BarrierReverseConvertible-Instrument
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1.BarrierReverseConvertible.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-V1-BarrierReverseConvertible-Types
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1.BarrierReverseConvertible.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-V1-Types
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Asset-Factory
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Asset.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Asset-Instrument
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Asset.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Asset-Types
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Asset.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-CreditDefault-Factory
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.CreditDefault.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-CreditDefault-Instrument
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.CreditDefault.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-CreditDefault-Types
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.CreditDefault.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Currency-Factory
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Currency.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Currency-Instrument
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Currency.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Currency-Types
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Currency.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-ForeignExchange-Factory
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.ForeignExchange.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-ForeignExchange-Instrument
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.ForeignExchange.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-ForeignExchange-Types
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.ForeignExchange.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Fpml-Factory
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Fpml.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Fpml-FpmlTypes
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Fpml.FpmlTypes"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Fpml-Instrument
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Fpml.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Fpml-Types
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Fpml.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-InterestRate-Factory
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.InterestRate.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-InterestRate-Instrument
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.InterestRate.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-InterestRate-Types
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.InterestRate.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-V4-Factory
+            title: "Daml.Finance.Interface.Instrument.Token.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-V4-Instrument
+            title: "Daml.Finance.Interface.Instrument.Token.V4.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-V4-Types
+            title: "Daml.Finance.Interface.Instrument.Token.V4.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Types-V2-FloatingRate
+            title: "Daml.Finance.Interface.Instrument.Types.V2.FloatingRate"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Effect
+            title: "Daml.Finance.Interface.Lifecycle.V4.Effect"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Election
+            title: "Daml.Finance.Interface.Lifecycle.V4.Election"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Election-Factory
+            title: "Daml.Finance.Interface.Lifecycle.V4.Election.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Event
+            title: "Daml.Finance.Interface.Lifecycle.V4.Event"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Event-Distribution
+            title: "Daml.Finance.Interface.Lifecycle.V4.Event.Distribution"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Event-Replacement
+            title: "Daml.Finance.Interface.Lifecycle.V4.Event.Replacement"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Event-Time
+            title: "Daml.Finance.Interface.Lifecycle.V4.Event.Time"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Observable-NumericObservable
+            title: "Daml.Finance.Interface.Lifecycle.V4.Observable.NumericObservable"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Observable-TimeObservable
+            title: "Daml.Finance.Interface.Lifecycle.V4.Observable.TimeObservable"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Rule-Claim
+            title: "Daml.Finance.Interface.Lifecycle.V4.Rule.Claim"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Rule-Lifecycle
+            title: "Daml.Finance.Interface.Lifecycle.V4.Rule.Lifecycle"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-V4-Batch
+            title: "Daml.Finance.Interface.Settlement.V4.Batch"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-V4-Factory
+            title: "Daml.Finance.Interface.Settlement.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-V4-Instruction
+            title: "Daml.Finance.Interface.Settlement.V4.Instruction"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-V4-RouteProvider
+            title: "Daml.Finance.Interface.Settlement.V4.RouteProvider"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-V4-Types
+            title: "Daml.Finance.Interface.Settlement.V4.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Common-V3-Types
+            title: "Daml.Finance.Interface.Types.Common.V3.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-V3-Calendar
+            title: "Daml.Finance.Interface.Types.Date.V3.Calendar"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-V3-Classes
+            title: "Daml.Finance.Interface.Types.Date.V3.Classes"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-V3-DateOffset
+            title: "Daml.Finance.Interface.Types.Date.V3.DateOffset"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-V3-DayCount
+            title: "Daml.Finance.Interface.Types.Date.V3.DayCount"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-V3-RollConvention
+            title: "Daml.Finance.Interface.Types.Date.V3.RollConvention"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-V3-Schedule
+            title: "Daml.Finance.Interface.Types.Date.V3.Schedule"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-V3-Common
+            title: "Daml.Finance.Interface.Util.V3.Common"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-V3-Disclosure
+            title: "Daml.Finance.Interface.Util.V3.Disclosure"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-V3-InterfaceKey
+            title: "Daml.Finance.Interface.Util.V3.InterfaceKey"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-V3-Lockable
+            title: "Daml.Finance.Interface.Util.V3.Lockable"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Effect
+            title: "Daml.Finance.Lifecycle.V4.Effect"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Election
+            title: "Daml.Finance.Lifecycle.V4.Election"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-ElectionEffect
+            title: "Daml.Finance.Lifecycle.V4.ElectionEffect"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Event-Distribution
+            title: "Daml.Finance.Lifecycle.V4.Event.Distribution"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Event-Replacement
+            title: "Daml.Finance.Lifecycle.V4.Event.Replacement"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Rule-Claim
+            title: "Daml.Finance.Lifecycle.V4.Rule.Claim"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Rule-Distribution
+            title: "Daml.Finance.Lifecycle.V4.Rule.Distribution"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Rule-Replacement
+            title: "Daml.Finance.Lifecycle.V4.Rule.Replacement"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Rule-Util
+            title: "Daml.Finance.Lifecycle.V4.Rule.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-V4-Batch
+            title: "Daml.Finance.Settlement.V4.Batch"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-V4-Factory
+            title: "Daml.Finance.Settlement.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-V4-Hierarchy
+            title: "Daml.Finance.Settlement.V4.Hierarchy"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-V4-Instruction
+            title: "Daml.Finance.Settlement.V4.Instruction"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-V4-RouteProvider-IntermediatedStatic
+            title: "Daml.Finance.Settlement.V4.RouteProvider.IntermediatedStatic"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-V4-RouteProvider-SingleCustodian
+            title: "Daml.Finance.Settlement.V4.RouteProvider.SingleCustodian"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-V4-Common
+            title: "Daml.Finance.Util.V4.Common"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-V4-Date-Calendar
+            title: "Daml.Finance.Util.V4.Date.Calendar"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-V4-Date-DayCount
+            title: "Daml.Finance.Util.V4.Date.DayCount"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-V4-Date-RollConvention
+            title: "Daml.Finance.Util.V4.Date.RollConvention"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-V4-Date-Schedule
+            title: "Daml.Finance.Util.V4.Date.Schedule"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-V4-Disclosure
+            title: "Daml.Finance.Util.V4.Disclosure"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-V4-Lockable
+            title: "Daml.Finance.Util.V4.Lockable"
 
 - caption: "Deploy Daml"
   entries:

--- a/docs/2.10.0/bin/daml-finance/update_tags.sh
+++ b/docs/2.10.0/bin/daml-finance/update_tags.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# Script: update_tags.sh (Daml Finance)
+#
+# Description:
+# Upgrades versioned references in the documentation from one version to another.
+#
+# Example:
+#   Updates `type-daml-finance-lifecycle-v4-event-replacement-event-23525` to
+#   `type-daml-finance-lifecycle-v5-event-replacement-event-53425` when upgrading to v5.
+#
+# Functionality:
+# 1. **Extract References**: Scans all files in the reference directory (`REF_DIR`) for lines
+#    starting with `.. _module`, `.. _type`, `.. _function`, or `.. _constr`.
+# 2. **Update References**:
+#    - Locates corresponding references in the target directory (`TRGT_DIR`).
+#    - Updates the version segment from the old version (e.g., `v4`) to the new version (e.g., `v5`).
+#    - Changes the numerical identifier to ensure uniqueness.
+#
+# Prerequisites:
+# - **Build Workdir**: Ensure the working directory (`workdir`) is fully built to have up-to-date
+#   reference files.
+#
+# Usage:
+# 1. **Set Directories**:
+#    - Define `REF_DIR` with the path to current reference files.
+#    - Define `TRGT_DIR` with the path where references should be updated.
+# 2. **Execute Script**:
+#    - Run the script in the terminal to automatically scan and update all relevant references based
+#      on the new version.
+
+# Get the directory where the script is located, to ensure paths are correct no matter where it's called from
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Set the reference directory (contains canonical _module, _type, _function, _constr lines)
+REF_DIR="${SCRIPT_DIR}/../../workdir/build/source/source/daml-finance/reference/code-documentation/daml-finance-rst"
+
+# Set the target directory (where we need to replace occurrences)
+TRGT_DIR="${SCRIPT_DIR}/../../docs/daml-finance"
+
+echo "Reference directory: $REF_DIR"
+echo "Target directory: $TRGT_DIR"
+
+tmpfile=$(mktemp)
+echo "Temporary file: $tmpfile"
+
+# Regex explanation:
+# .. _module-daml-finance-account-v4-account-[0-9]+$ : Match lines with the format 'module-<any number>'
+grep -hEr '..[[:space:]]+_(module|type|function|constr).*-[0-9]+:$' "$REF_DIR" > "$tmpfile" || true
+
+line_count=$(wc -l < "$tmpfile")
+echo "Found $line_count canonical lines."
+
+while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    echo "Processing line: $line"
+
+    # Remove everything before '.. _' and trailing ':'
+    line_no_prefix="${line##*.. _}"
+    base="${line_no_prefix%:}"
+
+    # Extract the last number
+    number="${base##*-}"
+
+    # Extract everything before the number as the pattern
+    pattern="${base%-*}"
+
+    echo "  Pattern: $pattern"
+    echo "  Number: $number"
+
+    # Check if the pattern contains a version segment like -vX- (e.g. -v4-)
+    # Example pattern: type-daml-finance-lifecycle-v4-event-replacement-event
+    if [[ $pattern =~ ^(.*)(-v[0-9]+)(-.*)$ ]]; then
+        pattern_before="${BASH_REMATCH[1]}"  # up to and including 'v'
+        pattern_version="${BASH_REMATCH[2]}" # the version digits
+        pattern_after="${BASH_REMATCH[3]}"   # the rest after the version
+
+        echo "  Detected version segment: $pattern_version"
+        echo "  Pattern before version: $pattern_before"
+        echo "  Pattern after version: $pattern_after"
+
+        # In target files,
+        # 1. Override any version number (say "-v3" or ""), with the current one (say "-v4").
+        # 2. Override the reference number with the current one.
+        # Using '#' as sed delimiter to avoid conflicts with '-'.
+        find "$TRGT_DIR" -type f -exec sed -i "s#${pattern_before}\(-v[0-9]\\{1,\\}\)\?${pattern_after}-[0-9]\\{1,\\}#${pattern_before}${pattern_version}${pattern_after}-${number}#g" {} +
+
+    else
+        # No version found, do the standard replacement
+        find "$TRGT_DIR" -type f -exec sed -i "s#${pattern}-[0-9]\\{1,\\}#${pattern}-${number}#g" {} +
+    fi
+
+    echo "  Done processing this pattern."
+    echo
+done < "$tmpfile"
+
+rm "$tmpfile"
+echo "All done."

--- a/docs/2.10.0/docs/daml-finance/concepts/asset-model.rst
+++ b/docs/2.10.0/docs/daml-finance/concepts/asset-model.rst
@@ -142,7 +142,7 @@ the interfaces :ref:`holding <module-daml-finance-interface-holding-holding-6412
 Implementations
 ===============
 
-``Daml.Finance.Holding`` provides implementations for each holding standard:
+``Daml.Finance.Holding.V4`` provides implementations for each holding standard:
 
 - :ref:`fungible only <module-daml-finance-holding-fungible-7201>`
 - :ref:`transferable only <module-daml-finance-holding-transferable-43388>`

--- a/docs/2.10.0/docs/daml-finance/concepts/asset-model.rst
+++ b/docs/2.10.0/docs/daml-finance/concepts/asset-model.rst
@@ -36,7 +36,7 @@ Keys and Versioning
 ===================
 
 Instruments are keyed by an
-:ref:`InstrumentKey <constr-daml-finance-interface-types-common-types-instrumentkey-32970>`,
+:ref:`InstrumentKey <constr-daml-finance-interface-types-common-v3-types-instrumentkey-49116>`,
 which comprises:
 
 - the instrument ``issuer``
@@ -55,21 +55,21 @@ Interfaces
 Instrument interfaces are defined in the ``Daml.Finance.Interface.Instrument.*`` packages.
 
 All instruments must implement the base interface, defined in
-:ref:`Daml.Finance.Interface.Instrument.Base <module-daml-finance-interface-instrument-base-instrument-57320>`.
+:ref:`Daml.Finance.Interface.Instrument.Base.V4 <module-daml-finance-interface-instrument-base-v4-instrument-47185>`.
 
 Implementations
 ===============
 
 A base implementation is provided in
-:ref:`Daml.Finance.Instrument.Token <module-daml-finance-instrument-token-instrument-10682>`.
+:ref:`Daml.Finance.Instrument.Token.V4 <module-daml-finance-instrument-token-v4-instrument-53415>`.
 
 This template does not define any lifecycling logic and is suitable to model contracts that are
 likely to stay stable, such as currency instruments.
 
 The extension packages provide additional business-specific implementations, such as an
-:ref:`Equity <module-daml-finance-instrument-equity-instrument-69265>`
+:ref:`Equity <module-daml-finance-instrument-equity-v1-instrument-56047>`
 instrument (where the issuer can pay dividends) or a
-:ref:`Bond <module-daml-finance-instrument-bond-fixedrate-instrument-67993>`
+:ref:`Bond <module-daml-finance-instrument-bond-v3-fixedrate-instrument-89221>`
 instrument (which includes coupon payments).
 
 The expectation is that customers define their own instruments suiting the use-case they are
@@ -117,12 +117,12 @@ When, for instance, a holding is transferable, the ownership can be transferred 
 at the same custodian.
 
 These properties are exposed by letting a holding template implement the corresponding interfaces
-(:ref:`Fungible <module-daml-finance-interface-holding-fungible-63712>` and
-:ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`,
+(:ref:`Fungible <module-daml-finance-interface-holding-v4-fungible-55495>` and
+:ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`,
 respectively).
 
 The library distinguishes four types of holdings, referred to as :ref:`Holding Standard
-<type-daml-finance-interface-types-common-types-holdingstandard-38061>`\s, namely:
+<type-daml-finance-interface-types-common-v3-types-holdingstandard-63293>`\s, namely:
 
 1. `Fungible`: Holdings that are fungible only.
 2. `Transferable`: Holdings that are transferable only.
@@ -132,10 +132,10 @@ The library distinguishes four types of holdings, referred to as :ref:`Holding S
 Interfaces
 ==========
 
-Holding interfaces are defined in the ``Daml.Finance.Interface.Holding`` package. It consists of
-the interfaces :ref:`holding <module-daml-finance-interface-holding-holding-64126>`,
-:ref:`transferable <module-daml-finance-interface-holding-transferable-88121>`, and
-:ref:`fungible <module-daml-finance-interface-holding-fungible-63712>`.
+Holding interfaces are defined in the ``Daml.Finance.Interface.Holding.V4`` package. It consists of
+the interfaces :ref:`holding <module-daml-finance-interface-holding-v4-holding-20535>`,
+:ref:`transferable <module-daml-finance-interface-holding-v4-transferable-93054>`, and
+:ref:`fungible <module-daml-finance-interface-holding-v4-fungible-55495>`.
 
 .. _implementations-1:
 
@@ -144,10 +144,10 @@ Implementations
 
 ``Daml.Finance.Holding.V4`` provides implementations for each holding standard:
 
-- :ref:`fungible only <module-daml-finance-holding-fungible-7201>`
-- :ref:`transferable only <module-daml-finance-holding-transferable-43388>`
-- :ref:`both transferable and fungible <module-daml-finance-holding-transferablefungible-77726>`
-- :ref:`neither transferable nor fungible <module-daml-finance-holding-baseholding-57062>`
+- :ref:`fungible only <module-daml-finance-holding-v4-fungible-60188>`
+- :ref:`transferable only <module-daml-finance-holding-v4-transferable-38649>`
+- :ref:`both transferable and fungible <module-daml-finance-holding-v4-transferablefungible-66907>`
+- :ref:`neither transferable nor fungible <module-daml-finance-holding-v4-baseholding-28133>`
 
 Account
 *******
@@ -162,7 +162,7 @@ bank’s services.
 
 The account contract also controls which parties are authorized to transfer holdings in and out of
 the account. To be more precise, the
-:ref:`controllers <type-daml-finance-interface-account-account-controllers-36430>`
+:ref:`controllers <type-daml-finance-interface-account-v4-account-controllers-59817>`
 field of the account contains:
 
 - ``outgoing``: a set of parties authorizing outgoing transfers
@@ -195,7 +195,7 @@ Keys
 ====
 
 Accounts are keyed by an
-:ref:`AccountKey <type-daml-finance-interface-types-common-types-accountkey-41482>`, which
+:ref:`AccountKey <type-daml-finance-interface-types-common-v3-types-accountkey-55962>`, which
 comprises:
 
 - the account ``owner``
@@ -208,22 +208,22 @@ Interfaces
 ==========
 
 The account interface is defined in the
-:ref:`Daml.Finance.Interface.Account <module-daml-finance-interface-account-account-92922>`
+:ref:`Daml.Finance.Interface.Account.V4 <module-daml-finance-interface-account-v4-account-30007>`
 package.
 
 Implementations
 ===============
 
 A base account implementation is provided in
-:ref:`Daml.Finance.Account <module-daml-finance-account-account-19369>`.
+:ref:`Daml.Finance.Account.V4 <module-daml-finance-account-v4-account-5834>`.
 
 The account can be created with arbitrary
-:ref:`controllers <type-daml-finance-interface-account-account-controllers-36430>`
+:ref:`controllers <type-daml-finance-interface-account-v4-account-controllers-59817>`
 (for incoming and outgoing transfers). Our examples typically let accounts be owners-controlled,
 i.e., both the current owner and the new owner must authorize transfers.
 
 The account also implements
-the :ref:`Lockable <module-daml-finance-interface-util-lockable-80915>` interface, enabling the
+the :ref:`Lockable <module-daml-finance-interface-util-v3-lockable-20339>` interface, enabling the
 freezing of an account, thus disabling credits and debits.
 
 Example setups
@@ -241,15 +241,15 @@ a Commercial Bank, and a Retail Client.
 The Central Bank defines the economic terms of the currency asset and is generally a highly trusted
 entity, therefore it acts as ``issuer`` as well as ``depository`` of the corresponding instrument.
 
-We can use the :ref:`Token <module-daml-finance-instrument-token-instrument-10682>`
+We can use the :ref:`Token <module-daml-finance-instrument-token-v4-instrument-53415>`
 instrument implementation for a currency asset, as we do not need any lifecycling logic.
 
 The Retail Client has an
-:ref:`Account <module-daml-finance-interface-account-account-92922>` at the Commercial Bank, with
+:ref:`Account <module-daml-finance-interface-account-v4-account-30007>` at the Commercial Bank, with
 the former acting as ``owner`` and the latter as ``custodian``.
 
 Finally, the Retail Client is ``owner`` of a
-:ref:`transferable and fungible holding <module-daml-finance-holding-transferablefungible-77726>` at
+:ref:`transferable and fungible holding <module-daml-finance-holding-v4-transferablefungible-66907>` at
 the Commercial Bank (i.e., the ``custodian`` in the contract). The holding references the currency
 instrument and the account.
 
@@ -268,7 +268,7 @@ We now model units of shares held by an investor. There are three parties involv
 Entity, a Securities Depository, and an Investor.
 
 The Issuing Entity acts as ``issuer`` of the :ref:`Equity Instrument
-<module-daml-finance-instrument-equity-instrument-69265>`. The Securities Depository acts
+<module-daml-finance-instrument-equity-v1-instrument-56047>`. The Securities Depository acts
 as ``depository`` of the instrument, thus preventing the Issuing Entity from single-handedly
 modifying details of the instrument (such as the share's nominal value).
 
@@ -289,7 +289,7 @@ OTC Swap
 
 Finally, we model an OTC (over-the-counter) fixed vs. floating interest rate swap agreement between
 two parties, namely Party A and Party B. We can use the :ref:`Interest Rate Swap
-<module-daml-finance-instrument-swap-interestrate-instrument-86260>` instrument template
+<module-daml-finance-instrument-swap-v1-interestrate-instrument-25554>` instrument template
 for this purpose.
 
 In this case, all contracts are agreed and co-signed by both parties. In the instrument contract,

--- a/docs/2.10.0/docs/daml-finance/concepts/lifecycling.rst
+++ b/docs/2.10.0/docs/daml-finance/concepts/lifecycling.rst
@@ -10,8 +10,8 @@ cashflows, as well as discretionary events, like dividends and other corporate a
 provides a standard mechanism for processing such events across different instruments. The output is
 not limited to cash but can also include the distribution of other asset types.
 
-The interfaces for lifecycling are defined in the ``Daml.Finance.Interface.Lifecycle`` package, and
-several default implementations are provided in the ``Daml.Finance.Lifecycle`` package.
+The interfaces for lifecycling are defined in the ``Daml.Finance.Interface.Lifecycle.V4`` package, and
+several default implementations are provided in the ``Daml.Finance.Lifecycle.V4`` package.
 
 In this section, we first motivate the particular approach to lifecycling in Daml Finance. We then
 explain the process in detail using the example of a cash dividend event. Finally, we describe each
@@ -179,7 +179,6 @@ Events
 An event contract is used to indicate that a certain action has occurred, which might trigger
 the lifecycling of certain instruments. In the context of the dividend example above, this is the
 Issuer declaring a "Cash Dividend" to be paid on a specific stock.
-
 
 Events implement the :ref:`Event <module-daml-finance-interface-lifecycle-event-43586>`
 interface, which describes basic properties of a lifecycle event:

--- a/docs/2.10.0/docs/daml-finance/concepts/lifecycling.rst
+++ b/docs/2.10.0/docs/daml-finance/concepts/lifecycling.rst
@@ -87,7 +87,7 @@ step.
 
 Now, the issuer creates a lifecycle event defining the terms of dividend. In our example we can
 use the ``DistributeDividend`` choice on the
-:ref:`Equity <module-daml-finance-interface-instrument-equity-instrument-13224>` instrument
+:ref:`Equity <module-daml-finance-interface-instrument-equity-v1-instrument-10480>` instrument
 to create such an event. This is merely a convenience choice available for equities, any workflow
 can be used to create new instrument versions and associated lifecycle events.
 
@@ -102,8 +102,8 @@ Processing the event
 =====================
 
 The event is now passed into a
-:ref:`Distribution Rule <module-daml-finance-lifecycle-rule-distribution-35531>`, which
-generates the :ref:`Lifecycle Effect <module-daml-finance-interface-lifecycle-effect-16050>`
+:ref:`Distribution Rule <module-daml-finance-lifecycle-v4-rule-distribution-2662>`, which
+generates the :ref:`Lifecycle Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>`
 describing the distribution of assets per unit of ``ACME`` stock. The effect refers to a
 ``targetInstrument``, which is the version of the instrument that can be used by stock holders to
 claim the cash dividend according to the number of stocks held. By being tied to a specific version
@@ -122,8 +122,8 @@ Claiming the effect
 ===================
 
 The investor can now present its holding of ``ACME`` stock along with the corresponding
-:ref:`Effect <module-daml-finance-interface-lifecycle-effect-16050>` to a
-:ref:`Claim Rule <module-daml-finance-interface-lifecycle-rule-claim-6739>`. This will
+:ref:`Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>` to a
+:ref:`Claim Rule <module-daml-finance-interface-lifecycle-v4-rule-claim-89954>`. This will
 instruct settlement for:
 
 - The exchange of ``ACME`` stock versions held: the investor sends back the old version, and
@@ -131,7 +131,7 @@ instruct settlement for:
 - The payment of the cash dividend amount corresponding to the number of stocks held
 
 Both legs of this settlement are grouped in a
-:ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` to provide atomicity. The
+:ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` to provide atomicity. The
 goal of the batch is to exchange a holding on the v1 instrument for a holding on the v2 instrument
 + $10 (for each share held). This ensures that the investor can never claim a dividend twice, as
 after settlement they only hold the new version of the stock, which is not entitled to the dividend
@@ -142,7 +142,7 @@ anymore.
          holding. This produces a batch and settlement instructions.
 
 Note that the party responsible for claiming an effect can be specified flexibly in the
-:ref:`Claim Rule <module-daml-finance-interface-lifecycle-rule-claim-6739>` contract. Through
+:ref:`Claim Rule <module-daml-finance-interface-lifecycle-v4-rule-claim-89954>` contract. Through
 this contract, custodians can be given the authority to push a given corporate action to the asset
 holder as is common in current operating procedures.
 
@@ -180,7 +180,7 @@ An event contract is used to indicate that a certain action has occurred, which 
 the lifecycling of certain instruments. In the context of the dividend example above, this is the
 Issuer declaring a "Cash Dividend" to be paid on a specific stock.
 
-Events implement the :ref:`Event <module-daml-finance-interface-lifecycle-event-43586>`
+Events implement the :ref:`Event <module-daml-finance-interface-lifecycle-v4-event-91777>`
 interface, which describes basic properties of a lifecycle event:
 
 - The event providers
@@ -189,10 +189,10 @@ interface, which describes basic properties of a lifecycle event:
 
 Different implementations exist to cover typical corporate actions:
 
-- The :ref:`Distribution <module-daml-finance-lifecycle-event-distribution-17302>` event can be
+- The :ref:`Distribution <module-daml-finance-lifecycle-v4-event-distribution-38493>` event can be
   used to distribute assets to holders of an instrument. This covers cash-, share-, and mixed
   dividends, rights issues, or the distribution of voting rights.
-- The :ref:`Replacement <module-daml-finance-lifecycle-event-replacement-51859>` event handles
+- The :ref:`Replacement <module-daml-finance-lifecycle-v4-event-replacement-94706>` event handles
   replacements of one instrument for another with support for a factor. This covers corporate
   actions like (reverse) stock splits, mergers, and spin-offs.
 
@@ -201,17 +201,17 @@ A single event can be used as a trigger to lifecycle multiple instruments.
 Lifecycle Rule
 ==============
 
-A :ref:`Lifecycle Rule <module-daml-finance-interface-lifecycle-rule-lifecycle-50431>` is
+A :ref:`Lifecycle Rule <module-daml-finance-interface-lifecycle-v4-rule-lifecycle-8270>` is
 used to process an event for a certain instrument and calculate the resulting lifecycle effects.
 
 A lifecycle rule can either
 assume that a new version of the instrument has already been created (as is the case for the
-:ref:`Distribution <module-daml-finance-lifecycle-rule-distribution-35531>` and
-:ref:`Replacement <module-daml-finance-lifecycle-rule-replacement-6984>` rules), or it can create
+:ref:`Distribution <module-daml-finance-lifecycle-v4-rule-distribution-2662>` and
+:ref:`Replacement <module-daml-finance-lifecycle-v4-rule-replacement-25183>` rules), or it can create
 the new version of the instrument as part of its implementation. The latter can be useful if
 information required to create the new version is only available upon processing of the event, as is
 the case for the evolution of the
-:ref:`Generic Instrument <module-daml-finance-interface-instrument-generic-instrument-53275>`, as
+:ref:`Generic Instrument <module-daml-finance-interface-instrument-generic-v4-instrument-7928>`, as
 well as other :doc:`Contingent Claims <../instruments/generic/contingent-claims>` based instruments.
 
 .. _time-vs-election-lifecycling:
@@ -241,7 +241,7 @@ bond that is callable only on some of the coupon dates.
 Effects
 =======
 
-An :ref:`Effect <module-daml-finance-interface-lifecycle-effect-16050>` describes the asset
+An :ref:`Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>` describes the asset
 movements resulting from a particular event. It specifies these movements per unit of a target
 instrument and version.
 
@@ -257,7 +257,7 @@ effect, which results in the required asset movements to be instructed.
 Claim Rule
 ==========
 
-The :ref:`Claim Rule <module-daml-finance-interface-lifecycle-rule-claim-6739>` is used by
+The :ref:`Claim Rule <module-daml-finance-interface-lifecycle-v4-rule-claim-89954>` is used by
 instrument holders to claim lifecycle effects and instruct settlement of the resulting asset
 movements.
 
@@ -269,8 +269,8 @@ serves as proof of ownership such that there is no need for an issuer to take a 
 of holdings as of a specific date.
 
 The output of the claim rule is a
-:ref:`Settlement Batch <module-daml-finance-interface-settlement-batch-39188>` and a set of
-:ref:`Instruction <module-daml-finance-interface-settlement-instruction-10970>` s that
+:ref:`Settlement Batch <module-daml-finance-interface-settlement-v4-batch-88127>` and a set of
+:ref:`Instruction <module-daml-finance-interface-settlement-v4-instruction-71097>` s that
 settle the asset movements atomically.
 
 Note that multiple holdings can be passed into the claim rule in order to instruct intermediated

--- a/docs/2.10.0/docs/daml-finance/concepts/settlement.rst
+++ b/docs/2.10.0/docs/daml-finance/concepts/settlement.rst
@@ -8,8 +8,8 @@ Settlement
 financial transaction.
 
 Daml Finance provides facilities to execute these transfers atomically (i.e., within the same Daml
-transaction). Interfaces are defined in the ``Daml.Finance.Interface.Settlement`` package, whereas
-implementations are provided in the ``Daml.Finance.Settlement`` package.
+transaction). Interfaces are defined in the ``Daml.Finance.Interface.Settlement.V4`` package, whereas
+implementations are provided in the ``Daml.Finance.Settlement.V4`` package.
 
 In this section, we first illustrate the settlement workflow with the help of an example FX
 transaction, where Alice transfers a EUR-denominated holding to Bob, in exchange for a

--- a/docs/2.10.0/docs/daml-finance/concepts/settlement.rst
+++ b/docs/2.10.0/docs/daml-finance/concepts/settlement.rst
@@ -37,11 +37,11 @@ Alice and Bob want to exchange their holdings and agree to enter into the transa
 signatories on a transaction contract. Settlement can then be instructed which results in 3
 contract instances being created:
 
-#. an :ref:`Instruction <module-daml-finance-settlement-instruction-87187>`
+#. an :ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>`
    to transfer EUR 1000 from Alice to Bob
-#. an :ref:`Instruction <module-daml-finance-settlement-instruction-87187>`
+#. an :ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>`
    to transfer USD 1000 from Bob to Alice
-#. a :ref:`Batch <module-daml-finance-settlement-batch-95573>`
+#. a :ref:`Batch <module-daml-finance-settlement-v4-batch-88124>`
    used to execute the above Instructions
 
 .. image:: ../images/settlement_instructed.png
@@ -59,9 +59,9 @@ In order to execute the FX transaction, we first need to:
 - approve, i.e., specify to which account the asset should be transferred
 
 Allocation and approval is required for
-each :ref:`Instruction <module-daml-finance-settlement-instruction-87187>`.
+each :ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>`.
 
-Alice :ref:`allocates <module-daml-finance-interface-settlement-instruction-10970>` the instruction
+Alice :ref:`allocates <module-daml-finance-interface-settlement-v4-instruction-71097>` the instruction
 where she is the sender by pledging her holding. Bob does the same on the instruction where he is
 the sender.
 
@@ -69,7 +69,7 @@ the sender.
    :alt: Settlement is allocated.
 
 Each receiver can then specify to which account the holding should be sent by
-:ref:`approving <module-daml-finance-interface-settlement-instruction-10970>`
+:ref:`approving <module-daml-finance-interface-settlement-v4-instruction-71097>`
 the corresponding instruction.
 
 .. image:: ../images/settlement_allocated_approved.png
@@ -79,8 +79,8 @@ Execute
 =======
 
 Once both instructions are allocated and approved, a Settler party uses the
-:ref:`Batch <module-daml-finance-settlement-batch-95573>` contract to
-:ref:`execute <module-daml-finance-interface-settlement-instruction-10970>`
+:ref:`Batch <module-daml-finance-settlement-v4-batch-88124>` contract to
+:ref:`execute <module-daml-finance-interface-settlement-v4-instruction-71097>`
 them and finalize settlement in one atomic transaction.
 
 .. image:: ../images/settlement_executed.png
@@ -96,7 +96,7 @@ There are some assumptions that need to hold in order for the settlement to work
 - Bob needs to have an account at the custodian where Alice's holding is held and vice versa (for
   an example with intermediaries, see `Route provider`_ below.
 - Both holdings need to be
-  :ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`
+  :ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`
 - The transfer must be fully authorized (i.e., the parties allocating and approving an instruction
   must be the controllers of outgoing and incoming transfers of the corresponding accounts,
   respectively)
@@ -110,7 +110,7 @@ Route provider
 ==============
 
 When a transfer requires intermediaries to be involved, the role of a
-:ref:`Route Provider <type-daml-finance-interface-settlement-routeprovider-routeprovider-53805>`
+:ref:`Route Provider <type-daml-finance-interface-settlement-v4-routeprovider-routeprovider-29628>`
 becomes important. Let us assume, for instance, that Alice's EUR holding in the example above is
 held at Bank A, whereas Bob has a EUR account at Bank B. Bank A and Bank B both have accounts at the
 Central Bank.
@@ -120,9 +120,9 @@ Central Bank.
          Bank B. Bank A and Bank B have an account at the Central Bank.
 
 In this case, a direct holding transfer from Alice to Bob cannot generally be instructed. The
-original :ref:`Instruction <module-daml-finance-settlement-instruction-87187>`
+original :ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>`
 between Alice and Bob needs to be replaced by three separate
-:ref:`Instructions <module-daml-finance-settlement-instruction-87187>`:
+:ref:`Instructions <module-daml-finance-settlement-v4-instruction-73130>`:
 
 - **1A**: Alice sends EUR 1000 (held at Bank A) to Bank A
 - **1B**: Bank A sends EUR 1000 (held at the Central Bank) to Bank B.
@@ -135,40 +135,40 @@ between Alice and Bob needs to be replaced by three separate
 We refer to this scenario as *settlement with intermediaries*, or just *intermediated settlement*.
 
 The Route Provider is used to discover a settlement route, i.e.,
-:ref:`routed steps <type-daml-finance-interface-settlement-types-routedstep-10086>`, for each
-settlement :ref:`step <type-daml-finance-interface-settlement-types-step-78661>`.
+:ref:`routed steps <type-daml-finance-interface-settlement-v4-types-routedstep-26293>`, for each
+settlement :ref:`step <type-daml-finance-interface-settlement-v4-types-step-16302>`.
 
 Settlement factory
 ==================
 
-The :ref:`Settlement Factory <module-daml-finance-interface-settlement-factory-75196>` is used
-to instruct settlement, i.e., create the :ref:`Batch <module-daml-finance-settlement-batch-95573>`
-contract and the settlement :ref:`Instructions <module-daml-finance-settlement-instruction-87187>`,
-from :ref:`routed steps <type-daml-finance-interface-settlement-types-routedstep-10086>`, so that
+The :ref:`Settlement Factory <module-daml-finance-interface-settlement-v4-factory-85379>` is used
+to instruct settlement, i.e., create the :ref:`Batch <module-daml-finance-settlement-v4-batch-88124>`
+contract and the settlement :ref:`Instructions <module-daml-finance-settlement-v4-instruction-73130>`,
+from :ref:`routed steps <type-daml-finance-interface-settlement-v4-types-routedstep-26293>`, so that
 they can be allocated and approved by the respective parties.
 
 Instruction
 ===========
 
-The :ref:`Instruction <module-daml-finance-interface-settlement-instruction-10970>` is
+The :ref:`Instruction <module-daml-finance-interface-settlement-v4-instruction-71097>` is
 used to settle a single holding transfer at a specific custodian, once it is ``allocated`` and
 ``approved``.
 
-In the :ref:`Allocation <type-daml-finance-interface-settlement-types-allocation-46483>` step, the
+In the :ref:`Allocation <type-daml-finance-interface-settlement-v4-types-allocation-41200>` step, the
 sender acknowledges the transfer and determines how to send the holding. This is usually done by
-allocating with a :ref:`Pledge <constr-daml-finance-interface-settlement-types-pledge-99803>`
+allocating with a :ref:`Pledge <constr-daml-finance-interface-settlement-v4-types-pledge-57866>`
 of the sender's existing holding (which has the correct instrument quantity) at the custodian. When
 the sender is also the custodian, the instruction can be allocated with
-:ref:`CreditReceiver <constr-daml-finance-interface-settlement-types-creditreceiver-50700>`. In this
+:ref:`CreditReceiver <constr-daml-finance-interface-settlement-v4-types-creditreceiver-33781>`. In this
 case, a new holding is directly credited into the receiver's account.
 
-In the :ref:`Approval <type-daml-finance-interface-settlement-types-approval-84286>` step, the
+In the :ref:`Approval <type-daml-finance-interface-settlement-v4-types-approval-77821>` step, the
 receiver acknowledges the transfer and determines how to receive the holding. This is usually done
 by approving with
-:ref:`TakeDelivery <constr-daml-finance-interface-settlement-types-takedelivery-14079>` to one of
+:ref:`TakeDelivery <constr-daml-finance-interface-settlement-v4-types-takedelivery-31030>` to one of
 the receiver's accounts at the custodian. When the receiver is also the incoming holding's
 custodian, the instruction can be approved with
-:ref:`DebitSender <constr-daml-finance-interface-settlement-types-debitsender-39086>`. In this case,
+:ref:`DebitSender <constr-daml-finance-interface-settlement-v4-types-debitsender-18125>`. In this case,
 the holding is directly debited from the sender's account. A holding owned by the custodian at the
 custodian has no economical value, it is a liability against themselves and can therefore be
 archived without consequence.
@@ -189,33 +189,33 @@ be allocated / approved.
 |                                                    | with CreditReceiver  | to his account       |
 +----------------------------------------------------+----------------------+----------------------+
 
-Finally, the :ref:`Instruction <module-daml-finance-settlement-instruction-87187>` supports two
+Finally, the :ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>` supports two
 additional settlement modes:
 
 - Any instruction can settle off-ledger (if the stakeholders agree to do so). For this to work, we
   require the custodian and the sender to jointly allocate the instruction with a
-  :ref:`SettleOffledger <constr-daml-finance-interface-settlement-types-settleoffledger-15836>`,
+  :ref:`SettleOffledger <constr-daml-finance-interface-settlement-v4-types-settleoffledger-82795>`,
   and the custodian and the receiver to jointly approve the instruction with a
   :ref:`SettleOffledgerAcknowledge
-  <constr-daml-finance-interface-settlement-types-settleoffledgeracknowledge-98269>`.
+  <constr-daml-finance-interface-settlement-v4-types-settleoffledgeracknowledge-65556>`.
 - A special case occurs when a transfer happens via an intermediary at the same custodian, i.e., we
   have 2 instructions having the same custodian and instrument quantity (in a batch), and the
   receiver of the first instruction is the same as the sender of the second instruction. In this
   case, we allow the holding received from the first instruction to be passed through to settle the
   second instruction, i.e., without using any pre-existing holding of the intermediary. For this to
   work, the first instruction is approved with
-  :ref:`PassThroughTo <constr-daml-finance-interface-settlement-types-passthroughto-68260>` (i.e.,
+  :ref:`PassThroughTo <constr-daml-finance-interface-settlement-v4-types-passthroughto-8399>` (i.e.,
   pass through to the second instruction), and the second instruction is allocated with
-  :ref:`PassThroughFrom <constr-daml-finance-interface-settlement-types-passthroughfrom-69429>`
+  :ref:`PassThroughFrom <constr-daml-finance-interface-settlement-v4-types-passthroughfrom-2474>`
   (i.e., pass through from the first instruction). An intermediary account used for the passthrough
   is thereby also to be specified.
 
 Batch
 =====
 
-The :ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` is used to execute a set
+The :ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` is used to execute a set
 of instructions atomically. Execution will fail if any of the
-:ref:`Instructions <module-daml-finance-settlement-instruction-87187>` is not fully allocated
+:ref:`Instructions <module-daml-finance-settlement-v4-instruction-73130>` is not fully allocated
 / approved, or if the transfer is unsuccessful.
 
 Settlement Time
@@ -227,8 +227,8 @@ transaction date plus one, two, or three business days, respectively. Some marke
 real-time settlement options. It's also common for certain trades between parties to have unique,
 mutually agreed-upon settlement periods.
 
-The :ref:`Batch <module-daml-finance-settlement-batch-95573>` and
-:ref:`Instruction <module-daml-finance-settlement-instruction-87187>`
+The :ref:`Batch <module-daml-finance-settlement-v4-batch-88124>` and
+:ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>`
 implementations are designed to allow the optional setting of a preferred settlement time, without
 any mechanisms that enforce a specific settlement time. This design choice offers several
 advantages:
@@ -239,15 +239,15 @@ advantages:
 
 - **Avoidance of Early Settlement:** Parties involved in sending or receiving a holding may opt to
   delay their
-  :ref:`allocation <module-daml-finance-interface-settlement-instruction-10970>` or
-  :ref:`approval <module-daml-finance-interface-settlement-instruction-10970>` of an instruction
+  :ref:`allocation <module-daml-finance-interface-settlement-v4-instruction-71097>` or
+  :ref:`approval <module-daml-finance-interface-settlement-v4-instruction-71097>` of an instruction
   until just prior to the settlement time. This strategy prevents the
-  :ref:`Batch <module-daml-finance-settlement-batch-95573>` from settling prematurely.
+  :ref:`Batch <module-daml-finance-settlement-v4-batch-88124>` from settling prematurely.
 
 - **Handling of Late Settlements:** To address cases where parties fail to settle by the desired
   time, we propose using a separate custom contract instance. This contact could facilitate the
-  rolling of a :ref:`Batch <module-daml-finance-settlement-batch-95573>` (along with its
-  :ref:`Instruction <module-daml-finance-settlement-instruction-87187>`\s) into a subsequent
+  rolling of a :ref:`Batch <module-daml-finance-settlement-v4-batch-88124>` (along with its
+  :ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>`\s) into a subsequent
   settlement cycle if the initial settlement period lapses. Additionally, the contract could allow
   for imposing penalties on parties that fail to allocate or approve the transaction in a timely
   manner.

--- a/docs/2.10.0/docs/daml-finance/index.rst
+++ b/docs/2.10.0/docs/daml-finance/index.rst
@@ -62,7 +62,7 @@ Finance:
 Current Release
 ===============
 
-Daml SDK 2.9.4
+Daml SDK 2.10.0
 
 This section details the list of released and deprecated packages, with status information provided
 for each package according to the
@@ -72,100 +72,29 @@ the last release.
 
 **Important Note**: The current Daml Finance release requires the use of Daml SDK v2.5 or later.
 
-Major Updates
--------------
+Smart Contract Upgradeability
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The main driver for this release has been to optimize the library for useability, maintainability,
-and upgradability. Along with code changes, new documentation and tutorials have been added to
-streamline the learning process for new users.
+Daml Finance is now smart contract upgradeable by relying on Daml SDK 2.10.0 and Daml LF 1.17. As
+part of this change, each package incorporates its major version number (Vx) into its path, package
+name, and module name. Consequently, the major version for all Daml Finance packages has been
+incremented.
 
-This section outlines the major changes and reasons behind them. The technical changelog for each
-package can be found as a sub-page under :doc:`Packages <packages/index>`.
+Context-Aware Semaphore Lock Release
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Enhanced Upgradeability, Extensibility, and Interoperability
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A fix added to the Daml.Finance.Util package ensures that a holding protected by a semaphore lock
+will only be released if the lock's context matches the provided unlock context. This prevents
+inadvertent releases.
 
-The core asset model (``Account``, ``Holding``, and ``Instrument`` interfaces) has been enhanced to
-streamline upgrade processes, enhance extensibility, and improve interoperability:
+New AutoCallable Instrument
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. The ``Account`` now links to its ``Daml.Finance.Interface.Holding.V4.Factory`` by key, a
-   ``HoldingFactoryKey``, instead of a ``ContractId``. This facilitates the upgrading of a
-   ``HoldingFactory`` without the need to modify existing ``Account`` contract instances. It also
-   enables a "lazy" upgrade approach for holdings, as detailed the
-   :doc:`Holding Upgrade Tutorial <./tutorials/upgrade/holding>`.
-
-#. In anticipation of the need for standardization when implementing composed workflows across
-   applications, the notion of a ``HoldingStandard`` was introduced (as part of the
-   ``InstrumenKey``). It categorizes holdings into four distinct classes, each defined by the
-   combination of holding interfaces (``Transferable``, ``Fungible``, and ``Holding``) they
-   implement. This new standard has guided the renaming and structuring of holding implementations.
-   The ``Fungible`` interface no longer requires the ``Transferable`` interface. However, both
-   ``Transferable`` and ``Fungible`` continue to require the implementation of the ``Holding``
-   interface (renamed from ``Base`` following customer feedback). Moreover, the settlement process
-   has been refined to require only a matching ``HoldingStandard``, allowing for implementation
-   variations.
-
-#. A unified ``HoldingFactory`` capable of creating holdings for any specified ``HoldingStandard``
-   has been adopted. In particular, this enables multiple holdings (of various ``HoldingStandards``)
-   to be credited to the same account.
-
-Foreseeing future integration with Daml 3.0 and the Canton Network
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In order to ease future transitions to Daml 3.0 and the Canton Network, there is a shift to
-single-maintainer contract keys:
-
-#. The `issuer : Party` of the ``InstrumentKey`` is now the single maintainer for the ``Instrument``
-   key.
-
-#. For ``Batch`` and ``Instruction``, the `requestors : Parties` field has been divided into a
-   single-maintainer `instructor : Party` for the ``Instruction`` key, alongside additional
-   signatories `consenters : Parties`. Corresponding changes have been made to the ``Batch`` and
-   ``Instruction`` views. In the ``Daml.Finance.Lifecycle.V4.Rule.Claim`` implementation,
-   `providers : Parties` has been replaced with a single `provider : Party` (to facilitate assigning
-   the `provider` as a settlement `instructor : Party`).
-
-#. The LedgerTime key has been completely removed, as it was redundant.
-
-Streamlining Interface Archival
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Previously, our factory contracts featured a ``Remove`` choice for archiving interface instances.
-With Daml now supporting direct archival of interface instances, these choices have been removed. To
-facilitate the simultaneous archival of ``Account``, ``Instrument``, and ``HoldingFactory``
-interfaces with their related ``Reference`` contract instance, a ``Remove`` choice has been added to
-the ``Account``, base ``Instrument``, and ``HoldingFactory`` interfaces.
-
-New Interface Lockable
-~~~~~~~~~~~~~~~~~~~~~~
-
-The locking mechanism has been separated from the base ``Holding`` interface into a new ``Lockable``
-interface (which the ``Holding`` now requires). That makes ``Lockable`` available for broader use;
-while the ``Account`` also implements ``Lockable`` allowing to freeze an account, it’s not required.
-
-Additionally, the implementations of ``Transfer``, ``Split``, ``Merge``, and ``Debit`` have been
-adjusted to require unlocking before they can be used when in the locked state.
-
-New Instruments
-~~~~~~~~~~~~~~~
-
-The library's functionality has been broadened by introducing new financial instruments,
-such as structured products and multi-underlying asset swap instruments (both early access).
-
-Usability Improvements
-~~~~~~~~~~~~~~~~~~~~~~
-
-Finally, a large number (around 50 tickets) of smaller improvements addressing customer feedback
-were made. These improvements range from the consistency of naming conventions (for example, the type
-synonym ``F`` for factories has been renamed to ``T`` for factory templates and ``I`` for factory
-interfaces) in the library to didactical improvements in our docs and tutorials.
-
-Additional Changes
-~~~~~~~~~~~~~~~~~~
-
-The ``Calculate`` choice in the ``Effect`` interface now accepts a quantity as an argument instead
-of a ``ContractId Holding``. This change enhances privacy by minimizing unnecessary data exposure.
-
+A new AutoCallable instrument
+:ref:`AutoCallable <module-daml-finance-instrument-structuredproduct-v1-autocallable-instrument-89951>`
+has been added to the experimental
+Daml.Finance.Instrument.StructuredProduct.V1 package. This addition expands the set of available
+structured product instruments.
 
 Stable Packages
 ---------------

--- a/docs/2.10.0/docs/daml-finance/index.rst
+++ b/docs/2.10.0/docs/daml-finance/index.rst
@@ -88,7 +88,7 @@ Enhanced Upgradeability, Extensibility, and Interoperability
 The core asset model (``Account``, ``Holding``, and ``Instrument`` interfaces) has been enhanced to
 streamline upgrade processes, enhance extensibility, and improve interoperability:
 
-#. The ``Account`` now links to its ``Daml.Finance.Interface.Holding.Factory`` by key, a
+#. The ``Account`` now links to its ``Daml.Finance.Interface.Holding.V4.Factory`` by key, a
    ``HoldingFactoryKey``, instead of a ``ContractId``. This facilitates the upgrading of a
    ``HoldingFactory`` without the need to modify existing ``Account`` contract instances. It also
    enables a "lazy" upgrade approach for holdings, as detailed the
@@ -121,7 +121,7 @@ single-maintainer contract keys:
 #. For ``Batch`` and ``Instruction``, the `requestors : Parties` field has been divided into a
    single-maintainer `instructor : Party` for the ``Instruction`` key, alongside additional
    signatories `consenters : Parties`. Corresponding changes have been made to the ``Batch`` and
-   ``Instruction`` views. In the ``Daml.Finance.Lifecycle.Rule.Claim`` implementation,
+   ``Instruction`` views. In the ``Daml.Finance.Lifecycle.V4.Rule.Claim`` implementation,
    `providers : Parties` has been replaced with a single `provider : Party` (to facilitate assigning
    the `provider` as a settlement `instructor : Party`).
 
@@ -170,132 +170,132 @@ of a ``ContractId Holding``. This change enhances privacy by minimizing unnecess
 Stable Packages
 ---------------
 
-+-------------------------------------------+---------+--------+
-| Package                                   | Version | Status |
-+===========================================+=========+========+
-| ContingentClaims.Core                     | 2.0.1   | Stable |
-+-------------------------------------------+---------+--------+
-| ContingentClaims.Lifecycle                | 2.0.1   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Account                      | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Claims                       | 2.1.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Data                         | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Holding                      | 3.0.1   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Bond              | 2.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Generic           | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Token             | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Account            | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Claims             | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Data               | 3.1.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Holding            | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Base    | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Bond    | 2.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Generic | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Token   | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Types   | 1.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Lifecycle          | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Settlement         | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Types.Common       | 2.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Types.Date         | 2.1.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Util               | 2.1.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Lifecycle                    | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Settlement                   | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Util                         | 3.1.0   | Stable |
-+-------------------------------------------+---------+--------+
++----------------------------------------------+---------+--------+
+| Package                                      | Version | Status |
++==============================================+=========+========+
+| ContingentClaims.Core.V3                     | 2.0.1   | Stable |
++----------------------------------------------+---------+--------+
+| ContingentClaims.Lifecycle.V3                | 2.0.1   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Account.V4                      | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Claims.V3                       | 2.1.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Data.V4                         | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Holding.V4                      | 3.0.1   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Instrument.Bond.V3              | 2.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Instrument.Generic.V4           | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Instrument.Token.V4             | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Account.V4            | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Claims.V4             | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Data.V4               | 3.1.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Holding.V4            | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Base.V4    | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Bond.V3    | 2.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Generic.V4 | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Token.V4   | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Types.V2   | 1.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Lifecycle.V4          | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Settlement.V4         | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Types.Common.V3       | 2.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Types.Date.V3         | 2.1.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Util.V3               | 2.1.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Lifecycle.V4                    | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Settlement.V4                   | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Util.V4                         | 3.1.0   | Stable |
++----------------------------------------------+---------+--------+
 
 Early Access Packages
 ---------------------
 
-+-----------------------------------------------------+---------+--------+
-| Package                                             | Version | Status |
-+=====================================================+=========+========+
-| ContingentClaims.Valuation                          | 0.2.2   | Labs   |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Equity                      | 0.4.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Option                      | 0.3.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.StructuredProduct           | 0.1.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Swap                        | 0.4.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Equity            | 0.4.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Option            | 0.3.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.StructuredProduct | 0.1.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Swap              | 0.4.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
++--------------------------------------------------------+---------+--------+
+| Package                                                | Version | Status |
++========================================================+=========+========+
+| ContingentClaims.Valuation.V1                          | 0.2.2   | Labs   |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Instrument.Equity.V1                      | 0.4.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Instrument.Option.V1                      | 0.3.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Instrument.StructuredProduct.V1           | 0.1.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Instrument.Swap.V1                        | 0.4.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Equity.V1            | 0.4.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Option.V1            | 0.3.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.StructuredProduct.V1 | 0.1.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Swap.V1              | 0.4.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
 
 Deprecated Packages
 -------------------
 
-+--------------------------------------------+--------------------+--------+
-| Package                                    | Version            | Status |
-+============================================+====================+========+
-| ContingentClaims.Core                      | 1.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| ContingentClaims.Lifecycle                 | 1.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Account                       | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Claims                        | 1.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Data                          | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Holding                       | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Instrument.Generic            | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Instrument.Token              | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Account             | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Claims              | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Data                | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Holding             | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Instrument.Base     | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Instrument.Generic  | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Instrument.Token    | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Lifecycle           | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Settlement          | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Util                | 1.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Lifecycle                     | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Settlement                    | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Util                          | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
++-----------------------------------------------+--------------------+--------+
+| Package                                       | Version            | Status |
++===============================================+====================+========+
+| ContingentClaims.Core.V3                      | 1.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| ContingentClaims.Lifecycle.V3                 | 1.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Account.V4                       | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Claims.V3                        | 1.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Data.V4                          | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Holding.V4                       | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Instrument.Generic.V4            | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Instrument.Token.V4              | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Account.V4             | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Claims.V4              | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Data.V4                | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Holding.V4             | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Instrument.Base.V4     | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Instrument.Generic.V4  | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Instrument.Token.V4    | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Lifecycle.V4           | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Settlement.V4          | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Util.V3                | 1.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Lifecycle.V4                     | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Settlement.V4                    | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Util.V4                          | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+

--- a/docs/2.10.0/docs/daml-finance/index.rst
+++ b/docs/2.10.0/docs/daml-finance/index.rst
@@ -173,57 +173,57 @@ Stable Packages
 +----------------------------------------------+---------+--------+
 | Package                                      | Version | Status |
 +==============================================+=========+========+
-| ContingentClaims.Core.V3                     | 2.0.1   | Stable |
+| ContingentClaims.Core.V3                     | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| ContingentClaims.Lifecycle.V3                | 2.0.1   | Stable |
+| ContingentClaims.Lifecycle.V3                | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Account.V4                      | 3.0.0   | Stable |
+| Daml.Finance.Account.V4                      | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Claims.V3                       | 2.1.0   | Stable |
+| Daml.Finance.Claims.V3                       | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Data.V4                         | 3.0.0   | Stable |
+| Daml.Finance.Data.V4                         | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Holding.V4                      | 3.0.1   | Stable |
+| Daml.Finance.Holding.V4                      | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Bond.V3              | 2.0.0   | Stable |
+| Daml.Finance.Instrument.Bond.V3              | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Generic.V4           | 3.0.0   | Stable |
+| Daml.Finance.Instrument.Generic.V4           | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Token.V4             | 3.0.0   | Stable |
+| Daml.Finance.Instrument.Token.V4             | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Account.V4            | 3.0.0   | Stable |
+| Daml.Finance.Interface.Account.V4            | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Claims.V4             | 3.0.0   | Stable |
+| Daml.Finance.Interface.Claims.V4             | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Data.V4               | 3.1.0   | Stable |
+| Daml.Finance.Interface.Data.V4               | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Holding.V4            | 3.0.0   | Stable |
+| Daml.Finance.Interface.Holding.V4            | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Base.V4    | 3.0.0   | Stable |
+| Daml.Finance.Interface.Instrument.Base.V4    | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Bond.V3    | 2.0.0   | Stable |
+| Daml.Finance.Interface.Instrument.Bond.V3    | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Generic.V4 | 3.0.0   | Stable |
+| Daml.Finance.Interface.Instrument.Generic.V4 | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Token.V4   | 3.0.0   | Stable |
+| Daml.Finance.Interface.Instrument.Token.V4   | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Types.V2   | 1.0.0   | Stable |
+| Daml.Finance.Interface.Instrument.Types.V2   | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Lifecycle.V4          | 3.0.0   | Stable |
+| Daml.Finance.Interface.Lifecycle.V4          | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Settlement.V4         | 3.0.0   | Stable |
+| Daml.Finance.Interface.Settlement.V4         | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Types.Common.V3       | 2.0.0   | Stable |
+| Daml.Finance.Interface.Types.Common.V3       | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Types.Date.V3         | 2.1.0   | Stable |
+| Daml.Finance.Interface.Types.Date.V3         | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Util.V3               | 2.1.0   | Stable |
+| Daml.Finance.Interface.Util.V3               | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Lifecycle.V4                    | 3.0.0   | Stable |
+| Daml.Finance.Lifecycle.V4                    | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Settlement.V4                   | 3.0.0   | Stable |
+| Daml.Finance.Settlement.V4                   | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Util.V4                         | 3.1.0   | Stable |
+| Daml.Finance.Util.V4                         | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
 
 Early Access Packages
@@ -232,23 +232,23 @@ Early Access Packages
 +--------------------------------------------------------+---------+--------+
 | Package                                                | Version | Status |
 +========================================================+=========+========+
-| ContingentClaims.Valuation.V1                          | 0.2.2   | Labs   |
+| ContingentClaims.Valuation.V1                          | 1.0.0   | Labs   |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Equity.V1                      | 0.4.0   | Alpha  |
+| Daml.Finance.Instrument.Equity.V1                      | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Option.V1                      | 0.3.0   | Alpha  |
+| Daml.Finance.Instrument.Option.V1                      | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.StructuredProduct.V1           | 0.1.0   | Alpha  |
+| Daml.Finance.Instrument.StructuredProduct.V1           | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Swap.V1                        | 0.4.0   | Alpha  |
+| Daml.Finance.Instrument.Swap.V1                        | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Equity.V1            | 0.4.0   | Alpha  |
+| Daml.Finance.Interface.Instrument.Equity.V1            | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Option.V1            | 0.3.0   | Alpha  |
+| Daml.Finance.Interface.Instrument.Option.V1            | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.StructuredProduct.V1 | 0.1.0   | Alpha  |
+| Daml.Finance.Interface.Instrument.StructuredProduct.V1 | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Swap.V1              | 0.4.0   | Alpha  |
+| Daml.Finance.Interface.Instrument.Swap.V1              | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
 
 Deprecated Packages
@@ -257,45 +257,45 @@ Deprecated Packages
 +-----------------------------------------------+--------------------+--------+
 | Package                                       | Version            | Status |
 +===============================================+====================+========+
-| ContingentClaims.Core.V3                      | 1.*                | Depr.  |
+| ContingentClaims.Core                         | 2.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| ContingentClaims.Lifecycle.V3                 | 1.*                | Depr.  |
+| ContingentClaims.Lifecycle                    | 2.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Account.V4                       | 2.*                | Depr.  |
+| Daml.Finance.Account                          | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Claims.V3                        | 1.*                | Depr.  |
+| Daml.Finance.Claims                           | 2.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Data.V4                          | 2.*                | Depr.  |
+| Daml.Finance.Data                             | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Holding.V4                       | 2.*                | Depr.  |
+| Daml.Finance.Holding                          | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Instrument.Generic.V4            | 2.*                | Depr.  |
+| Daml.Finance.Instrument.Generic               | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Instrument.Token.V4              | 2.*                | Depr.  |
+| Daml.Finance.Instrument.Token                 | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Account.V4             | 2.*                | Depr.  |
+| Daml.Finance.Interface.Account                | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Claims.V4              | 2.*                | Depr.  |
+| Daml.Finance.Interface.Claims                 | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Data.V4                | 2.*                | Depr.  |
+| Daml.Finance.Interface.Data                   | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Holding.V4             | 2.*                | Depr.  |
+| Daml.Finance.Interface.Holding                | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Instrument.Base.V4     | 2.*                | Depr.  |
+| Daml.Finance.Interface.Instrument.Base        | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Instrument.Generic.V4  | 2.*                | Depr.  |
+| Daml.Finance.Interface.Instrument.Generic     | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Instrument.Token.V4    | 2.*                | Depr.  |
+| Daml.Finance.Interface.Instrument.Token       | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Lifecycle.V4           | 2.*                | Depr.  |
+| Daml.Finance.Interface.Lifecycle              | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Settlement.V4          | 2.*                | Depr.  |
+| Daml.Finance.Interface.Settlement             | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Util.V3                | 1.*                | Depr.  |
+| Daml.Finance.Interface.Util                   | 2.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Lifecycle.V4                     | 2.*                | Depr.  |
+| Daml.Finance.Lifecycle                        | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Settlement.V4                    | 2.*                | Depr.  |
+| Daml.Finance.Settlement                       | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Util.V4                          | 2.*                | Depr.  |
+| Daml.Finance.Util                             | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+

--- a/docs/2.10.0/docs/daml-finance/index.rst
+++ b/docs/2.10.0/docs/daml-finance/index.rst
@@ -72,13 +72,16 @@ the last release.
 
 **Important Note**: The current Daml Finance release requires the use of Daml SDK v2.5 or later.
 
-Smart Contract Upgradeability
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Smart Contract Upgradeability (SCU)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Daml Finance is now smart contract upgradeable by relying on Daml SDK 2.10.0 and Daml LF 1.17. As
-part of this change, each package incorporates its major version number (Vx) into its path, package
-name, and module name. Consequently, the major version for all Daml Finance packages has been
-incremented.
+Daml Finance is now SCU compatible by relying on Daml SDK 2.10.0 and Daml LF 1.17. As part of this
+change, each package incorporates its major version number (Vx) into its path, package name, and
+module name. Consequently, the major version for all Daml Finance packages has been incremented.
+
+.. NOTE::
+   By default, SDK 2.10.0 uses LF 1.15. Enabling SCU support requires building with LF 1.17. To
+   ensure SCU compatibility within Daml Finance, we consistently use LF 1.17.
 
 Context-Aware Semaphore Lock Release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/2.10.0/docs/daml-finance/instruments/bond.rst
+++ b/docs/2.10.0/docs/daml-finance/instruments/bond.rst
@@ -35,7 +35,7 @@ currently supports the following bond types:
 Fixed Rate
 ==========
 
-:ref:`Fixed rate bonds <module-daml-finance-instrument-bond-fixedrate-instrument-67993>`
+:ref:`Fixed rate bonds <module-daml-finance-instrument-bond-v3-fixedrate-instrument-89221>`
 pay a constant coupon rate at the end of each coupon period. The coupon is quoted on a yearly basis
 (per annum, p.a.), but it could be paid more frequently (e.g. quarterly). For example, a bond could
 have a 2% p.a. coupon and a 6M coupon period. That would mean a 1% coupon is paid twice a year.
@@ -52,17 +52,17 @@ We start by defining the terms:
   :start-after: -- CREATE_FIXED_RATE_BOND_VARIABLES_BEGIN
   :end-before: -- CREATE_FIXED_RATE_BOND_VARIABLES_END
 
-The :ref:`day count convention <type-daml-finance-interface-types-date-daycount-daycountconventionenum-67281>`
+The :ref:`day count convention <type-daml-finance-interface-types-date-v3-daycount-daycountconventionenum-31>`
 is used to determine how many days, i.e., what fraction of a full year, each coupon period has. This
 will determine the exact coupon amount that will be paid each period.
 
-The :ref:`business day convention <type-daml-finance-interface-types-date-calendar-businessdayconventionenum-88986>`
+The :ref:`business day convention <type-daml-finance-interface-types-date-v3-calendar-businessdayconventionenum-14112>`
 determines *how* a coupon date is adjusted if it falls on a non-business day.
 
 We also need holiday calendars, which determine *when* to adjust dates.
 
 We can use these variables to create a
-:ref:`PeriodicSchedule <constr-daml-finance-interface-types-date-schedule-periodicschedule-99705>`:
+:ref:`PeriodicSchedule <constr-daml-finance-interface-types-date-v3-schedule-periodicschedule-24577>`:
 
 .. literalinclude:: ../src/test/daml/Daml/Finance/Test/Util/Time.daml
   :language: daml
@@ -72,10 +72,10 @@ We can use these variables to create a
 This is used to determine the periods that are used to calculate the coupon. There are a few things
 to note here:
 
-- The :ref:`RollConventionEnum <type-daml-finance-interface-types-date-rollconvention-rollconventionenum-73360>`
+- The :ref:`RollConventionEnum <type-daml-finance-interface-types-date-v3-rollconvention-rollconventionenum-89490>`
   defines whether dates are rolled at the end of the month or on a given date of the month. In our
   example above, we went for the latter option.
-- The :ref:`StubPeriodTypeEnum <type-daml-finance-interface-types-date-schedule-stubperiodtypeenum-69372>`
+- The :ref:`StubPeriodTypeEnum <type-daml-finance-interface-types-date-v3-schedule-stubperiodtypeenum-99734>`
   allows you to explicitly specify what kind of stub period the bond should have. This is optional
   and not used in the example above. Instead, we defined the stub implicitly by specifying a
   ``firstRegularPeriodStartDate``: since the time between the issue date and the first regular
@@ -93,12 +93,12 @@ Now that we have defined the terms we can create the bond instrument:
   :end-before: -- CREATE_FIXED_RATE_BOND_INSTRUMENT_END
 
 Once this is done, you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 
 Floating Rate
 =============
 
-:ref:`Floating rate bonds <module-daml-finance-instrument-bond-floatingrate-instrument-98586>`
+:ref:`Floating rate bonds <module-daml-finance-instrument-bond-v3-floatingrate-instrument-82370>`
 pay a coupon which is determined by a reference rate.
 There is also a rate spread, which is paid in addition to the reference rate.
 
@@ -110,7 +110,7 @@ Here is an example of a bond paying Euribor 3M + 1.1% p.a. with a 3M coupon peri
   :end-before: -- CREATE_FLOATING_RATE_BOND_VARIABLES_END
 
 The instrument supports two types of reference rates, which are configurable using the
-:ref:`ReferenceRateTypeEnum <type-daml-finance-interface-instrument-types-floatingrate-referenceratetypeenum-97197>`:
+:ref:`ReferenceRateTypeEnum <type-daml-finance-interface-instrument-types-v2-floatingrate-referenceratetypeenum-15522>`:
 
 - Libor/Euribor style rates with a single fixing
 - SOFR style reference rates (using a compounded index)
@@ -128,7 +128,7 @@ for the coupon payment at the end of that period.
 Callable
 ========
 
-:ref:`Callable bonds <module-daml-finance-instrument-bond-callable-instrument-83330>` are similar to
+:ref:`Callable bonds <module-daml-finance-instrument-bond-v3-callable-instrument-35206>` are similar to
 the bonds above, but in addition they can be redeemed by the issuer before maturity. The callability
 is restricted to some (or all) of the coupon dates. In other words, these bonds have a *Bermudan*
 style embedded call option.
@@ -147,7 +147,7 @@ The coupon rate in this example also has a 0% floor and a 1.5% cap. This is conf
 the cap or floor to *None* if it does not apply.
 
 The fixed rate is fairly simple to define, but the floating rate requires more inputs. A
-:ref:`FloatingRate <type-daml-finance-interface-instrument-types-floatingrate-floatingrate-77836>`
+:ref:`FloatingRate <type-daml-finance-interface-instrument-types-v2-floatingrate-floatingrate-56149>`
 data type is used to specify which reference rate should be used and on which date the reference
 rate is fixed for each coupon period.
 
@@ -166,7 +166,7 @@ amount).
 In addition to the Libor/Euribor style reference rates, compounded SOFR and similar reference rates
 are also supported. In order to optimize performance, these compounded rates are calculated via a
 (pre-computed) continuously compounded index, as described in the
-:ref:`ReferenceRateTypeEnum <type-daml-finance-interface-instrument-types-floatingrate-referenceratetypeenum-97197>`.
+:ref:`ReferenceRateTypeEnum <type-daml-finance-interface-instrument-types-v2-floatingrate-referenceratetypeenum-15522>`.
 For example, here is how *daily compounded SOFR* can be specified using the *SOFR Index*:
 
 .. literalinclude:: ../src/test/daml/Daml/Finance/Instrument/Bond/Test/Callable.daml
@@ -216,7 +216,7 @@ Inflation-Linked
 ================
 
 There are different types of inflation-linked bonds in the marketplace. The
-:ref:`Inflation-linked bonds <module-daml-finance-instrument-bond-inflationlinked-instrument-30250>`
+:ref:`Inflation-linked bonds <module-daml-finance-instrument-bond-v3-inflationlinked-instrument-99606>`
 currently supported in Daml Finance pay a fixed coupon rate at the end of every coupon period. This
 corresponds to the payoff of e.g. Treasury Inflation-Protected Securities (TIPS) that are issued by
 the U.S. Treasury. The coupon is calculated based on a principal that is adjusted according to an
@@ -244,7 +244,7 @@ specified coupon rate but the original principal would still be redeemed at matu
 Zero Coupon
 ===========
 
-A :ref:`zero coupon bond <module-daml-finance-instrument-bond-zerocoupon-instrument-52804>`
+A :ref:`zero coupon bond <module-daml-finance-instrument-bond-v3-zerocoupon-instrument-96672>`
 does not pay any coupons at all. It only pays the redemption amount at maturity.
 
 Here is an example of a zero coupon bond:

--- a/docs/2.10.0/docs/daml-finance/instruments/equity.rst
+++ b/docs/2.10.0/docs/daml-finance/instruments/equity.rst
@@ -27,7 +27,7 @@ The Equity Interface
 
 The equity instrument supports different lifecycle events, such as dividends, stock
 splits and mergers. These are modeled using the choices on the
-:ref:`Equity interface <module-daml-finance-interface-instrument-equity-instrument-13224>`,
+:ref:`Equity interface <module-daml-finance-interface-instrument-equity-v1-instrument-10480>`,
 namely ``DeclareDistribution``, ``DeclareReplacement`` and ``DeclareStockSplit``. We will now
 demonstrate each one with a concrete lifecycle event.
 
@@ -37,11 +37,11 @@ Dividend
 The most common lifecycle event of an equity is probably dividends. This normally means that
 the holder of a stock receives a given amount of cash for each stock held. This is modeled using
 the ``DeclareDistribution`` choice. It creates a
-:ref:`Distribution Event <module-daml-finance-lifecycle-event-distribution-17302>`,
+:ref:`Distribution Event <module-daml-finance-lifecycle-v4-event-distribution-38493>`,
 which allows you to specify distribution per share. In the case of a cash dividend, this would be a
 cash instrument. However, the company can also choose to distribute additional stock or even stock
 options. Since the
-:ref:`Distribution Event <module-daml-finance-lifecycle-event-distribution-17302>`
+:ref:`Distribution Event <module-daml-finance-lifecycle-v4-event-distribution-38493>`
 supports an arbitrary ``perUnitDistribution`` instrument, it can be used to model those use cases as
 well.
 
@@ -122,7 +122,7 @@ The preferred way is to model this using the following two components:
 
 - A dividend option instrument, which describes the economic terms of the rights a shareholder
   receives. The page on the :doc:`Option Instrument package <option>` describes how to
-  create a physically settled :ref:`Dividend <module-daml-finance-instrument-option-dividend-instrument-7333>`
+  create a physically settled :ref:`Dividend <module-daml-finance-instrument-option-v1-dividend-instrument-35111>`
   option.
 - The ``DeclareDistribution`` choice to distribute the above option instrument in the correct
   proportion (e.g. 1 option contract for each share held). This can be done in the same way as the
@@ -214,7 +214,7 @@ means that a shareholder will have two shares after the split for every share he
 This is modeled using the ``DeclareStockSplit`` choice, which has an ``adjustmentFactor`` argument.
 
 The ``DeclareStockSplit`` choice creates a
-:ref:`Replacement Event <module-daml-finance-lifecycle-event-replacement-51859>`,
+:ref:`Replacement Event <module-daml-finance-lifecycle-v4-event-replacement-94706>`,
 which allows you to replace units of an instrument with another instrument (or a basket of other
 instruments). Consequently, this interface can also be used for other types of corporate actions
 (for example, see the *merger* scenario below).
@@ -265,7 +265,7 @@ Merger
 
 The merger scenario models the case when one company acquires another company and pays for it using
 its own shares. This is modeled using the ``DeclareReplacement`` choice, which also uses the
-:ref:`Replacement Event <module-daml-finance-lifecycle-event-replacement-51859>`
+:ref:`Replacement Event <module-daml-finance-lifecycle-v4-event-replacement-94706>`
 (like the *stock split* scenario above).
 This is a mandatory exchange offer: no election is required (or possible) by the shareholder.
 

--- a/docs/2.10.0/docs/daml-finance/instruments/generic.rst
+++ b/docs/2.10.0/docs/daml-finance/instruments/generic.rst
@@ -56,7 +56,7 @@ Alternatively, if you want to model a European Option instead, you can define th
   :start-after: -- CREATE_CC_OPTION_INSTRUMENT_VARIABLES_BEGIN
   :end-before: -- CREATE_CC_OPTION_INSTRUMENT_VARIABLES_END
 
-This uses the :ref:`european <function-contingentclaims-core-builders-european-99265>` builder
+This uses the :ref:`european <function-contingentclaims-core-v3-builders-european-38509>` builder
 function, which is included in :doc:`Contingent Claims <generic/contingent-claims>`.
 
 Compared to the bond, where the passage of time results in a coupon payment being due, the
@@ -134,7 +134,7 @@ Daml Finance library. There can be different processes to create the Election, s
 application specific. Still, in order to showcase one way how this could be done, this workflow is
 included here for convenience.
 
-The :ref:`Election <module-daml-finance-interface-lifecycle-election-24570>`
+The :ref:`Election <module-daml-finance-interface-lifecycle-v4-election-15483>`
 has a flag *electorIsOwner*, which indicates whether the election is on behalf of the owner of the
 holding. This is typically the case for options, where the option holder has the right, but not the
 obligation, to exercise the option. On the other hand, for callable bonds it is not the holding

--- a/docs/2.10.0/docs/daml-finance/instruments/generic/contingent-claims.rst
+++ b/docs/2.10.0/docs/daml-finance/instruments/generic/contingent-claims.rst
@@ -8,7 +8,7 @@ Introduction
 ************
 
 Contingent Claims is a library for modeling financial instruments in Daml. An instrument is
-represented by a tree of :ref:`Claims <type-contingentclaims-core-internal-claim-claim-35538>`,
+represented by a tree of :ref:`Claims <type-contingentclaims-core-v3-internal-claim-claim-83050>`,
 which describe future contractual events (cashflows and other `effects <#lifecycling-effect>`__)
 between two parties as well as the conditions under which these contractual events occur.
 
@@ -40,7 +40,7 @@ intervals (the small arrows), and a single repayment of the loan at maturity (th
 right). So how do we go about modelling this?
 
 We use the following data type, slightly simplified from
-:ref:`Claim <type-contingentclaims-core-internal-claim-claim-35538>`:
+:ref:`Claim <type-contingentclaims-core-v3-internal-claim-claim-83050>`:
 
 .. code-block:: daml
 
@@ -113,7 +113,7 @@ wish to avoid repeating ourselves. Hence, we could write functions to re-use sub
 tree. But which parts should we factor out? It turns out that Finance 101 comes to the rescue
 again. Fixed income practitioners will typically model a fixed-rate bond as a sum of zero-coupon
 bonds. That’s how we model them in :ref:`Claims.Util.Builders
-<module-daml-finance-claims-util-builders-48637>`. Below are slightly simplified versions:
+<module-daml-finance-claims-v3-util-builders-30825>`. Below are slightly simplified versions:
 
 .. code:: daml
 
@@ -225,7 +225,7 @@ a different use case: the lifecycling (aka safekeeping, processing corporate act
 instruments.
 
 Let’s go back to our fixed-rate bond example, above. We want to process the coupon payments. There
-is a function in the :ref:`Lifecycle module <module-contingentclaims-lifecycle-lifecycle-72039>`
+is a function in the :ref:`Lifecycle module <module-contingentclaims-lifecycle-v3-lifecycle-61551>`
 for doing exactly this:
 
 .. literalinclude:: ../../src/main/daml/ContingentClaims/Lifecycle/V3/Lifecycle.daml
@@ -268,7 +268,7 @@ Pricing (Experimental)
 
 This is an *experimental* feature. Expect breaking changes.
 
-The :ref:`ContigentClaims.Valuation.Stochastic <module-contingentclaims-valuation-stochastic-37844>`
+The :ref:`ContigentClaims.Valuation.Stochastic <module-contingentclaims-valuation-v1-stochastic-86240>`
 module can be used for valuation. There is a ``fapf``
 function which is used to derive a *fundamental asset pricing formula* for an arbitrary ``Claim``
 tree. The resulting AST is represented by ``Expr``, but can be rendered as XML/MathML with the

--- a/docs/2.10.0/docs/daml-finance/instruments/generic/contingent-claims.rst
+++ b/docs/2.10.0/docs/daml-finance/instruments/generic/contingent-claims.rst
@@ -228,7 +228,7 @@ Let’s go back to our fixed-rate bond example, above. We want to process the co
 is a function in the :ref:`Lifecycle module <module-contingentclaims-lifecycle-lifecycle-72039>`
 for doing exactly this:
 
-.. literalinclude:: ../../src/main/daml/ContingentClaims/Lifecycle/Lifecycle.daml
+.. literalinclude:: ../../src/main/daml/ContingentClaims/Lifecycle/V3/Lifecycle.daml
   :language: daml
   :start-after: -- CLAIMS_LIFECYCLE_BEGIN
   :end-before: -- CLAIMS_LIFECYCLE_END

--- a/docs/2.10.0/docs/daml-finance/instruments/option.rst
+++ b/docs/2.10.0/docs/daml-finance/instruments/option.rst
@@ -32,7 +32,7 @@ Physically settled European Option
 ----------------------------------
 
 The
-:ref:`EuropeanPhysical <module-daml-finance-instrument-option-europeanphysical-instrument-71708>`
+:ref:`EuropeanPhysical <module-daml-finance-instrument-option-v1-europeanphysical-instrument-98774>`
 instrument models physically settled call or put options.
 
 There are two important characteristics of this instrument:
@@ -65,14 +65,14 @@ Now that the terms have been defined, you can create the option instrument:
   :end-before: -- CREATE_EUROPEAN_PHYSICAL_OPTION_INSTRUMENT_END
 
 Once this is done, you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 
 Cash-settled European Option
 ----------------------------
 
-The  :ref:`EuropeanCash <module-daml-finance-instrument-option-europeancash-instrument-22074>`
+The  :ref:`EuropeanCash <module-daml-finance-instrument-option-v1-europeancash-instrument-97900>`
 instrument models cash-settled, auto-exercising call or put options. They are similar to the
-:ref:`EuropeanPhysical <module-daml-finance-instrument-option-europeancash-instrument-22074>`
+:ref:`EuropeanPhysical <module-daml-finance-instrument-option-v1-europeancash-instrument-97900>`
 instrument described above, but there are two important differences:
 
 #. *cash settlement*: This means that the underlying asset will not change hands. Instead, a cash
@@ -100,7 +100,7 @@ Now that the terms have been defined, you can create the option instrument:
   :end-before: -- CREATE_EUROPEAN_OPTION_INSTRUMENT_END
 
 Once this is done, you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 
 If the close price of AAPL on the expiry date is above the *strike* price, the option holder would
 profit from exercising the option and buying the stock at the strike price. The value of the option
@@ -123,18 +123,18 @@ Barrier Option
 ==============
 
 The
-:ref:`BarrierEuropeanCash <module-daml-finance-interface-instrument-option-barriereuropeancash-instrument-61159>`
+:ref:`BarrierEuropeanCash <module-daml-finance-interface-instrument-option-v1-barriereuropeancash-instrument-53071>`
 instrument models barrier options. They are similar to the
-:ref:`EuropeanCash <module-daml-finance-instrument-option-europeancash-instrument-22074>`
+:ref:`EuropeanCash <module-daml-finance-instrument-option-v1-europeancash-instrument-97900>`
 instrument described above, but also contain a barrier that is used to activate (or, alternatively,
 knock out) the option. The
-:ref:`BarrierTypeEnum <type-daml-finance-interface-instrument-option-types-barriertypeenum-80356>`
+:ref:`BarrierTypeEnum <type-daml-finance-interface-instrument-option-v1-types-barriertypeenum-4880>`
 describes which barrier types are supported.
 
 As an example, consider an option instrument that gives the holder the right to buy AAPL stock
 at a given price. However, if AAPL ever trades at or below a given barrier level, the option is
 knocked out (which means that it expires worthless). In other words, this describes a
-:ref:`DownAndOut <constr-daml-finance-interface-instrument-option-types-downandout-16889>` option.
+:ref:`DownAndOut <constr-daml-finance-interface-instrument-option-v1-types-downandout-65367>` option.
 This example is taken from
 `Instrument/Option/Test/BarrierEuropeanCash.daml <https://github.com/digital-asset/daml-finance/blob/main/src/test/daml/Daml/Finance/Instrument/Option/Test/BarrierEuropeanCash.daml>`_
 , where all the details are available.
@@ -154,10 +154,10 @@ Now that the terms have been defined, you can create the option instrument:
   :end-before: -- CREATE_BARRIER_EUROPEAN_OPTION_INSTRUMENT_END
 
 Once this is done, you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 
 Compared to the
-:ref:`EuropeanCash option <module-daml-finance-instrument-option-europeancash-instrument-22074>`
+:ref:`EuropeanCash option <module-daml-finance-instrument-option-v1-europeancash-instrument-97900>`
 this instrument needs to be lifecycled not only at expiry but also during its lifetime in case of a
 barrier hit. This is done in the same way as lifecycling at maturity, i.e. an *Observation* is
 provided for the reference asset identifier, containing the date and the underlying price.
@@ -165,7 +165,7 @@ provided for the reference asset identifier, containing the date and the underly
 Dividend Option
 ===============
 
-The :ref:`Dividend <module-daml-finance-instrument-option-dividend-instrument-7333>`
+The :ref:`Dividend <module-daml-finance-instrument-option-v1-dividend-instrument-35111>`
 instrument models physically settled, manually exercised dividend options. For reference, a
 dividend option gives the holder the right to choose one out of several dividend payouts, on a
 specific *expiry* date in the future. The following payout types are supported:
@@ -196,7 +196,7 @@ Now that the terms have been defined, you can create the option instrument:
   :end-before: -- CREATE_DIVIDEND_OPTION_INSTRUMENT_END
 
 Once this is done, you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 
 On the expiry date, the option holder will make an *Election* out of the available choices. The
 lifecycling of this option works in the same way as for

--- a/docs/2.10.0/docs/daml-finance/instruments/structured-product.rst
+++ b/docs/2.10.0/docs/daml-finance/instruments/structured-product.rst
@@ -22,7 +22,7 @@ Barrier Reverse Convertible
 ===========================
 
 The
-:ref:`BarrierReverseConvertible <module-daml-finance-instrument-structuredproduct-barrierreverseconvertible-instrument-95793>`
+:ref:`BarrierReverseConvertible <module-daml-finance-instrument-structuredproduct-v1-barrierreverseconvertible-instrument-16231>`
 instrument models cash-settled, auto-exercising barrier reverse convertible (BRC) instruments. It
 can be seen as a long fixed coupon bond and a short Down-And-In put option.
 
@@ -49,7 +49,7 @@ Now that the terms have been defined, you can create the BRC instrument:
   :end-before: -- CREATE_BARRIER_REVERSE_CONVERTIBLE_INSTRUMENT_END
 
 Once this is done, you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 
 This BRC instrument is automatically exercised. This means that the decision whether or not to
 exercise the embedded option is done automatically by comparing observations of the underlying to
@@ -68,7 +68,7 @@ Auto-Callable
 =============
 
 The
-:ref:`AutoCallable <module-daml-finance-interface-instrument-structuredproduct-autocallable-instrument-66988>`
+:ref:`AutoCallable <module-daml-finance-interface-instrument-structuredproduct-v1-autocallable-instrument-15420>`
 instrument models a single-underlying auto-callable note that pays a conditional coupon.
 
 Coupon payment
@@ -118,7 +118,7 @@ Now that the terms have been defined, you can create the AutoCallable instrument
   :end-before: -- CREATE_AUTO_CALLABLE_INSTRUMENT_END
 
 Then you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 
 This instrument is automatically called. This means that the decision whether or not to exercise the
 embedded option is done automatically using the observations of the underlying asset.

--- a/docs/2.10.0/docs/daml-finance/instruments/swap.rst
+++ b/docs/2.10.0/docs/daml-finance/instruments/swap.rst
@@ -29,7 +29,7 @@ currently supports the following types of swaps:
 Interest Rate
 =============
 
-:ref:`Interest rate swap <module-daml-finance-instrument-swap-interestrate-instrument-86260>`
+:ref:`Interest rate swap <module-daml-finance-instrument-swap-v1-interestrate-instrument-25554>`
 is the type of swap that shares most similarities with a bond. It has two legs:
 one which pays a fix rate and another one which pays a floating rate. These rates are paid at the
 end of every payment period.
@@ -47,9 +47,9 @@ We start by defining the terms:
   :end-before: -- CREATE_INTEREST_RATE_SWAP_VARIABLES_END
 
 The floating leg depends on a reference rate, which is specified in the
-:ref:`FloatingRate <type-daml-finance-interface-instrument-types-floatingrate-floatingrate-77836>`
+:ref:`FloatingRate <type-daml-finance-interface-instrument-types-v2-floatingrate-floatingrate-56149>`
 data structure. It supports two types of reference rates, which are configurable using the
-:ref:`ReferenceRateTypeEnum <type-daml-finance-interface-instrument-types-floatingrate-referenceratetypeenum-97197>`:
+:ref:`ReferenceRateTypeEnum <type-daml-finance-interface-instrument-types-v2-floatingrate-referenceratetypeenum-15522>`:
 
 - Libor/Euribor style rates with a single fixing
 - SOFR style reference rates (using a compounded index)
@@ -62,7 +62,7 @@ issuer to the holder). However, in the case of a swap with two counterparties A 
 the holding owner receives the floating leg.
 
 Just as for bonds, we can use these variables to create a
-:ref:`PeriodicSchedule <constr-daml-finance-interface-types-date-schedule-periodicschedule-99705>`:
+:ref:`PeriodicSchedule <constr-daml-finance-interface-types-date-v3-schedule-periodicschedule-24577>`:
 
 .. literalinclude:: ../src/test/daml/Daml/Finance/Test/Util/Time.daml
   :language: daml
@@ -89,13 +89,13 @@ Now that we have defined the terms we can create the swap instrument:
   :end-before: -- CREATE_INTEREST_RATE_SWAP_INSTRUMENT_END
 
 Once this is done, you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 The owner of the holding receives the floating leg (and pays the fix leg).
 
 Currency
 ========
 
-:ref:`Currency swaps <module-daml-finance-instrument-swap-currency-instrument-67721>`
+:ref:`Currency swaps <module-daml-finance-instrument-swap-v1-currency-instrument-73211>`
 are quite similar to interest rate swaps, except that the two legs are in different
 currencies. Consequently, we need to create two cash instruments:
 
@@ -138,7 +138,7 @@ Foreign Exchange
 ================
 
 Despite the similarities in name,
-:ref:`foreign exchange swaps <module-daml-finance-instrument-swap-foreignexchange-instrument-43394>`
+:ref:`foreign exchange swaps <module-daml-finance-instrument-swap-v1-foreignexchange-instrument-82256>`
 (or FX swaps) are quite different from currency swaps.
 An FX swap does not pay or receive interest. Instead, the two legs define an initial
 FX transaction and a final FX transaction. Each transaction requires an FX rate and a transaction
@@ -178,7 +178,7 @@ the foreign currency in the initial transaction. In the final transaction the si
 Credit Default
 ==============
 
-A :ref:`credit default swap <module-daml-finance-instrument-swap-creditdefault-instrument-88725>`
+A :ref:`credit default swap <module-daml-finance-instrument-swap-v1-creditdefault-instrument-52131>`
 (CDS) pays a protection amount in case of a credit default event, in exchange
 for a fix rate at the end of every payment period. The protection amount is defined as
 *1-recoveryRate*. The *recoveryRate* is defined as the amount recovered when a borrower defaults,
@@ -218,7 +218,7 @@ holding receives the protection leg (and pays the fix leg).
 Asset
 =====
 
-An :ref:`asset swap <module-daml-finance-instrument-swap-asset-instrument-28127>`
+An :ref:`asset swap <module-daml-finance-instrument-swap-v1-asset-instrument-35945>`
 is a general type of swap with two legs: one which pays an interest rate and another one
 which pays the performance of an asset (or a basket of assets). It can be used to model:
 
@@ -268,7 +268,7 @@ FpML
 ====
 
 Unlike the other swap types above, the
-:ref:`FpML swap <module-daml-finance-instrument-swap-fpml-instrument-17241>` template is
+:ref:`FpML swap <module-daml-finance-instrument-swap-v1-fpml-instrument-78235>` template is
 not a new type of payoff. Instead, it allows you to input other types of swaps using the
 `FpML schema <https://www.fpml.org/spec/fpml-5-11-3-lcwd-1/html/confirmation/schemaDocumentation/schemas/fpml-ird-5-11_xsd/complexTypes/Swap.html>`_.
 Currently, interest rate swaps and currency swaps are supported.
@@ -298,7 +298,7 @@ schema:
   :end-before: -- CREATE_FPML_SWAP_FIX_LEG_END
 
 As you can see, the
-:ref:`Daml SwapStream data type <type-daml-finance-interface-instrument-swap-fpml-fpmltypes-swapstream-38811>`
+:ref:`Daml SwapStream data type <type-daml-finance-interface-instrument-swap-v1-fpml-fpmltypes-swapstream-11715>`
 matches the `swapStream FpML schema <https://www.fpml.org/spec/fpml-5-11-3-lcwd-1/html/confirmation/schemaDocumentation/schemas/fpml-ird-5-11_xsd/complexTypes/Swap/swapStream.html>`_.
 Please note that the actual parsing from FpML to Daml is not done by this template. It has to be
 implemented on the client side.
@@ -313,11 +313,11 @@ Similarly, the floating leg of the swap is defined like this:
 There are three main ways to define which interest rate should be used for a stub period. They are
 all included in the fix or floating leg above, either in the inital or in the final stub period. In
 short, it depends on the content of
-:ref:`StubCalculationPeriodAmount <type-daml-finance-interface-instrument-swap-fpml-fpmltypes-stubcalculationperiodamount-23577>`:
+:ref:`StubCalculationPeriodAmount <type-daml-finance-interface-instrument-swap-v1-fpml-fpmltypes-stubcalculationperiodamount-90721>`:
 
 #. *None*: No special stub rate is provided. Instead, use the same rate as was specified in the
    corresponding
-   :ref:`Calculation <type-daml-finance-interface-instrument-swap-fpml-fpmltypes-calculation-37694>`.
+   :ref:`Calculation <type-daml-finance-interface-instrument-swap-v1-fpml-fpmltypes-calculation-72470>`.
 #. Specific *stubRate*: Use this specific fix rate.
 #. Specific *floatingRate*: Use this specific floating rate (if one rate is provided). If two rates
    are provided: use linear interpolation between the two rates.

--- a/docs/2.10.0/docs/daml-finance/instruments/token.rst
+++ b/docs/2.10.0/docs/daml-finance/instruments/token.rst
@@ -37,7 +37,7 @@ How to lifecycle a Token Instrument
 ***********************************
 
 Generic corporate actions, such as
-:ref:`Distribution events <module-daml-finance-lifecycle-event-distribution-17302>`, can be
+:ref:`Distribution events <module-daml-finance-lifecycle-v4-event-distribution-38493>`, can be
 applied to Token Instruments.
 The :doc:`Lifecycling <../tutorials/getting-started/lifecycling>`
 section of the Getting Started tutorial shows how this is done in detail.

--- a/docs/2.10.0/docs/daml-finance/overview/architecture.rst
+++ b/docs/2.10.0/docs/daml-finance/overview/architecture.rst
@@ -46,10 +46,10 @@ Implementation Layer
 The implementation layer contains concrete template definitions implementing the interfaces defined
 in the interface layer. These represent the contracts that are ultimately stored on the ledger.
 
-For instance, ``Daml.Finance.Holding`` contains a concrete implementation of a
-:ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>` and
-:ref:`Fungible <module-daml-finance-interface-holding-fungible-63712>` holding. These
-interfaces are defined in ``Daml.Finance.Interface.Holding``.
+For instance, ``Daml.Finance.Holding.V4`` contains a concrete implementation of a
+:ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>` and
+:ref:`Fungible <module-daml-finance-interface-holding-v4-fungible-55495>` holding. These
+interfaces are defined in ``Daml.Finance.Interface.Holding.V4``.
 
 The implementation layer consists of the following packages:
 

--- a/docs/2.10.0/docs/daml-finance/overview/architecture.rst
+++ b/docs/2.10.0/docs/daml-finance/overview/architecture.rst
@@ -23,21 +23,21 @@ These packages can in principle be used independently of each other.
 
 The interface layer consists of the following packages:
 
-- ``Daml.Finance.Interface.Holding`` defines interfaces for holdings and related properties such
+- ``Daml.Finance.Interface.Holding.V4`` defines interfaces for holdings and related properties such
   as :ref:`transferability <transferability>` or :ref:`fungibility <fungibility>`.
-- ``Daml.Finance.Interface.Account`` defines interfaces for accounts
-- ``Daml.Finance.Interface.Settlement`` defines interfaces for settlement route providers,
+- ``Daml.Finance.Interface.Account.V4`` defines interfaces for accounts
+- ``Daml.Finance.Interface.Settlement.V4`` defines interfaces for settlement route providers,
   settlement instructions, and batched settlements
-- ``Daml.Finance.Interface.Lifecycle`` defines interfaces used for instrument lifecycling
+- ``Daml.Finance.Interface.Lifecycle.V4`` defines interfaces used for instrument lifecycling
 - ``Daml.Finance.Interface.Instrument.*`` contains interfaces used for different instrument types
-- ``Daml.Finance.Interface.Claims`` contains interfaces used for
+- ``Daml.Finance.Interface.Claims.V4`` contains interfaces used for
   :doc:`Contingent Claims <../instruments/generic/contingent-claims>` based instrument types
-- ``Daml.Finance.Interface.Data`` defines interfaces related to reference data
-- ``Daml.Finance.Interface.Types.Common`` provides common types
-- ``Daml.Finance.Interface.Types.Date`` provides types related to dates
-- ``Daml.Finance.Interface.Util`` defines utilities and interfaces used by other interface
+- ``Daml.Finance.Interface.Data.V4`` defines interfaces related to reference data
+- ``Daml.Finance.Interface.Types.Common.V3`` provides common types
+- ``Daml.Finance.Interface.Types.Date.V3`` provides types related to dates
+- ``Daml.Finance.Interface.Util.V3`` defines utilities and interfaces used by other interface
   packages.
-- ``ContingentClaims.Core`` contains types for representing
+- ``ContingentClaims.Core.V3`` contains types for representing
   :doc:`Contingent Claims <../instruments/generic/contingent-claims>` tree structures.
 
 Implementation Layer
@@ -53,21 +53,21 @@ interfaces are defined in ``Daml.Finance.Interface.Holding``.
 
 The implementation layer consists of the following packages:
 
-- ``Daml.Finance.Holding`` defines default implementations for holdings
-- ``Daml.Finance.Account`` defines default implementations for accounts
-- ``Daml.Finance.Settlement`` defines templates for settlement route providers, settlement
+- ``Daml.Finance.Holding.V4`` defines default implementations for holdings
+- ``Daml.Finance.Account.V4`` defines default implementations for accounts
+- ``Daml.Finance.Settlement.V4`` defines templates for settlement route providers, settlement
   instructions, and batched settlements
-- ``Daml.Finance.Lifecycle`` defines an implementation of lifecycle effects and a rule template to
+- ``Daml.Finance.Lifecycle.V4`` defines an implementation of lifecycle effects and a rule template to
   facilitate their settlement
 - ``Daml.Finance.Instrument.*`` contains implementations for various instrument types
-- ``Daml.Finance.Data`` includes templates used to store reference data on the ledger
-- ``Daml.Finance.Claims`` contains utility functions relating to
+- ``Daml.Finance.Data.V4`` includes templates used to store reference data on the ledger
+- ``Daml.Finance.Claims.V3`` contains utility functions relating to
   :doc:`Contingent Claims <../instruments/generic/contingent-claims>` based instruments and
   lifecycling
-- ``Daml.Finance.Util`` provides a set of pure utility functions mainly for date manipulation
-- ``ContingentClaims.Lifecycle`` provides lifecycle utility functions for
+- ``Daml.Finance.Util.V4`` provides a set of pure utility functions mainly for date manipulation
+- ``ContingentClaims.Lifecycle.V3`` provides lifecycle utility functions for
   :doc:`Contingent Claims <../instruments/generic/contingent-claims>` based instruments
-- ``ContingentClaims.Valuation`` contains experimental functions to transform
+- ``ContingentClaims.Valuation.V1`` contains experimental functions to transform
   :doc:`Contingent Claims <../instruments/generic/contingent-claims>` instrument trees into a
   mathematical representation suitable for integration with pricing and risk frameworks
 

--- a/docs/2.10.0/docs/daml-finance/overview/extending-daml-finance.rst
+++ b/docs/2.10.0/docs/daml-finance/overview/extending-daml-finance.rst
@@ -23,16 +23,16 @@ Daml Finance provides default holding implementations for the following holding 
 4. neither fungible nor transferable (i.e., the `BaseHolding` holding standard)
 
 The transferability of transferable holdings can be flexibly controlled through the
-:ref:`controllers <type-daml-finance-interface-account-account-controllers-36430>`
-property on an :ref:`Account <module-daml-finance-account-account-19369>`.
+:ref:`controllers <type-daml-finance-interface-account-v4-account-controllers-59817>`
+property on an :ref:`Account <module-daml-finance-account-v4-account-5834>`.
 Some use cases, however, might require additional functionality on holding contracts:
 
 - *Restricted transferability*: a custom implementation of the
-  :ref:`Transferable interface <module-daml-finance-interface-holding-transferable-88121>`
+  :ref:`Transferable interface <module-daml-finance-interface-holding-v4-transferable-93054>`
   can enforce additional conditions (e.g. the presence of some contract) required to transfer a
   holding.
 - *Fixed divisibility*: a custom implementation of the
-  :ref:`Fungible interface <module-daml-finance-interface-holding-fungible-63712>` can enforce
+  :ref:`Fungible interface <module-daml-finance-interface-holding-v4-fungible-55495>` can enforce
   specific requirements regarding the divisibility of a holding.
 - *Additional information*: a custom implementation of a holding can provide additional information,
   for example, the timestamp of when the holding was obtained. This can be used to implement
@@ -42,7 +42,7 @@ Some use cases, however, might require additional functionality on holding contr
 Note that any custom holding implementation will still allow you to leverage other parts of the
 library (e.g. lifecycling or settlement) as those are implemented against the respective interfaces.
 You will need to provide an implementation of the
-:ref:`Holding Factory <module-daml-finance-interface-holding-factory-6211>` interface for
+:ref:`Holding Factory <module-daml-finance-interface-holding-v4-factory-49942>` interface for
 your implementation to be usable throughout the library.
 
 Custom Account Implementations
@@ -50,19 +50,19 @@ Custom Account Implementations
 
 The default account implementation in Daml Finance allows you to define authorization requirements
 for incoming and outgoing transfers through the
-:ref:`controllers <type-daml-finance-interface-account-account-controllers-36430>` property.
+:ref:`controllers <type-daml-finance-interface-account-v4-account-controllers-59817>` property.
 For some cases, however, a custom account implementation may be warranted:
 
 - Restricted credit and debit: a custom implementation of the ``Credit`` and / or
   ``Debit`` choices on the
-  :ref:`Account interface <module-daml-finance-interface-account-account-92922>` can place
+  :ref:`Account interface <module-daml-finance-interface-account-v4-account-30007>` can place
   additional restrictions on those actions that can depend, for example, on the presence of a
   separate know-your-customer (KYC) contract.
 - Additional information: a custom account implementation can serve to represent different concepts
   of accounts. For example, a shelf in a vault for gold bars or a specific location within a
   warehouse can be represented by providing additional information on an account implementation.
 - Account Freezing: an account can optionally implement
-  the :ref:`Lockable <module-daml-finance-interface-util-lockable-80915>` interface, allowing it to
+  the :ref:`Lockable <module-daml-finance-interface-util-v3-lockable-20339>` interface, allowing it to
   be frozen, i.e., temporarily disabling credits and debits.
 
 Custom Instrument Implementations
@@ -74,7 +74,7 @@ entirely new instrument types. The following are typical examples of when a cust
 implementation is required:
 
 - Additional information: a custom instrument implementation might, for example, build upon the
-  :ref:`Equity interface <module-daml-finance-interface-instrument-equity-instrument-13224>` to
+  :ref:`Equity interface <module-daml-finance-interface-instrument-equity-v1-instrument-10480>` to
   provide additional information pertinent to private equity (like share class, or liquidation
   preference).
 - New instrument types: if Daml Finance does not provide an implementation for a given instrument
@@ -83,20 +83,20 @@ implementation is required:
   described in
   :doc:`this tutorial <../tutorials/advanced-topics/instrument-modeling/contingent-claims-instrument>`,
   or be implemented through standard interfaces, as seen in the implementation of the
-  :ref:`Equity instrument <module-daml-finance-instrument-equity-instrument-69265>`.
+  :ref:`Equity instrument <module-daml-finance-instrument-equity-v1-instrument-56047>`.
 
 Custom Lifecycle Implementations
 ********************************
 
 Daml Finance provides a default set of lifecycle rules that can be used to evolve instruments.
 Examples are the implementation of
-:ref:`Distributions <module-daml-finance-lifecycle-rule-distribution-35531>`,
-:ref:`Replacements <module-daml-finance-lifecycle-rule-replacement-6984>`, or the
-:ref:`time-based evolution <module-daml-finance-interface-lifecycle-event-time-4252>`
+:ref:`Distributions <module-daml-finance-lifecycle-v4-rule-distribution-2662>`,
+:ref:`Replacements <module-daml-finance-lifecycle-v4-rule-replacement-25183>`, or the
+:ref:`time-based evolution <module-daml-finance-interface-lifecycle-v4-event-time-69757>`
 of contingent-claims based instruments. There are many more lifecycle events and rules
 that can be implemented using the provided interfaces. Typically, implementations of the
-:ref:`Event <module-daml-finance-interface-lifecycle-event-43586>` and
-:ref:`Rule <module-daml-finance-interface-lifecycle-rule-lifecycle-50431>` interface are required to
+:ref:`Event <module-daml-finance-interface-lifecycle-v4-event-91777>` and
+:ref:`Rule <module-daml-finance-interface-lifecycle-v4-rule-lifecycle-8270>` interface are required to
 handle new lifecycle events. Examples of events where a library extension might be warranted
 include:
 

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/contingent-claims-lifecycle.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/contingent-claims-lifecycle.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Lifecycle - Changelog
-######################################
+ContingentClaims.Lifecycle.V3 - Changelog
+#########################################
 
 Version 2.0.1
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/contingent-claims-lifecycle.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/contingent-claims-lifecycle.rst
@@ -10,7 +10,7 @@ ContingentClaims.Lifecycle.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 - Bumps `daml-ctl` to `2.4.1`.
 

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/contingent-claims-lifecycle.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/contingent-claims-lifecycle.rst
@@ -1,8 +1,21 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Lifecycle.V3 - Changelog
-#########################################
+Changelog
+#########
+
+ContingentClaims.Lifecycle.V3
+=============================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+- Bumps `daml-ctl` to `2.4.1`.
+
+ContingentClaims.Lifecycle
+==========================
 
 Version 2.0.1
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/contingent-claims-valuation.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/contingent-claims-valuation.rst
@@ -1,8 +1,21 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Valuation.V1 - Changelog
-#########################################
+Changelog
+#########
+
+ContingentClaims.Valuation.V1
+=============================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+- Bumps `daml-ctl` to `2.4.1`.
+
+ContingentClaims.Valuation
+==========================
 
 Version 0.2.2
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/contingent-claims-valuation.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/contingent-claims-valuation.rst
@@ -10,7 +10,7 @@ ContingentClaims.Valuation.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 - Bumps `daml-ctl` to `2.4.1`.
 

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/contingent-claims-valuation.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/contingent-claims-valuation.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Valuation - Changelog
-######################################
+ContingentClaims.Valuation.V1 - Changelog
+#########################################
 
 Version 0.2.2
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-account.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-account.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Account - Changelog
-################################
+Daml.Finance.Account.V4 - Changelog
+###################################
 
 Version 3.0.0
 *************
@@ -10,7 +10,7 @@ Version 3.0.0
 - Update of SDK version and dependencies.
 
 - The Account now uses a key (specifically, a `HoldingFactoryKey`)
-  to reference its `Daml.Finance.Interface.Holding.Factory`, rather than a `ContractId`.
+  to reference its `Daml.Finance.Interface.Holding.V4.Factory`, rather than a `ContractId`.
 
 - The `Remove` implementation was removed from the `Factory` (it is newly part of the `Account`
   interface).

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-account.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-account.rst
@@ -10,7 +10,7 @@ Daml.Finance.Account.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Account
 ====================

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-account.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-account.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Account.V4 - Changelog
-###################################
+Changelog
+#########
+
+Daml.Finance.Account.V4
+=======================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Account
+====================
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-claims.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-claims.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Claims.V3 - Changelog
-##################################
+Changelog
+#########
+
+Daml.Finance.Claims.V3
+======================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Claims
+===================
 
 Version 2.1.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-claims.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-claims.rst
@@ -10,7 +10,7 @@ Daml.Finance.Claims.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Claims
 ===================

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-claims.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-claims.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Claims - Changelog
-###############################
+Daml.Finance.Claims.V3 - Changelog
+##################################
 
 Version 2.1.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-data.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-data.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Data.V4 - Changelog
-################################
+Changelog
+#########
+
+Daml.Finance.Data.V4
+====================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Data
+=================
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-data.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-data.rst
@@ -10,7 +10,7 @@ Daml.Finance.Data.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Data
 =================

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-data.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-data.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Data - Changelog
-#############################
+Daml.Finance.Data.V4 - Changelog
+################################
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-holding.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-holding.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Holding.V4 - Changelog
-###################################
+Changelog
+#########
+
+Daml.Finance.Holding.V4
+=======================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Holding
+====================
 
 Version 3.0.1
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-holding.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-holding.rst
@@ -10,7 +10,7 @@ Daml.Finance.Holding.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Holding
 ====================

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-holding.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-holding.rst
@@ -1,14 +1,14 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Holding - Changelog
-################################
+Daml.Finance.Holding.V4 - Changelog
+###################################
 
 Version 3.0.1
 *************
 
-- Resolved an issue in the `Daml.Finance.Holding` package affecting the `Disclosure.I`
-  implementation of the `Factory` template within the `Daml.Finance.Holding.Factory` module. This
+- Resolved an issue in the `Daml.Finance.Holding.V4` package affecting the `Disclosure.I`
+  implementation of the `Factory` template within the `Daml.Finance.Holding.V4.Factory` module. This
   patch ensures that observers are now correctly updated for the associated `Reference` template.
 
 Version 3.0.0
@@ -32,8 +32,8 @@ Version 3.0.0
 - The holding implementations newly `ensure` that the desired `HoldingStandard` is met.
 
 - The locking logic was factored out to a separate `Lockable` interface (within the
-  `Daml.Finance.Interface.Util` package), and the `acquireImpl` and `releaseImpl` utility functions
-  moved to the `Lockable` module in the `Daml.Finance.Util` implementation package.
+  `Daml.Finance.Interface.Util.V3` package), and the `acquireImpl` and `releaseImpl` utility functions
+  moved to the `Lockable` module in the `Daml.Finance.Util.V4` implementation package.
 
 - The `Transfer`, `Split`, `Merge`, and `Debit` actions on holdings are prohibited in a locked
   state, requiring them to be unlocked first. Notably, the type signatures for `splitImpl` and

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-bond.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-bond.rst
@@ -10,7 +10,7 @@ Daml.Finance.Instrument.Bond.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Instrument.Bond
 ============================

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-bond.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-bond.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Bond.V3 - Changelog
-###########################################
+Changelog
+#########
+
+Daml.Finance.Instrument.Bond.V3
+===============================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Instrument.Bond
+============================
 
 Version 2.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-bond.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-bond.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Bond - Changelog
-########################################
+Daml.Finance.Instrument.Bond.V3 - Changelog
+###########################################
 
 Version 2.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-equity.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-equity.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Equity.V1 - Changelog
-#############################################
+Changelog
+#########
+
+Daml.Finance.Instrument.Equity.V1
+=================================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Instrument.Equity
+==============================
 
 Version 0.4.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-equity.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-equity.rst
@@ -10,7 +10,7 @@ Daml.Finance.Instrument.Equity.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Instrument.Equity
 ==============================

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-equity.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-equity.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Equity - Changelog
-##########################################
+Daml.Finance.Instrument.Equity.V1 - Changelog
+#############################################
 
 Version 0.4.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-generic.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-generic.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Generic.V4 - Changelog
-##############################################
+Changelog
+#########
+
+Daml.Finance.Instrument.Generic.V4
+==================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Instrument.Generic
+===============================
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-generic.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-generic.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Generic - Changelog
-###########################################
+Daml.Finance.Instrument.Generic.V4 - Changelog
+##############################################
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-generic.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-generic.rst
@@ -10,7 +10,7 @@ Daml.Finance.Instrument.Generic.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Instrument.Generic
 ===============================

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-option.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-option.rst
@@ -10,7 +10,7 @@ Daml.Finance.Instrument.Option.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Instrument.Option
 ==============================

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-option.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-option.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Option - Changelog
-##########################################
+Daml.Finance.Instrument.Option.V1 - Changelog
+#############################################
 
 Version 0.3.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-option.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-option.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Option.V1 - Changelog
-#############################################
+Changelog
+#########
+
+Daml.Finance.Instrument.Option.V1
+=================================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Instrument.Option
+==============================
 
 Version 0.3.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-structuredproduct.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-structuredproduct.rst
@@ -10,9 +10,9 @@ Daml.Finance.Instrument.StructuredProduct.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
-- Add new AutoCallable instrument.
+- New AutoCallable instrument.
 
 Daml.Finance.Instrument.StructuredProduct
 =========================================

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-structuredproduct.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-structuredproduct.rst
@@ -1,8 +1,21 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.StructuredProduct.V1 - Changelog
-########################################################
+Changelog
+#########
+
+Daml.Finance.Instrument.StructuredProduct.V1
+============================================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+- Add new AutoCallable instrument.
+
+Daml.Finance.Instrument.StructuredProduct
+=========================================
 
 Version 0.1.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-structuredproduct.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-structuredproduct.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.StructuredProduct - Changelog
-#####################################################
+Daml.Finance.Instrument.StructuredProduct.V1 - Changelog
+########################################################
 
 Version 0.1.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-swap.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-swap.rst
@@ -10,7 +10,7 @@ Daml.Finance.Instrument.Swap.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Instrument.Swap
 ============================

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-swap.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-swap.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Swap - Changelog
-########################################
+Daml.Finance.Instrument.Swap.V1 - Changelog
+###########################################
 
 Version 0.4.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-swap.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-swap.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Swap.V1 - Changelog
-###########################################
+Changelog
+#########
+
+Daml.Finance.Instrument.Swap.V1
+===============================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Instrument.Swap
+============================
 
 Version 0.4.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-token.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-token.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Token.V4 - Changelog
-############################################
+Changelog
+#########
+
+Daml.Finance.Instrument.Token.V4
+================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Instrument.Token
+=============================
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-token.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-token.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Token - Changelog
-#########################################
+Daml.Finance.Instrument.Token.V4 - Changelog
+############################################
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-token.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-token.rst
@@ -10,7 +10,7 @@ Daml.Finance.Instrument.Token.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Instrument.Token
 =============================

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-lifecycle.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-lifecycle.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Lifecycle.V4 - Changelog
-#####################################
+Changelog
+#########
+
+Daml.Finance.Lifecycle.V4
+=========================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Lifecycle
+======================
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-lifecycle.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-lifecycle.rst
@@ -10,7 +10,7 @@ Daml.Finance.Lifecycle.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Lifecycle
 ======================

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-lifecycle.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-lifecycle.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Lifecycle - Changelog
-##################################
+Daml.Finance.Lifecycle.V4 - Changelog
+#####################################
 
 Version 3.0.0
 *************
@@ -11,7 +11,7 @@ Version 3.0.0
 
 - The `Calculate` choice of the `Effect` and `ElectionEffect` now takes a quantity as argument
   to reflect the change in the `Effect.I` interface. The implementation of the `ClaimEffect` choice
-  body of `Daml.Finance.Lifecycle.Rule.Claim` also changed accordingly.
+  body of `Daml.Finance.Lifecycle.V4.Rule.Claim` also changed accordingly.
 
 - Replaced `lookupByKey` by an `exerciseByKey` in the `Distribution` and `Replacement` rule.
 

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-settlement.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-settlement.rst
@@ -10,7 +10,7 @@ Daml.Finance.Settlement.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Settlement
 =======================

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-settlement.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-settlement.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Settlement.V4 - Changelog
-######################################
+Changelog
+#########
+
+Daml.Finance.Settlement.V4
+==========================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Settlement
+=======================
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-settlement.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-settlement.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Settlement - Changelog
-###################################
+Daml.Finance.Settlement.V4 - Changelog
+######################################
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-util.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-util.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Util - Changelog
-#############################
+Daml.Finance.Util.V4 - Changelog
+################################
 
 Version 3.1.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-util.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-util.rst
@@ -10,9 +10,9 @@ Daml.Finance.Util.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
-- Only release a Semaphore lock if the provided context is recognized (patch).
+- Only release a Semaphore lock if the provided context is recognized.
 
 Daml.Finance.Util
 =================

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-util.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/changelogs/daml-finance-util.rst
@@ -1,8 +1,21 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Util.V4 - Changelog
-################################
+Changelog
+#########
+
+Daml.Finance.Util.V4
+====================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+- Only release a Semaphore lock if the provided context is recognized (patch).
+
+Daml.Finance.Util
+=================
 
 Version 3.1.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/contingent-claims-lifecycle.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/contingent-claims-lifecycle.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Lifecycle
-##########################
+ContingentClaims.Lifecycle.V3
+#############################
 
 This package contains the *implementation* of utility functions to lifecycle a
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` tree. The following modules

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/contingent-claims-lifecycle.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/contingent-claims-lifecycle.rst
@@ -8,10 +8,10 @@ This package contains the *implementation* of utility functions to lifecycle a
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` tree. The following modules
 are included:
 
-- :ref:`Lifecycle <module-contingentclaims-lifecycle-lifecycle-72039>`:
+- :ref:`Lifecycle <module-contingentclaims-lifecycle-v3-lifecycle-61551>`:
   Functions to lifecycle a :doc:`Contingent Claims <../../instruments/generic/contingent-claims>`
   tree
-- :ref:`Util <module-contingentclaims-lifecycle-util-90074>`:
+- :ref:`Util <module-contingentclaims-lifecycle-v3-util-47746>`:
   Utility functions to query a
   :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` tree for certain properties
 

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/contingent-claims-valuation.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/contingent-claims-valuation.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Valuation
-##########################
+ContingentClaims.Valuation.V1
+#############################
 
 This package contains the *implementation* of utility functions to map a
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` tree into a mathematical

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/contingent-claims-valuation.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/contingent-claims-valuation.rst
@@ -9,10 +9,10 @@ This package contains the *implementation* of utility functions to map a
 representation to facilitate integration with pricing and risk frameworks. The following modules are
 included:
 
-- :ref:`Stochastic <module-contingentclaims-valuation-stochastic-37844>`: Utilities to map a
+- :ref:`Stochastic <module-contingentclaims-valuation-v1-stochastic-86240>`: Utilities to map a
   :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` tree to a stochastic
   process representation
-- :ref:`MathML <module-contingentclaims-valuation-mathml-30102>`: Typeclass definition to map an
+- :ref:`MathML <module-contingentclaims-valuation-v1-mathml-73874>`: Typeclass definition to map an
   expression in the MathML presentation format
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-account.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-account.rst
@@ -6,7 +6,7 @@ Daml.Finance.Account.V4
 
 This package contains the *implementation* of accounts. It has the following module:
 
-- :ref:`Account <module-daml-finance-account-account-19369>`: Implementation of an account, i.e., a
+- :ref:`Account <module-daml-finance-account-v4-account-5834>`: Implementation of an account, i.e., a
   relationship between a custodian and an asset owner, referenced by holdings. It also provides an
   implementation of a factory from which you can create and remove accounts. Upon creation of an
   account, it allows you to specify controlling parties for incoming / outgoing transfers.

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-account.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-account.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Account
-####################
+Daml.Finance.Account.V4
+#######################
 
 This package contains the *implementation* of accounts. It has the following module:
 

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-claims.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-claims.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Claims
-###################
+Daml.Finance.Claims.V3
+######################
 
 This package contains utility functions that facilitate building and working with
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` based instruments. It includes the

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-claims.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-claims.rst
@@ -8,18 +8,18 @@ This package contains utility functions that facilitate building and working wit
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` based instruments. It includes the
 following modules:
 
-- :ref:`Lifecycle.Rule <module-daml-finance-claims-lifecycle-rule-53980>`:
+- :ref:`Lifecycle.Rule <module-daml-finance-claims-v3-lifecycle-rule-196>`:
   Rule to process a lifecycle event for instruments that build a
   :doc:`Contingent Claims tree dynamically <../../tutorials/advanced-topics/instrument-modeling/contingent-claims-instrument>`.
-- :ref:`Util <module-daml-finance-claims-util-5254>`:
+- :ref:`Util <module-daml-finance-claims-v3-util-10150>`:
   Contains utility functions for claims, e.g., checking the content of a claim and converting the
   claim time
-- :ref:`Util.Lifecycle <module-daml-finance-claims-util-lifecycle-9534>`:
+- :ref:`Util.Lifecycle <module-daml-finance-claims-v3-util-lifecycle-43238>`:
   Defines different types of events and how to lifecycle them
-- :ref:`Util.Builders <module-daml-finance-claims-util-builders-48637>`:
+- :ref:`Util.Builders <module-daml-finance-claims-v3-util-builders-30825>`:
   Utility functions related to creating :doc:`Contingent Claims <../../instruments/generic/contingent-claims>`,
   e.g. for bonds/swaps
-- :ref:`Util.Date <module-daml-finance-claims-util-date-40505>`:
+- :ref:`Util.Date <module-daml-finance-claims-v3-util-date-8229>`:
   Utility functions related to dates and schedule periods, which are used to define claims.
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-data.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-data.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Data
-#################
+Daml.Finance.Data.V4
+####################
 
 This package implements templates containing reference data. It includes the following modules:
 

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-data.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-data.rst
@@ -6,22 +6,22 @@ Daml.Finance.Data.V4
 
 This package implements templates containing reference data. It includes the following modules:
 
-- :ref:`Numeric.Observation <module-daml-finance-data-numeric-observation-78761>`:
+- :ref:`Numeric.Observation <module-daml-finance-data-v4-numeric-observation-19522>`:
   An implementation of an observation that explicitly stores time-dependent numerical values on the
   ledger. It can be used to, e.g., store equity or rate fixings.
-- :ref:`Reference.HolidayCalendar <module-daml-finance-data-reference-holidaycalendar-10773>`:
+- :ref:`Reference.HolidayCalendar <module-daml-finance-data-v4-reference-holidaycalendar-15110>`:
   A holiday calendar of an entity (typically an exchange or a currency)
-- :ref:`Time.DateClock.Types <module-daml-finance-data-time-dateclock-types-48777>`:
+- :ref:`Time.DateClock.Types <module-daml-finance-data-v4-time-dateclock-types-32520>`:
   A date type which can be converted to time, and time-related utility functions
-- :ref:`Time.DateClock <module-daml-finance-data-time-dateclock-65212>`:
+- :ref:`Time.DateClock <module-daml-finance-data-v4-time-dateclock-1389>`:
   A contract specifying what is the current local date. It is used to inject date information in
   lifecycle processing rules
-- :ref:`Time.DateClockUpdate <module-daml-finance-data-time-dateclockupdate-48859>`:
+- :ref:`Time.DateClockUpdate <module-daml-finance-data-v4-time-dateclockupdate-59678>`:
   A contract representing passing of (market) time that can be used to trigger contractual,
   time-based `effects <#lifecycling-effect>`__, like interest payments on a bond. It is, for
   example, used to drive the evolution and lifecycling of
   :doc:`Contingent Claims <../../instruments/generic/contingent-claims>`-based instruments.
-- :ref:`Time.LedgerTime <module-daml-finance-data-time-ledgertime-84639>`:
+- :ref:`Time.LedgerTime <module-daml-finance-data-v4-time-ledgertime-80144>`:
   A time observable which uses ledger time
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-holding.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-holding.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Holding
-####################
+Daml.Finance.Holding.V4
+#######################
 
 This package contains the *implementation* of holdings, including utility functions. It has the
 following modules:

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-holding.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-holding.rst
@@ -7,15 +7,15 @@ Daml.Finance.Holding.V4
 This package contains the *implementation* of holdings, including utility functions. It has the
 following modules:
 
-- :ref:`Fungible <module-daml-finance-holding-fungible-7201>`: Implementation of a holding which is
+- :ref:`Fungible <module-daml-finance-holding-v4-fungible-60188>`: Implementation of a holding which is
   fungible only, i.e., include split and merge functionality
-- :ref:`Transferable <module-daml-finance-holding-transferable-43388>`: Implementation of a holding
+- :ref:`Transferable <module-daml-finance-holding-v4-transferable-38649>`: Implementation of a holding
   which is transferable only
-- :ref:`TransferableFungible <module-daml-finance-holding-transferablefungible-77726>`:
+- :ref:`TransferableFungible <module-daml-finance-holding-v4-transferablefungible-66907>`:
   Implementation of a holding which is both transferable and fungible
-- :ref:`BaseHolding <module-daml-finance-holding-baseholding-57062>`: Implementation of
+- :ref:`BaseHolding <module-daml-finance-holding-v4-baseholding-28133>`: Implementation of
   a holding which is neither transferable nor fungible
-- :ref:`Util <module-daml-finance-holding-util-87323>`: Utility functions related to holdings, e.g.,
+- :ref:`Util <module-daml-finance-holding-v4-util-71966>`: Utility functions related to holdings, e.g.,
   to transfer or split/merge a holding
 
 The :doc:`Asset Model <../../concepts/asset-model>` page explains the relationship between

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-bond.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-bond.rst
@@ -7,27 +7,27 @@ Daml.Finance.Instrument.Bond.V3
 This package contains the *implementation* of different bond types, defined in the following
 modules:
 
-- :ref:`Callable.Instrument <module-daml-finance-instrument-bond-callable-instrument-83330>`:
+- :ref:`Callable.Instrument <module-daml-finance-instrument-bond-v3-callable-instrument-35206>`:
   Instrument implementation for callable bonds
-- :ref:`Callable.Factory <module-daml-finance-instrument-bond-callable-factory-52054>`:
+- :ref:`Callable.Factory <module-daml-finance-instrument-bond-v3-callable-factory-64026>`:
   Factory implementation to instantiate callable bonds
-- :ref:`FixedRate.Instrument <module-daml-finance-instrument-bond-fixedrate-instrument-67993>`:
+- :ref:`FixedRate.Instrument <module-daml-finance-instrument-bond-v3-fixedrate-instrument-89221>`:
   Instrument implementation for fixed-rate bonds
-- :ref:`FixedRate.Factory <module-daml-finance-instrument-bond-fixedrate-factory-46203>`:
+- :ref:`FixedRate.Factory <module-daml-finance-instrument-bond-v3-fixedrate-factory-55391>`:
   Factory implementation to instantiate fixed-rate bonds
-- :ref:`FloatingRate.Instrument <module-daml-finance-instrument-bond-floatingrate-instrument-98586>`:
+- :ref:`FloatingRate.Instrument <module-daml-finance-instrument-bond-v3-floatingrate-instrument-82370>`:
   Instrument implementation for floating-rate bonds
-- :ref:`FloatingRate.Factory <module-daml-finance-instrument-bond-floatingrate-factory-64782>`:
+- :ref:`FloatingRate.Factory <module-daml-finance-instrument-bond-v3-floatingrate-factory-96062>`:
   Factory implementation to instantiate floating-rate bonds
-- :ref:`InflationLinked.Instrument <module-daml-finance-instrument-bond-inflationlinked-instrument-30250>`:
+- :ref:`InflationLinked.Instrument <module-daml-finance-instrument-bond-v3-inflationlinked-instrument-99606>`:
   Instrument implementation for inflation-linked bonds
-- :ref:`InflationLinked.Factory <module-daml-finance-instrument-bond-inflationlinked-factory-70614>`:
+- :ref:`InflationLinked.Factory <module-daml-finance-instrument-bond-v3-inflationlinked-factory-84934>`:
   Factory implementation to instantiate inflation-linked bonds
-- :ref:`ZeroCoupon.Instrument <module-daml-finance-instrument-bond-zerocoupon-instrument-52804>`:
+- :ref:`ZeroCoupon.Instrument <module-daml-finance-instrument-bond-v3-zerocoupon-instrument-96672>`:
   Instrument implementation for zero-coupon bonds
-- :ref:`ZeroCoupon.Factory <module-daml-finance-instrument-bond-zerocoupon-factory-51640>`:
+- :ref:`ZeroCoupon.Factory <module-daml-finance-instrument-bond-v3-zerocoupon-factory-47672>`:
   Factory implementation to instantiate zero-coupon bonds
-- :ref:`Util <module-daml-finance-instrument-bond-util-70458>`:
+- :ref:`Util <module-daml-finance-instrument-bond-v3-util-25042>`:
   Bond-specific utility functions
 
 Check out the page on

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-bond.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-bond.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Bond
-############################
+Daml.Finance.Instrument.Bond.V3
+###############################
 
 This package contains the *implementation* of different bond types, defined in the following
 modules:

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-equity.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-equity.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Equity
-##############################
+Daml.Finance.Instrument.Equity.V1
+#################################
 
 This package contains the *implementation* of equity instruments, defined in the following modules:
 

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-equity.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-equity.rst
@@ -6,9 +6,9 @@ Daml.Finance.Instrument.Equity.V1
 
 This package contains the *implementation* of equity instruments, defined in the following modules:
 
-- :ref:`Instrument <module-daml-finance-instrument-equity-instrument-69265>`:
+- :ref:`Instrument <module-daml-finance-instrument-equity-v1-instrument-56047>`:
   Instrument implementation for equities
-- :ref:`Factory <module-daml-finance-instrument-equity-factory-96899>`:
+- :ref:`Factory <module-daml-finance-instrument-equity-v1-factory-43861>`:
   Factory implementation to instantiate equities
 
 For a detailed explanation of this package, check out the page on

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-generic.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-generic.rst
@@ -8,11 +8,11 @@ This package contains the *implementation* of generic,
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` based instruments, defined
 in the following modules:
 
-- :ref:`Instrument <module-daml-finance-instrument-generic-instrument-67364>`:
+- :ref:`Instrument <module-daml-finance-instrument-generic-v4-instrument-39541>`:
   Instrument implementation for generic instruments
-- :ref:`Factory <module-daml-finance-instrument-generic-factory-42712>`:
+- :ref:`Factory <module-daml-finance-instrument-generic-v4-factory-26927>`:
   Factory implementation to instantiate generic instruments
-- :ref:`Lifecycle.Rule <module-daml-finance-instrument-generic-lifecycle-rule-68537>`:
+- :ref:`Lifecycle.Rule <module-daml-finance-instrument-generic-v4-lifecycle-rule-7812>`:
   Rule to process a lifecycle event for generic instruments
 
 Check out the page on :doc:`How to use the Generic Instrument packages <../../instruments/generic>`

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-generic.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-generic.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Generic
-###############################
+Daml.Finance.Instrument.Generic.V4
+##################################
 
 This package contains the *implementation* of generic,
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` based instruments, defined

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-option.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-option.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Option
-##############################
+Daml.Finance.Instrument.Option.V1
+#################################
 
 This package contains the *implementation* of different option types, defined in the
 following modules:

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-option.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-option.rst
@@ -7,23 +7,23 @@ Daml.Finance.Instrument.Option.V1
 This package contains the *implementation* of different option types, defined in the
 following modules:
 
-- :ref:`BarrierEuropeanCash.Instrument <module-daml-finance-instrument-option-barriereuropeancash-instrument-15498>`:
+- :ref:`BarrierEuropeanCash.Instrument <module-daml-finance-instrument-option-v1-barriereuropeancash-instrument-70992>`:
   Instrument implementation for barrier options
-- :ref:`BarrierEuropeanCash.Factory <module-daml-finance-instrument-option-barriereuropeancash-factory-43938>`:
+- :ref:`BarrierEuropeanCash.Factory <module-daml-finance-instrument-option-v1-barriereuropeancash-factory-25456>`:
   Factory implementation to instantiate barrier options
-- :ref:`Dividend.Instrument <module-daml-finance-instrument-option-dividend-instrument-7333>`:
+- :ref:`Dividend.Instrument <module-daml-finance-instrument-option-v1-dividend-instrument-35111>`:
   Instrument implementation for dividend options
-- :ref:`Dividend.Factory <module-daml-finance-instrument-option-dividend-factory-82807>`:
+- :ref:`Dividend.Factory <module-daml-finance-instrument-option-v1-dividend-factory-65033>`:
   Factory implementation to instantiate dividend options
-- :ref:`Dividend.Election <module-daml-finance-instrument-option-dividend-election-79353>`:
+- :ref:`Dividend.Election <module-daml-finance-instrument-option-v1-dividend-election-77267>`:
   Factory implementation to create an Election for dividend options
-- :ref:`EuropeanCash.Instrument <module-daml-finance-instrument-option-europeancash-instrument-22074>`:
+- :ref:`EuropeanCash.Instrument <module-daml-finance-instrument-option-v1-europeancash-instrument-97900>`:
   Instrument implementation for cash-settled European options
-- :ref:`EuropeanCash.Factory <module-daml-finance-instrument-option-europeancash-factory-75778>`:
+- :ref:`EuropeanCash.Factory <module-daml-finance-instrument-option-v1-europeancash-factory-80316>`:
   Factory implementation to instantiate cash-settled European options
-- :ref:`EuropeanPhysical.Instrument <module-daml-finance-instrument-option-europeanphysical-instrument-71708>`:
+- :ref:`EuropeanPhysical.Instrument <module-daml-finance-instrument-option-v1-europeanphysical-instrument-98774>`:
   Instrument implementation for physically settled European options
-- :ref:`EuropeanPhysical.Factory <module-daml-finance-instrument-option-europeanphysical-factory-58032>`:
+- :ref:`EuropeanPhysical.Factory <module-daml-finance-instrument-option-v1-europeanphysical-factory-99630>`:
   Factory implementation to instantiate physically settled European options
 
 Check out the page on :doc:`How to use the Option Instrument packages <../../instruments/option>`

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-structuredproduct.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-structuredproduct.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.StructuredProduct
-#########################################
+Daml.Finance.Instrument.StructuredProduct.V1
+############################################
 
 This package contains the *implementation* of different structured product types, defined in the
 following modules:

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-structuredproduct.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-structuredproduct.rst
@@ -7,9 +7,9 @@ Daml.Finance.Instrument.StructuredProduct.V1
 This package contains the *implementation* of different structured product types, defined in the
 following modules:
 
-- :ref:`BarrierReverseConvertible.Instrument <module-daml-finance-instrument-structuredproduct-barrierreverseconvertible-instrument-95793>`:
+- :ref:`BarrierReverseConvertible.Instrument <module-daml-finance-instrument-structuredproduct-v1-barrierreverseconvertible-instrument-16231>`:
   Instrument implementation for Barrier Reverse Convertibles
-- :ref:`BarrierReverseConvertible.Factory <module-daml-finance-instrument-structuredproduct-barrierreverseconvertible-factory-6075>`:
+- :ref:`BarrierReverseConvertible.Factory <module-daml-finance-instrument-structuredproduct-v1-barrierreverseconvertible-factory-25753>`:
   Factory implementation to instantiate Barrier Reverse Convertibles
 
 Check out the page on

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-structuredproduct.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-structuredproduct.rst
@@ -7,6 +7,10 @@ Daml.Finance.Instrument.StructuredProduct.V1
 This package contains the *implementation* of different structured product types, defined in the
 following modules:
 
+- :ref:`AutoCallable.Instrument <module-daml-finance-instrument-structuredproduct-v1-autocallable-instrument-89951>`:
+  Instrument implementation for Auto Callables
+- :ref:`AutoCallable.Factory <module-daml-finance-instrument-structuredproduct-v1-autocallable-factory-58405>`:
+  Factory implementation to instantiate Auto Callables
 - :ref:`BarrierReverseConvertible.Instrument <module-daml-finance-instrument-structuredproduct-v1-barrierreverseconvertible-instrument-16231>`:
   Instrument implementation for Barrier Reverse Convertibles
 - :ref:`BarrierReverseConvertible.Factory <module-daml-finance-instrument-structuredproduct-v1-barrierreverseconvertible-factory-25753>`:

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-swap.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-swap.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Swap
-############################
+Daml.Finance.Instrument.Swap.V1
+###############################
 
 This package contains the *implementation* of different swap types, defined in the following
 modules:

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-swap.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-swap.rst
@@ -7,31 +7,31 @@ Daml.Finance.Instrument.Swap.V1
 This package contains the *implementation* of different swap types, defined in the following
 modules:
 
-- :ref:`Asset.Instrument <module-daml-finance-instrument-swap-asset-instrument-28127>`:
+- :ref:`Asset.Instrument <module-daml-finance-instrument-swap-v1-asset-instrument-35945>`:
   Instrument implementation for asset swaps
-- :ref:`Asset.Factory <module-daml-finance-instrument-swap-asset-factory-18993>`:
+- :ref:`Asset.Factory <module-daml-finance-instrument-swap-v1-asset-factory-5803>`:
   Factory implementation to instantiate asset swaps
-- :ref:`CreditDefault.Instrument <module-daml-finance-instrument-swap-creditdefault-instrument-88725>`:
+- :ref:`CreditDefault.Instrument <module-daml-finance-instrument-swap-v1-creditdefault-instrument-52131>`:
   Instrument implementation for credit default swaps
-- :ref:`CreditDefault.Factory <module-daml-finance-instrument-swap-creditdefault-factory-17039>`:
+- :ref:`CreditDefault.Factory <module-daml-finance-instrument-swap-v1-creditdefault-factory-79921>`:
   Factory implementation to instantiate credit default swaps
-- :ref:`Currency.Instrument <module-daml-finance-instrument-swap-currency-instrument-67721>`:
+- :ref:`Currency.Instrument <module-daml-finance-instrument-swap-v1-currency-instrument-73211>`:
   Instrument implementation for currency swaps
-- :ref:`Currency.Factory <module-daml-finance-instrument-swap-currency-factory-52907>`:
+- :ref:`Currency.Factory <module-daml-finance-instrument-swap-v1-currency-factory-69701>`:
   Factory implementation to instantiate currency swaps
-- :ref:`ForeignExchange.Instrument <module-daml-finance-instrument-swap-foreignexchange-instrument-43394>`:
+- :ref:`ForeignExchange.Instrument <module-daml-finance-instrument-swap-v1-foreignexchange-instrument-82256>`:
   Instrument implementation for foreign exchange swaps
-- :ref:`ForeignExchange.Factory <module-daml-finance-instrument-swap-foreignexchange-factory-31070>`:
+- :ref:`ForeignExchange.Factory <module-daml-finance-instrument-swap-v1-foreignexchange-factory-56532>`:
   Factory implementation to instantiate foreign exchange swaps
-- :ref:`Fpml.Instrument <module-daml-finance-instrument-swap-fpml-instrument-17241>`:
+- :ref:`Fpml.Instrument <module-daml-finance-instrument-swap-v1-fpml-instrument-78235>`:
   Instrument implementation for FpML swaps (`FpML swap schema <https://www.fpml.org/spec/fpml-5-11-3-lcwd-1/html/confirmation/schemaDocumentation/schemas/fpml-ird-5-11_xsd/complexTypes/Swap.html>`_)
-- :ref:`Fpml.Factory <module-daml-finance-instrument-swap-fpml-factory-80739>`:
+- :ref:`Fpml.Factory <module-daml-finance-instrument-swap-v1-fpml-factory-41381>`:
   Factory implementation to instantiate FpML swaps
-- :ref:`Fpml.Util <module-daml-finance-instrument-swap-fpml-util-24838>`:
+- :ref:`Fpml.Util <module-daml-finance-instrument-swap-v1-fpml-util-68548>`:
   Utility functions to support FpML swaps
-- :ref:`InterestRate.Instrument <module-daml-finance-instrument-swap-interestrate-instrument-86260>`:
+- :ref:`InterestRate.Instrument <module-daml-finance-instrument-swap-v1-interestrate-instrument-25554>`:
   Instrument implementation for interest rate swaps
-- :ref:`InterestRate.Factory <module-daml-finance-instrument-swap-interestrate-factory-62092>`:
+- :ref:`InterestRate.Factory <module-daml-finance-instrument-swap-v1-interestrate-factory-6094>`:
   Factory implementation to instantiate interest rate swaps
 
 Check out the page on :doc:`How to use the Swap Instrument packages <../../instruments/swap>` for a

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-token.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-token.rst
@@ -7,9 +7,9 @@ Daml.Finance.Instrument.Token.V4
 This package contains the *implementation* of simple token instruments which do not define any
 lifecycling logic. It contains the following modules:
 
-- :ref:`Instrument <module-daml-finance-instrument-token-instrument-10682>`:
+- :ref:`Instrument <module-daml-finance-instrument-token-v4-instrument-53415>`:
   Instrument implementation for simple tokens
-- :ref:`Factory <module-daml-finance-instrument-token-factory-62942>`:
+- :ref:`Factory <module-daml-finance-instrument-token-v4-factory-92377>`:
   Factory implementation to instantiate simple tokens
 
 Check out the :doc:`Transfer tutorial <../../tutorials/getting-started/transfer>` for an example on

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-token.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-instrument-token.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Token
-#############################
+Daml.Finance.Instrument.Token.V4
+################################
 
 This package contains the *implementation* of simple token instruments which do not define any
 lifecycling logic. It contains the following modules:

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-lifecycle.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-lifecycle.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Lifecycle
-######################
+Daml.Finance.Lifecycle.V4
+#########################
 
 This package contains the *implementation* of lifecycle related processes. It contains the following
 modules:

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-lifecycle.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-lifecycle.rst
@@ -7,38 +7,38 @@ Daml.Finance.Lifecycle.V4
 This package contains the *implementation* of lifecycle related processes. It contains the following
 modules:
 
-- :ref:`Effect <module-daml-finance-lifecycle-effect-1975>`:
+- :ref:`Effect <module-daml-finance-lifecycle-v4-effect-31424>`:
   A contract encoding the *consequences of a lifecycle event* for one unit of the target
   instrument
-- :ref:`Election <module-daml-finance-lifecycle-election-53183>`:
+- :ref:`Election <module-daml-finance-lifecycle-v4-election-2732>`:
   Implementation of elections (e.g. the exercise of an option) for claim based instruments
-- :ref:`ElectionEffect <module-daml-finance-lifecycle-electioneffect-99924>`:
+- :ref:`ElectionEffect <module-daml-finance-lifecycle-v4-electioneffect-83755>`:
   A contract encoding the *consequences of an election* for one unit of the target instrument
-- :ref:`Rule.Claim <module-daml-finance-lifecycle-rule-claim-99318>`:
+- :ref:`Rule.Claim <module-daml-finance-lifecycle-v4-rule-claim-11721>`:
   Rule contract that allows an actor to process/claim effects, returning settlement instructions
-- :ref:`Rule.Distribution <module-daml-finance-lifecycle-rule-distribution-35531>`:
+- :ref:`Rule.Distribution <module-daml-finance-lifecycle-v4-rule-distribution-2662>`:
   Rule contract that defines the distribution of units of an instrument for each unit of a
   target instrument (e.g. share or cash dividends)
-- :ref:`Rule.Replacement <module-daml-finance-lifecycle-rule-replacement-6984>`:
+- :ref:`Rule.Replacement <module-daml-finance-lifecycle-v4-rule-replacement-25183>`:
   Rule contract that defines the replacement of units of an instrument with a basket of other
   instruments (e.g. stock merger)
-- :ref:`Rule.Util <module-daml-finance-lifecycle-rule-util-40465>`:
+- :ref:`Rule.Util <module-daml-finance-lifecycle-v4-rule-util-70932>`:
   Utility functions to net, split and merge pending payments
-- :ref:`Event.Distribution <module-daml-finance-lifecycle-event-distribution-17302>`:
+- :ref:`Event.Distribution <module-daml-finance-lifecycle-v4-event-distribution-38493>`:
   Event contract for the distribution of units of an instrument for each unit of a target
   instrument (e.g. share or cash dividends)
-- :ref:`Event.Replacement <module-daml-finance-lifecycle-event-replacement-51859>`:
+- :ref:`Event.Replacement <module-daml-finance-lifecycle-v4-event-replacement-94706>`:
   Event contract for the replacement of units of an instrument with a basket of other
   instruments (e.g. stock merger)
 
 Check out the :doc:`Lifecycling tutorial <../../tutorials/getting-started/lifecycling>` for a
 description on how lifecycling works in practice, including how to
-:ref:`Claim <module-daml-finance-interface-lifecycle-rule-claim-6739>` an
-:ref:`Effect <module-daml-finance-interface-lifecycle-effect-16050>`.
+:ref:`Claim <module-daml-finance-interface-lifecycle-v4-rule-claim-89954>` an
+:ref:`Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>`.
 There is also the tutorial
 :doc:`How to implement a Contingent Claims-based instrument <../../tutorials/advanced-topics/instrument-modeling/contingent-claims-instrument>`,
 which describes how to create an
-:ref:`Effect <module-daml-finance-interface-lifecycle-effect-16050>`.
+:ref:`Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>`.
 For a description of ``Distribution`` and ``Replacement``, check out the
 `Instrument/Equity/Test <https://github.com/digital-asset/daml-finance/blob/main/src/test/daml/Daml/Finance/Instrument/Equity/Test>`_
 folder. It demonstrates how to create and lifecycle a cash dividend, and how to handle corporate

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-settlement.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-settlement.rst
@@ -7,17 +7,17 @@ Daml.Finance.Settlement.V4
 This package contains the *implementation* of the components used for settlement. It has the
 following modules:
 
-- :ref:`RouteProvider.SingleCustodian <module-daml-finance-settlement-routeprovider-singlecustodian-83455>`:
+- :ref:`RouteProvider.SingleCustodian <module-daml-finance-settlement-v4-routeprovider-singlecustodian-88974>`:
   Used to generate a single `RoutedStep` from a `Step` using a single custodian
-- :ref:`RouteProvider.IntermediatedStatic <module-daml-finance-settlement-routeprovider-intermediatedstatic-17490>`:
+- :ref:`RouteProvider.IntermediatedStatic <module-daml-finance-settlement-v4-routeprovider-intermediatedstatic-92315>`:
   Used to generate a route, i.e., `RoutedStep`\s, for each settlement `Step`
-- :ref:`Instruction <module-daml-finance-settlement-instruction-87187>`: Used to settle a single
+- :ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>`: Used to settle a single
   `RoutedStep`, i.e., a `Step` at a custodian.
-- :ref:`Batch <module-daml-finance-settlement-batch-95573>`: Allows you to atomically settle a
+- :ref:`Batch <module-daml-finance-settlement-v4-batch-88124>`: Allows you to atomically settle a
   set of settlement `Instruction`\s
-- :ref:`Factory <module-daml-finance-settlement-factory-257>`: Used to create a set of
+- :ref:`Factory <module-daml-finance-settlement-v4-factory-65040>`: Used to create a set of
   settlement `Instruction`\s, and a `Batch` to atomically settle them
-- :ref:`Hierarchy <module-daml-finance-settlement-hierarchy-15826>`: Data type that describes a
+- :ref:`Hierarchy <module-daml-finance-settlement-v4-hierarchy-83331>`: Data type that describes a
   hierarchical account structure between multiple parties
 
 The :doc:`Settlement <../../concepts/settlement>` page contains an overview of the settlement

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-settlement.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-settlement.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Settlement
-#######################
+Daml.Finance.Settlement.V4
+##########################
 
 This package contains the *implementation* of the components used for settlement. It has the
 following modules:

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-util.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-util.rst
@@ -8,19 +8,19 @@ This package primarily contains utility functions related to dates (see the
 :doc:`interface docs <../interfaces/daml-finance-interface-types-date>` for an introduction), lists,
 maps, and disclosure. They are defined in the following modules:
 
-- :ref:`Date.Calendar <module-daml-finance-util-date-calendar-17588>`:
+- :ref:`Date.Calendar <module-daml-finance-util-v4-date-calendar-71711>`:
   Functions regarding dates and holiday calendars (business vs non-business days)
-- :ref:`Date.DayCount <module-daml-finance-util-date-daycount-38239>`:
+- :ref:`Date.DayCount <module-daml-finance-util-v4-date-daycount-38488>`:
   Functions to calculate day count fractions according to different conventions
-- :ref:`Date.RollConvention <module-daml-finance-util-date-rollconvention-88672>`:
+- :ref:`Date.RollConvention <module-daml-finance-util-v4-date-rollconvention-61455>`:
   Functions to calculate date periods including rolling dates
-- :ref:`Date.Schedule <module-daml-finance-util-date-schedule-32303>`:
+- :ref:`Date.Schedule <module-daml-finance-util-v4-date-schedule-63724>`:
   Functions to calculate a periodic schedule, including both adjusted and unadjusted dates
-- :ref:`Common <module-daml-finance-util-common-41560>`:
+- :ref:`Common <module-daml-finance-util-v4-common-85309>`:
   Various functions related to lists and maps, which are used in several packages
-- :ref:`Disclosure <module-daml-finance-util-disclosure-73352>`:
+- :ref:`Disclosure <module-daml-finance-util-v4-disclosure-31001>`:
   Utility functions related to disclosure, e.g., to add or remove observers
-- :ref:`Lockable <module-daml-finance-util-lockable-3360>`:
+- :ref:`Lockable <module-daml-finance-util-v4-lockable-69357>`:
   Default implementation for the locking of holdings (acquire, release and validation check).
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-util.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/implementations/daml-finance-util.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Util
-#################
+Daml.Finance.Util.V4
+####################
 
 This package primarily contains utility functions related to dates (see the
 :doc:`interface docs <../interfaces/daml-finance-interface-types-date>` for an introduction), lists,

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/contingent-claims-core.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/contingent-claims-core.rst
@@ -1,8 +1,21 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Core.V3 - Changelog
-####################################
+Changelog
+#########
+
+ContingentClaims.Core.V3
+========================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+- Bumps `daml-ctl` to `2.4.1`.
+
+ContingentClaims.Core
+=====================
 
 Version 2.0.1
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/contingent-claims-core.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/contingent-claims-core.rst
@@ -10,7 +10,7 @@ ContingentClaims.Core.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 - Bumps `daml-ctl` to `2.4.1`.
 

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/contingent-claims-core.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/contingent-claims-core.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Core - Changelog
-#################################
+ContingentClaims.Core.V3 - Changelog
+####################################
 
 Version 2.0.1
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-account.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-account.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Account.V4 - Changelog
-#############################################
+Changelog
+#########
+
+Daml.Finance.Interface.Account.V4
+=================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Account
+==============================
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-account.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-account.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Account - Changelog
-##########################################
+Daml.Finance.Interface.Account.V4 - Changelog
+#############################################
 
 Version 3.0.0
 *************
@@ -15,7 +15,7 @@ Version 3.0.0
   the `Account`.
 
 - The `Create` choice of the account's `Factory` has been adapted; it now takes a
-  `HoldingFactoryKey` instead of the `ContractId Daml.Finance.Interface.Holding.Factory` as input
+  `HoldingFactoryKey` instead of the `ContractId Daml.Finance.Interface.Holding.V4.Factory` as input
 
 - Renamed the `F` type synonym to `I` .
 

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-account.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-account.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Account.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Account
 ==============================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-claims.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-claims.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Claims.V4 - Changelog
-############################################
+Changelog
+#########
+
+Daml.Finance.Interface.Claims.V4
+================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Claims
+=============================
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-claims.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-claims.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Claims - Changelog
-#########################################
+Daml.Finance.Interface.Claims.V4 - Changelog
+############################################
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-claims.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-claims.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Claims.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Claims
 =============================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
@@ -1,12 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Data.V4 - Changelog
-##########################################
+Changelog
+#########
 
-- Update of SDK version and dependencies.
+Daml.Finance.Interface.Data.V4
+==============================
 
-- Added new day-count conventions: Act365NL, Basis30365, and Basis30E2360.
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Data
+===========================
 
 Version 3.1.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Data.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Data
 ===========================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Data - Changelog
-#######################################
+Daml.Finance.Interface.Data.V4 - Changelog
+##########################################
 
 - Update of SDK version and dependencies.
 

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-holding.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-holding.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Holding.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Holding
 ==============================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-holding.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-holding.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Holding.V4 - Changelog
-#############################################
+Changelog
+#########
+
+Daml.Finance.Interface.Holding.V4
+=================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Holding
+==============================
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-holding.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-holding.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Holding - Changelog
-##########################################
+Daml.Finance.Interface.Holding.V4 - Changelog
+#############################################
 
 Version 3.0.0
 *************
@@ -10,9 +10,9 @@ Version 3.0.0
 - Update of SDK version and dependencies.
 
 - Factored out the locking logic from the base `Holding` interface to a separate interface called
-  `Lockable` of the `Daml.Finance.Interface.Util` package.
+  `Lockable` of the `Daml.Finance.Interface.Util.V3` package.
 
-- Updated the `Daml.Finance.Interface.Holding.Factory` to use a key, employing a `Reference`
+- Updated the `Daml.Finance.Interface.Holding.V4.Factory` to use a key, employing a `Reference`
   template and the `HoldingFactoryKey` data type. Additionally, It also requires the `Disclosure.I`
   and has a `getKey` method and `Remove` choice.
 

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-base.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-base.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Base.V4 - Changelog
-#####################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Base.V4
+=========================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Base
+======================================
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-base.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-base.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Base.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Base
 ======================================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-base.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-base.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Base - Changelog
-##################################################
+Daml.Finance.Interface.Instrument.Base.V4 - Changelog
+#####################################################
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-bond.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-bond.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Bond - Changelog
-##################################################
+Daml.Finance.Interface.Instrument.Bond.V3 - Changelog
+#####################################################
 
 Version 2.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-bond.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-bond.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Bond.V3 - Changelog
-#####################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Bond.V3
+=========================================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Bond
+======================================
 
 Version 2.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-bond.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-bond.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Bond.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Bond
 ======================================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-equity.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-equity.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Equity.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Equity
 ========================================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-equity.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-equity.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Equity - Changelog
-####################################################
+Daml.Finance.Interface.Instrument.Equity.V1 - Changelog
+#######################################################
 
 Version 0.4.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-equity.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-equity.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Equity.V1 - Changelog
-#######################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Equity.V1
+===========================================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Equity
+========================================
 
 Version 0.4.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-generic.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-generic.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Generic.V4 - Changelog
-########################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Generic.V4
+============================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Generic.V4
+============================================
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-generic.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-generic.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Generic - Changelog
-#####################################################
+Daml.Finance.Interface.Instrument.Generic.V4 - Changelog
+########################################################
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-generic.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-generic.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Generic.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Generic.V4
 ============================================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-option.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-option.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Option.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Option.V1
 ===========================================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-option.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-option.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Option - Changelog
-####################################################
+Daml.Finance.Interface.Instrument.Option.V1 - Changelog
+#######################################################
 
 Version 0.3.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-option.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-option.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Option.V1 - Changelog
-#######################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Option.V1
+===========================================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Option.V1
+===========================================
 
 Version 0.3.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-structuredproduct.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-structuredproduct.rst
@@ -1,8 +1,21 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.StructuredProduct.V1 - Changelog
-##################################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.StructuredProduct.V1
+======================================================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+- Add new AutoCallable instrument.
+
+Daml.Finance.Interface.Instrument.StructuredProduct
+===================================================
 
 Version 0.1.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-structuredproduct.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-structuredproduct.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.StructuredProduct - Changelog
-###############################################################
+Daml.Finance.Interface.Instrument.StructuredProduct.V1 - Changelog
+##################################################################
 
 Version 0.1.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-structuredproduct.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-structuredproduct.rst
@@ -10,9 +10,9 @@ Daml.Finance.Interface.Instrument.StructuredProduct.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
-- Add new AutoCallable instrument.
+- New AutoCallable instrument.
 
 Daml.Finance.Interface.Instrument.StructuredProduct
 ===================================================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-swap.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-swap.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Swap.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Swap
 ======================================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-swap.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-swap.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Swap - Changelog
-##################################################
+Daml.Finance.Interface.Instrument.Swap.V1 - Changelog
+#####################################################
 
 Version 0.4.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-swap.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-swap.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Swap.V1 - Changelog
-#####################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Swap.V1
+=========================================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Swap
+======================================
 
 Version 0.4.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-token.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-token.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Token - Changelog
-###################################################
+Daml.Finance.Interface.Instrument.Token.V4 - Changelog
+######################################################
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-token.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-token.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Token.V4 - Changelog
-######################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Token.V4
+==========================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Token
+=======================================
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-token.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-token.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Token.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Token
 =======================================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-types.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-types.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Types.V2 - Changelog
-######################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Types.V2
+==========================================
+
+Version 2.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Types
+=======================================
 
 Version 1.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-types.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-types.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Types.V2
 Version 2.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Types
 =======================================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-types.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-types.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Types - Changelog
-###################################################
+Daml.Finance.Interface.Instrument.Types.V2 - Changelog
+######################################################
 
 Version 1.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-lifecycle.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-lifecycle.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Lifecycle - Changelog
-############################################
+Daml.Finance.Interface.Lifecycle.V4 - Changelog
+###############################################
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-lifecycle.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-lifecycle.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Lifecycle.V4 - Changelog
-###############################################
+Changelog
+#########
+
+Daml.Finance.Interface.Lifecycle.V4
+===================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Lifecycle
+================================
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-lifecycle.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-lifecycle.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Lifecycle.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Lifecycle
 ================================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-settlement.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-settlement.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Settlement - Changelog
-#############################################
+Daml.Finance.Interface.Settlement.V4 - Changelog
+################################################
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-settlement.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-settlement.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Settlement.V4 - Changelog
-################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Settlement.V4
+====================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Settlement
+=================================
 
 Version 3.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-settlement.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-settlement.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Settlement.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Settlement
 =================================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-common.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-common.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Types.Common - Changelog
-###############################################
+Daml.Finance.Interface.Types.Common.V3 - Changelog
+##################################################
 
 Version 2.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-common.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-common.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Types.Common.V3 - Changelog
-##################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Types.Common.V3
+======================================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Types.Common
+===================================
 
 Version 2.0.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-common.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-common.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Types.Common.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Types.Common
 ===================================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-date.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-date.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Types.Date - Changelog
-#############################################
+Daml.Finance.Interface.Types.Date.V3 - Changelog
+################################################
 
 Version 2.1.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-date.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-date.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Types.Date.V3 - Changelog
-################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Types.Date.V3
+====================================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Types.Date
+=================================
 
 Version 2.1.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-date.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-date.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Types.Date.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Types.Date
 =================================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-util.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-util.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Util - Changelog
-#######################################
+Daml.Finance.Interface.Util.V3 - Changelog
+##########################################
 
 Version 2.1.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-util.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-util.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Util.V3 - Changelog
-##########################################
+Changelog
+#########
+
+Daml.Finance.Interface.Util.V3
+==============================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Util
+===========================
 
 Version 2.1.0
 *************

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-util.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-util.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Util.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Util
 ===========================

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/contingent-claims-core.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/contingent-claims-core.rst
@@ -9,15 +9,15 @@ This package contains the *interface* to represent
 and utility functions to process such trees. It also contains builder functions to facilitate the
 creation of trees using composition. The following modules are included:
 
-- :ref:`Builders <module-contingentclaims-core-builders-15004>`: Builder functions to compose trees
+- :ref:`Builders <module-contingentclaims-core-v3-builders-35188>`: Builder functions to compose trees
   from smaller building blocks
-- :ref:`Internal.Claim <module-contingentclaims-core-internal-claim-23633>`: Internal data types to
+- :ref:`Internal.Claim <module-contingentclaims-core-v3-internal-claim-26517>`: Internal data types to
   represent tree nodes
-- :ref:`Claim <module-contingentclaims-core-claim-90861>`: Smart constructors for the types defined
-  in :ref:`Internal.Claim <module-contingentclaims-core-internal-claim-23633>`
-- :ref:`Observation <module-contingentclaims-core-observation-86605>`: Data types to represent
+- :ref:`Claim <module-contingentclaims-core-v3-claim-98141>`: Smart constructors for the types defined
+  in :ref:`Internal.Claim <module-contingentclaims-core-v3-internal-claim-26517>`
+- :ref:`Observation <module-contingentclaims-core-v3-observation-36021>`: Data types to represent
   observations in trees
-- :ref:`Util.Recursion <module-contingentclaims-core-util-recursion-31812>`: Utility functions to
+- :ref:`Util.Recursion <module-contingentclaims-core-v3-util-recursion-82116>`: Utility functions to
   facilitate recursive traversal of trees
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/contingent-claims-core.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/contingent-claims-core.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Core
-#####################
+ContingentClaims.Core.V3
+########################
 
 This package contains the *interface* to represent
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` trees. It contains data types

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-account.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-account.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Account
-##############################
+Daml.Finance.Interface.Account.V4
+#################################
 
 This package contains the *interface* and utility functions for accounts. It has the following
 modules:

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-account.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-account.rst
@@ -7,13 +7,13 @@ Daml.Finance.Interface.Account.V4
 This package contains the *interface* and utility functions for accounts. It has the following
 modules:
 
-- :ref:`Factory <module-daml-finance-interface-account-factory-11691>`:
+- :ref:`Factory <module-daml-finance-interface-account-v4-factory-69358>`:
   Interface that allows implementing templates to create and remove accounts
-- :ref:`Account <module-daml-finance-interface-account-account-92922>`:
+- :ref:`Account <module-daml-finance-interface-account-v4-account-30007>`:
   Interface which represents an established relationship between a custodian and an owner. It
   specifies parties controlling incoming and outgoing transfers, and allows for crediting and
   debiting holdings
-- :ref:`Util <module-daml-finance-interface-account-util-56106>`:
+- :ref:`Util <module-daml-finance-interface-account-v4-util-78761>`:
   Utility functions related to accounts, e.g., getting the custodian or the owner of an account
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-claims.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-claims.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Claims
-#############################
+Daml.Finance.Interface.Claims.V4
+################################
 
 This package contains the *interface* for Contingent Claims based instruments. It contains the
 following modules:

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-claims.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-claims.rst
@@ -7,12 +7,12 @@ Daml.Finance.Interface.Claims.V4
 This package contains the *interface* for Contingent Claims based instruments. It contains the
 following modules:
 
-- :ref:`Claim <module-daml-finance-interface-claims-claim-82866>`:
+- :ref:`Claim <module-daml-finance-interface-claims-v4-claim-38573>`:
   Interface implemented by templates that can be represented as a set of contingent claims
-- :ref:`Dynamic.Instrument <module-daml-finance-interface-claims-dynamic-instrument-83951>`:
+- :ref:`Dynamic.Instrument <module-daml-finance-interface-claims-v4-dynamic-instrument-86702>`:
   Interface implemented by instruments that create Contingent Claims trees on-the-fly (i.e. the
   tree is not stored on disk as part of a contract, but created and processed in-memory)
-- :ref:`Types <module-daml-finance-interface-claims-types-95967>`:
+- :ref:`Types <module-daml-finance-interface-claims-v4-types-7840>`:
   Types related to claims and what is required to represent claims (e.g. Deliverable and
   Observable)
 

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-data.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-data.rst
@@ -7,16 +7,16 @@ Daml.Finance.Interface.Data.V4
 This package contains the *interface* for inspecting and working with observables, which are used
 in the context of lifecycling. It contains the following modules:
 
-- :ref:`Numeric.Observation.Factory <module-daml-finance-interface-data-numeric-observation-factory-57560>`:
+- :ref:`Numeric.Observation.Factory <module-daml-finance-interface-data-v4-numeric-observation-factory-95641>`:
   Interface for a factory used to create, remove and view a ``Numeric.Observation``
-- :ref:`Numeric.Observation <module-daml-finance-interface-data-numeric-observation-99152>`:
+- :ref:`Numeric.Observation <module-daml-finance-interface-data-v4-numeric-observation-41921>`:
   Interface for a time-dependent ``Numeric.Observation``, where the values are explicitly stored
   on-ledger
-- :ref:`Reference.HolidayCalendar.Factory <module-daml-finance-interface-data-reference-holidaycalendar-factory-22148>`:
+- :ref:`Reference.HolidayCalendar.Factory <module-daml-finance-interface-data-v4-reference-holidaycalendar-factory-36485>`:
   Interface for a factory used to create, remove and view a ``HolidayCalendar``
-- :ref:`Reference.HolidayCalendar <module-daml-finance-interface-data-reference-holidaycalendar-19648>`:
+- :ref:`Reference.HolidayCalendar <module-daml-finance-interface-data-v4-reference-holidaycalendar-24201>`:
   Interface for contracts storing holiday calendar data on the ledger
-- :ref:`Reference.Time <module-daml-finance-interface-data-reference-time-54882>`:
+- :ref:`Reference.Time <module-daml-finance-interface-data-v4-reference-time-12465>`:
   Interface for contracts that control business time, providing choices to advance or rewind time
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-data.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-data.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Data
-###########################
+Daml.Finance.Interface.Data.V4
+##############################
 
 This package contains the *interface* for inspecting and working with observables, which are used
 in the context of lifecycling. It contains the following modules:

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-holding.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-holding.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Holding
-##############################
+Daml.Finance.Interface.Holding.V4
+#################################
 
 This package contains the *interface* and utility functions for holdings. It has the following
 modules:

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-holding.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-holding.rst
@@ -7,15 +7,15 @@ Daml.Finance.Interface.Holding.V4
 This package contains the *interface* and utility functions for holdings. It has the following
 modules:
 
-- :ref:`Factory <module-daml-finance-interface-holding-factory-6211>`:
+- :ref:`Factory <module-daml-finance-interface-holding-v4-factory-49942>`:
   Interface for a holding factory used to create (credit) and archive (debit) holdings
-- :ref:`Holding <module-daml-finance-interface-holding-holding-64126>`:
+- :ref:`Holding <module-daml-finance-interface-holding-v4-holding-20535>`:
   Interface for a base holding which includes locking capabilities
-- :ref:`Fungible <module-daml-finance-interface-holding-fungible-63712>`:
+- :ref:`Fungible <module-daml-finance-interface-holding-v4-fungible-55495>`:
   Interface for a fungible holding which allows splitting and merging
-- :ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`:
+- :ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`:
   Interface for a transferable holding, i.e., where ownership can be transferred to other parties
-- :ref:`Util <module-daml-finance-interface-holding-util-81618>`:
+- :ref:`Util <module-daml-finance-interface-holding-v4-util-74545>`:
   Utility functions related to holdings, e.g., getting the amount or the instrument of a holding
 
 The :doc:`Asset Model <../../concepts/asset-model>` page explains the relationship between

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-base.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-base.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Base
-######################################
+Daml.Finance.Interface.Instrument.Base.V4
+#########################################
 
 This package contains the *root interface* for all instruments. It contains the following modules:
 

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-base.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-base.rst
@@ -6,7 +6,7 @@ Daml.Finance.Interface.Instrument.Base.V4
 
 This package contains the *root interface* for all instruments. It contains the following modules:
 
-- :ref:`Instrument <module-daml-finance-interface-instrument-base-instrument-57320>`:
+- :ref:`Instrument <module-daml-finance-interface-instrument-base-v4-instrument-47185>`:
   Root instrument abstraction containing basic properties that every instrument exhibits
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-bond.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-bond.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Bond
-######################################
+Daml.Finance.Interface.Instrument.Bond.V3
+#########################################
 
 This package contains the *interface* definitions for bond instruments. It contains the following
 modules:

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-bond.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-bond.rst
@@ -7,35 +7,35 @@ Daml.Finance.Interface.Instrument.Bond.V3
 This package contains the *interface* definitions for bond instruments. It contains the following
 modules:
 
-- :ref:`Callable.Instrument <module-daml-finance-interface-instrument-bond-callable-instrument-70617>`:
+- :ref:`Callable.Instrument <module-daml-finance-interface-instrument-bond-v3-callable-instrument-14719>`:
   Instrument interface for callable bonds
-- :ref:`Callable.Factory <module-daml-finance-interface-instrument-bond-callable-factory-92299>`:
+- :ref:`Callable.Factory <module-daml-finance-interface-instrument-bond-v3-callable-factory-33809>`:
   Factory interface to instantiate callable bond instruments
-- :ref:`Callable.Types <module-daml-finance-interface-instrument-bond-callable-types-46430>`:
+- :ref:`Callable.Types <module-daml-finance-interface-instrument-bond-v3-callable-types-79940>`:
   Type definitions to support callable bond instruments
-- :ref:`FixedRate.Instrument <module-daml-finance-interface-instrument-bond-fixedrate-instrument-43896>`:
+- :ref:`FixedRate.Instrument <module-daml-finance-interface-instrument-bond-v3-fixedrate-instrument-6918>`:
   Instrument interface for fixed-rate bonds
-- :ref:`FixedRate.Factory <module-daml-finance-interface-instrument-bond-fixedrate-factory-42532>`:
+- :ref:`FixedRate.Factory <module-daml-finance-interface-instrument-bond-v3-fixedrate-factory-45278>`:
   Factory interface to instantiate fixed-rate bond instruments
-- :ref:`FixedRate.Types <module-daml-finance-interface-instrument-bond-fixedrate-types-40221>`:
+- :ref:`FixedRate.Types <module-daml-finance-interface-instrument-bond-v3-fixedrate-types-11835>`:
   Type definitions to support fixed-rate bond instruments
-- :ref:`FloatingRate.Instrument <module-daml-finance-interface-instrument-bond-floatingrate-instrument-46777>`:
+- :ref:`FloatingRate.Instrument <module-daml-finance-interface-instrument-bond-v3-floatingrate-instrument-18047>`:
   Instrument interface for floating-rate bonds
-- :ref:`FloatingRate.Factory <module-daml-finance-interface-instrument-bond-floatingrate-factory-53843>`:
+- :ref:`FloatingRate.Factory <module-daml-finance-interface-instrument-bond-v3-floatingrate-factory-1777>`:
   Factory interface to instantiate floating-rate bond instruments
-- :ref:`FloatingRate.Types <module-daml-finance-interface-instrument-bond-floatingrate-types-45430>`:
+- :ref:`FloatingRate.Types <module-daml-finance-interface-instrument-bond-v3-floatingrate-types-56004>`:
   Type definitions to support floating-rate bond instruments
-- :ref:`InflationLinked.Instrument <module-daml-finance-interface-instrument-bond-inflationlinked-instrument-38495>`:
+- :ref:`InflationLinked.Instrument <module-daml-finance-interface-instrument-bond-v3-inflationlinked-instrument-29769>`:
   Instrument interface for inflation-linked bonds
-- :ref:`InflationLinked.Factory <module-daml-finance-interface-instrument-bond-inflationlinked-factory-57553>`:
+- :ref:`InflationLinked.Factory <module-daml-finance-interface-instrument-bond-v3-inflationlinked-factory-90803>`:
   Factory interface to instantiate inflation-linked bond instruments
-- :ref:`InflationLinked.Types <module-daml-finance-interface-instrument-bond-inflationlinked-types-71908>`:
+- :ref:`InflationLinked.Types <module-daml-finance-interface-instrument-bond-v3-inflationlinked-types-43490>`:
   Type definitions to support inflation-linked bond instruments
-- :ref:`ZeroCoupon.Instrument <module-daml-finance-interface-instrument-bond-zerocoupon-instrument-59755>`:
+- :ref:`ZeroCoupon.Instrument <module-daml-finance-interface-instrument-bond-v3-zerocoupon-instrument-34777>`:
   Instrument interface for zero-coupon bonds
-- :ref:`ZeroCoupon.Factory <module-daml-finance-interface-instrument-bond-zerocoupon-factory-70433>`:
+- :ref:`ZeroCoupon.Factory <module-daml-finance-interface-instrument-bond-v3-zerocoupon-factory-22139>`:
   Factory interface to instantiate zero-coupon bond instruments
-- :ref:`ZeroCoupon.Types <module-daml-finance-interface-instrument-bond-zerocoupon-types-74248>`:
+- :ref:`ZeroCoupon.Types <module-daml-finance-interface-instrument-bond-v3-zerocoupon-types-44506>`:
   Type definitions to support zero-coupon bond instruments
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-equity.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-equity.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Equity
-########################################
+Daml.Finance.Interface.Instrument.Equity.V1
+###########################################
 
 This package contains the *interface* definitions for equity instruments. It contains the following
 modules:

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-equity.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-equity.rst
@@ -7,10 +7,10 @@ Daml.Finance.Interface.Instrument.Equity.V1
 This package contains the *interface* definitions for equity instruments. It contains the following
 modules:
 
-- :ref:`Instrument <module-daml-finance-interface-instrument-equity-instrument-13224>`:
+- :ref:`Instrument <module-daml-finance-interface-instrument-equity-v1-instrument-10480>`:
   Instrument interface for equities. It supports lifecycling events through the
   ``DeclareDistribution``, ``DeclareReplacement`` and ``DeclareStockSplit`` choices.
-- :ref:`Factory <module-daml-finance-interface-instrument-equity-factory-97140>`:
+- :ref:`Factory <module-daml-finance-interface-instrument-equity-v1-factory-86676>`:
   Factory interface to instantiate equities
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-generic.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-generic.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Generic
-#########################################
+Daml.Finance.Interface.Instrument.Generic.V4
+############################################
 
 This package contains the *interface* definitions for generic, contingent-claims-based instruments.
 It contains the following modules:

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-generic.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-generic.rst
@@ -7,9 +7,9 @@ Daml.Finance.Interface.Instrument.Generic.V4
 This package contains the *interface* definitions for generic, contingent-claims-based instruments.
 It contains the following modules:
 
-- :ref:`Instrument <module-daml-finance-interface-instrument-generic-instrument-53275>`:
+- :ref:`Instrument <module-daml-finance-interface-instrument-generic-v4-instrument-7928>`:
   Instrument interface for generic instruments
-- :ref:`Factory <module-daml-finance-interface-instrument-generic-factory-11761>`:
+- :ref:`Factory <module-daml-finance-interface-instrument-generic-v4-factory-73556>`:
   Factory interface to instantiate generic instruments
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-option.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-option.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Option
-########################################
+Daml.Finance.Interface.Instrument.Option.V1
+###########################################
 
 This package contains the *interface* definitions for various option instruments. It contains the
 following modules:

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-option.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-option.rst
@@ -7,33 +7,33 @@ Daml.Finance.Interface.Instrument.Option.V1
 This package contains the *interface* definitions for various option instruments. It contains the
 following modules:
 
-- :ref:`BarrierEuropeanCash.Instrument <module-daml-finance-interface-instrument-option-barriereuropeancash-instrument-61159>`:
+- :ref:`BarrierEuropeanCash.Instrument <module-daml-finance-interface-instrument-option-v1-barriereuropeancash-instrument-53071>`:
   Instrument interface for barrier options
-- :ref:`BarrierEuropeanCash.Factory <module-daml-finance-interface-instrument-option-barriereuropeancash-factory-6809>`:
+- :ref:`BarrierEuropeanCash.Factory <module-daml-finance-interface-instrument-option-v1-barriereuropeancash-factory-7901>`:
   Factory interface to instantiate barrier options
-- :ref:`BarrierEuropeanCash.Types <module-daml-finance-interface-instrument-option-barriereuropeancash-types-4296>`:
+- :ref:`BarrierEuropeanCash.Types <module-daml-finance-interface-instrument-option-v1-barriereuropeancash-types-88688>`:
   Type definitions to support barrier options
-- :ref:`Dividend.Instrument <module-daml-finance-interface-instrument-option-dividend-instrument-3166>`:
+- :ref:`Dividend.Instrument <module-daml-finance-interface-instrument-option-v1-dividend-instrument-62914>`:
   Instrument interface for dividend options
-- :ref:`Dividend.Factory <module-daml-finance-interface-instrument-option-dividend-factory-77394>`:
+- :ref:`Dividend.Factory <module-daml-finance-interface-instrument-option-v1-dividend-factory-13790>`:
   Factory interface to instantiate dividend options
-- :ref:`Dividend.Types <module-daml-finance-interface-instrument-option-dividend-types-84299>`:
+- :ref:`Dividend.Types <module-daml-finance-interface-instrument-option-v1-dividend-types-94199>`:
   Type definitions to support dividend options
-- :ref:`Dividend.Election.Factory <module-daml-finance-interface-instrument-option-dividend-election-factory-158>`:
+- :ref:`Dividend.Election.Factory <module-daml-finance-interface-instrument-option-v1-dividend-election-factory-48110>`:
   Factory interface to instantiate elections for dividend options
-- :ref:`EuropeanCash.Instrument <module-daml-finance-interface-instrument-option-europeancash-instrument-96357>`:
+- :ref:`EuropeanCash.Instrument <module-daml-finance-interface-instrument-option-v1-europeancash-instrument-57397>`:
   Instrument interface for cash-settled European options
-- :ref:`EuropeanCash.Factory <module-daml-finance-interface-instrument-option-europeancash-factory-18215>`:
+- :ref:`EuropeanCash.Factory <module-daml-finance-interface-instrument-option-v1-europeancash-factory-30359>`:
   Factory interface to instantiate cash-settled European options
-- :ref:`EuropeanCash.Types <module-daml-finance-interface-instrument-option-europeancash-types-42062>`:
+- :ref:`EuropeanCash.Types <module-daml-finance-interface-instrument-option-v1-europeancash-types-26382>`:
   Type definitions to support cash-settled European options
-- :ref:`EuropeanPhysical.Instrument <module-daml-finance-interface-instrument-option-europeanphysical-instrument-46335>`:
+- :ref:`EuropeanPhysical.Instrument <module-daml-finance-interface-instrument-option-v1-europeanphysical-instrument-41255>`:
   Instrument interface for physically settled European options
-- :ref:`EuropeanPhysical.Factory <module-daml-finance-interface-instrument-option-europeanphysical-factory-8645>`:
+- :ref:`EuropeanPhysical.Factory <module-daml-finance-interface-instrument-option-v1-europeanphysical-factory-44217>`:
   Factory interface to instantiate physically settled European options
-- :ref:`EuropeanPhysical.Types <module-daml-finance-interface-instrument-option-europeanphysical-types-48412>`:
+- :ref:`EuropeanPhysical.Types <module-daml-finance-interface-instrument-option-v1-europeanphysical-types-4904>`:
   Type definitions to support physically settled European options
-- :ref:`Types <module-daml-finance-interface-instrument-option-types-52343>`:
+- :ref:`Types <module-daml-finance-interface-instrument-option-v1-types-50595>`:
   Type definitions common to several instruments in this package
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-structuredproduct.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-structuredproduct.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.StructuredProduct
-###################################################
+Daml.Finance.Interface.Instrument.StructuredProduct.V1
+######################################################
 
 This package contains the *interface* definitions for various structured product instruments. It
 contains the following modules:

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-structuredproduct.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-structuredproduct.rst
@@ -7,13 +7,13 @@ Daml.Finance.Interface.Instrument.StructuredProduct.V1
 This package contains the *interface* definitions for various structured product instruments. It
 contains the following modules:
 
-- :ref:`BarrierReverseConvertible.Instrument <module-daml-finance-interface-instrument-structuredproduct-barrierreverseconvertible-instrument-73562>`:
+- :ref:`BarrierReverseConvertible.Instrument <module-daml-finance-interface-instrument-structuredproduct-v1-barrierreverseconvertible-instrument-63394>`:
   Instrument interface for Barrier Reverse Convertibles
-- :ref:`BarrierReverseConvertible.Factory <module-daml-finance-interface-instrument-structuredproduct-barrierreverseconvertible-factory-31742>`:
+- :ref:`BarrierReverseConvertible.Factory <module-daml-finance-interface-instrument-structuredproduct-v1-barrierreverseconvertible-factory-71934>`:
   Factory interface to instantiate Barrier Reverse Convertibles
-- :ref:`BarrierReverseConvertible.Types <module-daml-finance-interface-instrument-structuredproduct-barrierreverseconvertible-types-21839>`:
+- :ref:`BarrierReverseConvertible.Types <module-daml-finance-interface-instrument-structuredproduct-v1-barrierreverseconvertible-types-37471>`:
   Type definitions to support Barrier Reverse Convertibles
-- :ref:`Types <module-daml-finance-interface-instrument-structuredproduct-types-79453>`:
+- :ref:`Types <module-daml-finance-interface-instrument-structuredproduct-v1-types-27765>`:
   Type definitions common to instruments in this package
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-structuredproduct.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-structuredproduct.rst
@@ -7,6 +7,12 @@ Daml.Finance.Interface.Instrument.StructuredProduct.V1
 This package contains the *interface* definitions for various structured product instruments. It
 contains the following modules:
 
+- :ref:`AutoCallable.Instrument <module-daml-finance-interface-instrument-structuredproduct-v1-autocallable-instrument-15420>`:
+  Instrument interface for Auto Callables
+- :ref:`AutoCallable.Factory <module-daml-finance-interface-instrument-structuredproduct-v1-autocallable-factory-27792>`:
+  Factory interface to instantiate Auto Callables
+- :ref:`AutoCallable.Types <module-daml-finance-interface-instrument-structuredproduct-v1-autocallable-types-17541>`:
+  Type definitions to support Auto Callable
 - :ref:`BarrierReverseConvertible.Instrument <module-daml-finance-interface-instrument-structuredproduct-v1-barrierreverseconvertible-instrument-63394>`:
   Instrument interface for Barrier Reverse Convertibles
 - :ref:`BarrierReverseConvertible.Factory <module-daml-finance-interface-instrument-structuredproduct-v1-barrierreverseconvertible-factory-71934>`:

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-swap.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-swap.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Swap
-######################################
+Daml.Finance.Interface.Instrument.Swap.V1
+#########################################
 
 This package contains the *interface* definitions for various swap instruments. It contains the
 following modules:

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-swap.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-swap.rst
@@ -7,43 +7,43 @@ Daml.Finance.Interface.Instrument.Swap.V1
 This package contains the *interface* definitions for various swap instruments. It contains the
 following modules:
 
-- :ref:`Asset.Instrument <module-daml-finance-interface-instrument-swap-asset-instrument-37258>`:
+- :ref:`Asset.Instrument <module-daml-finance-interface-instrument-swap-v1-asset-instrument-20594>`:
   Instrument interface for asset swaps
-- :ref:`Asset.Factory <module-daml-finance-interface-instrument-swap-asset-factory-39510>`:
+- :ref:`Asset.Factory <module-daml-finance-interface-instrument-swap-v1-asset-factory-94466>`:
   Factory interface to instantiate asset swaps
-- :ref:`Asset.Types <module-daml-finance-interface-instrument-swap-asset-types-80415>`:
+- :ref:`Asset.Types <module-daml-finance-interface-instrument-swap-v1-asset-types-74535>`:
   Type definitions to support asset swaps
-- :ref:`CreditDefault.Instrument <module-daml-finance-interface-instrument-swap-creditdefault-instrument-27480>`:
+- :ref:`CreditDefault.Instrument <module-daml-finance-interface-instrument-swap-v1-creditdefault-instrument-73888>`:
   Instrument interface for credit default swaps
-- :ref:`CreditDefault.Factory <module-daml-finance-interface-instrument-swap-creditdefault-factory-3156>`:
+- :ref:`CreditDefault.Factory <module-daml-finance-interface-instrument-swap-v1-creditdefault-factory-54420>`:
   Factory interface to instantiate credit default swaps
-- :ref:`CreditDefault.Types <module-daml-finance-interface-instrument-swap-creditdefault-types-77045>`:
+- :ref:`CreditDefault.Types <module-daml-finance-interface-instrument-swap-v1-creditdefault-types-7361>`:
   Type definitions to support credit default swaps
-- :ref:`Currency.Instrument <module-daml-finance-interface-instrument-swap-currency-instrument-11782>`:
+- :ref:`Currency.Instrument <module-daml-finance-interface-instrument-swap-v1-currency-instrument-56842>`:
   Instrument interface for currency swaps
-- :ref:`Currency.Factory <module-daml-finance-interface-instrument-swap-currency-factory-24950>`:
+- :ref:`Currency.Factory <module-daml-finance-interface-instrument-swap-v1-currency-factory-88578>`:
   Factory interface to instantiate currency swaps
-- :ref:`Currency.Types <module-daml-finance-interface-instrument-swap-currency-types-6291>`:
+- :ref:`Currency.Types <module-daml-finance-interface-instrument-swap-v1-currency-types-57191>`:
   Type definitions to support currency swaps
-- :ref:`ForeignExchange.Instrument <module-daml-finance-interface-instrument-swap-foreignexchange-instrument-90743>`:
+- :ref:`ForeignExchange.Instrument <module-daml-finance-interface-instrument-swap-v1-foreignexchange-instrument-1927>`:
   Instrument interface for foreign exchange swaps
-- :ref:`ForeignExchange.Factory <module-daml-finance-interface-instrument-swap-foreignexchange-factory-12809>`:
+- :ref:`ForeignExchange.Factory <module-daml-finance-interface-instrument-swap-v1-foreignexchange-factory-73309>`:
   Factory interface to instantiate foreign exchange swaps
-- :ref:`ForeignExchange.Types <module-daml-finance-interface-instrument-swap-foreignexchange-types-73964>`:
+- :ref:`ForeignExchange.Types <module-daml-finance-interface-instrument-swap-v1-foreignexchange-types-23348>`:
   Type definitions to support foreign exchange swaps
-- :ref:`Fpml.Instrument <module-daml-finance-interface-instrument-swap-fpml-instrument-38654>`:
+- :ref:`Fpml.Instrument <module-daml-finance-interface-instrument-swap-v1-fpml-instrument-33450>`:
   Instrument interface for FpML swaps
-- :ref:`Fpml.Factory <module-daml-finance-interface-instrument-swap-fpml-factory-59622>`:
+- :ref:`Fpml.Factory <module-daml-finance-interface-instrument-swap-v1-fpml-factory-48474>`:
   Factory interface to instantiate FpML swaps
-- :ref:`Fpml.FpmlTypes <module-daml-finance-interface-instrument-swap-fpml-fpmltypes-35062>`:
+- :ref:`Fpml.FpmlTypes <module-daml-finance-interface-instrument-swap-v1-fpml-fpmltypes-21994>`:
   Specific FpML types used to support FpML swaps
-- :ref:`Fpml.Types <module-daml-finance-interface-instrument-swap-fpml-types-21219>`:
+- :ref:`Fpml.Types <module-daml-finance-interface-instrument-swap-v1-fpml-types-78959>`:
   Type definitions to support FpML swaps
-- :ref:`InterestRate.Instrument <module-daml-finance-interface-instrument-swap-interestrate-instrument-49463>`:
+- :ref:`InterestRate.Instrument <module-daml-finance-interface-instrument-swap-v1-interestrate-instrument-49411>`:
   Instrument interface for interest rate swaps
-- :ref:`InterestRate.Factory <module-daml-finance-interface-instrument-swap-interestrate-factory-76077>`:
+- :ref:`InterestRate.Factory <module-daml-finance-interface-instrument-swap-v1-interestrate-factory-67829>`:
   Factory interface to instantiate interest rate swaps
-- :ref:`InterestRate.Types <module-daml-finance-interface-instrument-swap-interestrate-types-72064>`:
+- :ref:`InterestRate.Types <module-daml-finance-interface-instrument-swap-v1-interestrate-types-3648>`:
   Type definitions to support interest rate swaps
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-token.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-token.rst
@@ -7,11 +7,11 @@ Daml.Finance.Interface.Instrument.Token.V4
 This package contains the *interface* definitions for simple token instruments which do not define
 any lifecycling logic. It contains the following modules:
 
-- :ref:`Instrument <module-daml-finance-interface-instrument-token-instrument-24425>`:
+- :ref:`Instrument <module-daml-finance-interface-instrument-token-v4-instrument-40238>`:
   Instrument interface for simple tokens
-- :ref:`Factory <module-daml-finance-interface-instrument-token-factory-34763>`:
+- :ref:`Factory <module-daml-finance-interface-instrument-token-v4-factory-1398>`:
   Factory interface to instantiate simple tokens
-- :ref:`Types <module-daml-finance-interface-instrument-token-types-26222>`:
+- :ref:`Types <module-daml-finance-interface-instrument-token-v4-types-62835>`:
   Type definitions to support simple tokens
 
 Check out the :doc:`Transfer tutorial <../../tutorials/getting-started/transfer>` for an example on

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-token.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-token.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Token
-#######################################
+Daml.Finance.Interface.Instrument.Token.V4
+##########################################
 
 This package contains the *interface* definitions for simple token instruments which do not define
 any lifecycling logic. It contains the following modules:

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-types.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-types.rst
@@ -6,7 +6,7 @@ Daml.Finance.Interface.Instrument.Types.V2
 
 This package contains types shared by several instruments. It contains the following modules:
 
-- :ref:`FloatingRate <module-daml-finance-interface-instrument-types-floatingrate-35782>`:
+- :ref:`FloatingRate <module-daml-finance-interface-instrument-types-v2-floatingrate-85519>`:
   Types used to specify different kinds of floating reference rates.
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-types.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-types.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Types
-#######################################
+Daml.Finance.Interface.Instrument.Types.V2
+##########################################
 
 This package contains types shared by several instruments. It contains the following modules:
 

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-lifecycle.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-lifecycle.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Lifecycle
-################################
+Daml.Finance.Interface.Lifecycle.V4
+###################################
 
 This package contains the *interface* for lifecycle related processes. It contains the following
 modules:

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-lifecycle.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-lifecycle.rst
@@ -7,33 +7,33 @@ Daml.Finance.Interface.Lifecycle.V4
 This package contains the *interface* for lifecycle related processes. It contains the following
 modules:
 
-- :ref:`Effect <module-daml-finance-interface-lifecycle-effect-16050>`:
+- :ref:`Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>`:
   Interface for contracts exposing effects of lifecycling processes, e.g., the payment resulting
   from a bond coupon
-- :ref:`Election <module-daml-finance-interface-lifecycle-election-24570>`:
+- :ref:`Election <module-daml-finance-interface-lifecycle-v4-election-15483>`:
   Interface to allow for elections to be made on claim based instruments
-- :ref:`Election.Factory <module-daml-finance-interface-lifecycle-election-factory-66610>`:
+- :ref:`Election.Factory <module-daml-finance-interface-lifecycle-v4-election-factory-21763>`:
   Factory interface to instantiate elections on claim based instruments
-- :ref:`Event <module-daml-finance-interface-lifecycle-event-43586>`:
+- :ref:`Event <module-daml-finance-interface-lifecycle-v4-event-91777>`:
   Interface for a lifecycle event. An event is any contract that triggers the processing of a
   lifecycle rule. Events can be, e.g., dividend announcements or simply the passing of time.
-- :ref:`Event.Distribution <module-daml-finance-interface-lifecycle-event-distribution-91943>`:
+- :ref:`Event.Distribution <module-daml-finance-interface-lifecycle-v4-event-distribution-56030>`:
   Event interface for the distribution of units of an instrument for each unit of a target
   instrument (e\.g\. share or cash dividends)
-- :ref:`Event.Replacement <module-daml-finance-interface-lifecycle-event-replacement-2440>`:
+- :ref:`Event.Replacement <module-daml-finance-interface-lifecycle-v4-event-replacement-41051>`:
   Event interface for the replacement of units of an instrument with a basket of other
   instruments (e\.g\. stock merger)
-- :ref:`Event.Time <module-daml-finance-interface-lifecycle-event-time-4252>`:
+- :ref:`Event.Time <module-daml-finance-interface-lifecycle-v4-event-time-69757>`:
   Event interface for events that signal the passing of (business) time
-- :ref:`Rule.Lifecycle <module-daml-finance-interface-lifecycle-rule-lifecycle-50431>`:
+- :ref:`Rule.Lifecycle <module-daml-finance-interface-lifecycle-v4-rule-lifecycle-8270>`:
   Interface implemented by rules that lifecycle and evolve instruments
-- :ref:`Rule.Claim <module-daml-finance-interface-lifecycle-rule-claim-6739>`:
+- :ref:`Rule.Claim <module-daml-finance-interface-lifecycle-v4-rule-claim-89954>`:
   Interface for contracts that allow holders to claim an ``Effect`` and generate settlement
   instructions
-- :ref:`Observable.NumericObservable <module-daml-finance-interface-lifecycle-observable-numericobservable-67288>`:
+- :ref:`Observable.NumericObservable <module-daml-finance-interface-lifecycle-v4-observable-numericobservable-50817>`:
   Interface to observe time-dependent numerical values (e.g. a stock price or an interest rate
   fixing)
-- :ref:`Observable.TimeObservable <module-daml-finance-interface-lifecycle-observable-timeobservable-45971>`:
+- :ref:`Observable.TimeObservable <module-daml-finance-interface-lifecycle-v4-observable-timeobservable-64296>`:
   Interface implemented by templates exposing time information
 
 The :doc:`Lifecycling <../../concepts/lifecycling>` page contains an overview of the lifecycle

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-settlement.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-settlement.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Settlement
-#################################
+Daml.Finance.Interface.Settlement.V4
+####################################
 
 This package contains the *interface* for settlement. It has the following modules:
 

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-settlement.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-settlement.rst
@@ -6,15 +6,15 @@ Daml.Finance.Interface.Settlement.V4
 
 This package contains the *interface* for settlement. It has the following modules:
 
-- :ref:`RouteProvider <module-daml-finance-interface-settlement-routeprovider-15164>`:
+- :ref:`RouteProvider <module-daml-finance-interface-settlement-v4-routeprovider-63>`:
   Interface for providing a discovery mechanism for settlement routes
-- :ref:`Instruction <module-daml-finance-interface-settlement-instruction-10970>`:
+- :ref:`Instruction <module-daml-finance-interface-settlement-v4-instruction-71097>`:
   Interface for providing a single instruction to transfer an asset at a custodian
-- :ref:`Batch <module-daml-finance-interface-settlement-batch-39188>`:
+- :ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>`:
   Interface for atomically executing instructions, i.e., settling `Transferable`\s
-- :ref:`Factory <module-daml-finance-interface-settlement-factory-75196>`:
+- :ref:`Factory <module-daml-finance-interface-settlement-v4-factory-85379>`:
   Interface used to generate a batch and associated instructions
-- :ref:`Types <module-daml-finance-interface-settlement-types-44085>`:
+- :ref:`Types <module-daml-finance-interface-settlement-v4-types-65938>`:
   Types required in the settlement process, e.g., `Step`, `RoutedStep`, `Allocation`, and
   `Approval`
 

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-types-common.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-types-common.rst
@@ -6,7 +6,7 @@ Daml.Finance.Interface.Types.Common.V3
 
 This package contains common type definitions. They are defined in the following modules:
 
-- :ref:`Types <module-daml-finance-interface-types-common-types-55444>`:
+- :ref:`Types <module-daml-finance-interface-types-common-v3-types-97540>`:
   Various types related to keys, observers, parties, identifiers and quantities, which are
   commonly used in several packages
 

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-types-common.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-types-common.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Types.Common
-###################################
+Daml.Finance.Interface.Types.Common.V3
+######################################
 
 This package contains common type definitions. They are defined in the following modules:
 

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-types-date.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-types-date.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Types.Date
-#################################
+Daml.Finance.Interface.Types.Date.V3
+####################################
 
 Financial instruments, especially those related to interest rates, often depend on periodic
 schedules. For example, consider a fixed rate bond with a coupon that should be paid every three

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-types-date.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-types-date.rst
@@ -14,19 +14,19 @@ This package contains types related to dates, in particular how to define regula
 dates should be adjusted when they fall on non-business days. They are defined in the following
 modules:
 
-- :ref:`Calendar <module-daml-finance-interface-types-date-calendar-23555>`:
+- :ref:`Calendar <module-daml-finance-interface-types-date-v3-calendar-20021>`:
   Types for holiday calendar data and how to adjust non-business days
-- :ref:`Classes <module-daml-finance-interface-types-date-classes-73544>`:
+- :ref:`Classes <module-daml-finance-interface-types-date-v3-classes-49826>`:
   Type class that specifies what can be converted to UTC time
-- :ref:`DateOffset <module-daml-finance-interface-types-date-dateoffset-40136>`:
+- :ref:`DateOffset <module-daml-finance-interface-types-date-v3-dateoffset-17578>`:
   Types for date offsets that can be used e.g. to specify a rate fixing date relative to the reset
   date in terms of a business days offset and an associated set of financial business centers.
-- :ref:`DayCount <module-daml-finance-interface-types-date-daycount-90980>`:
+- :ref:`DayCount <module-daml-finance-interface-types-date-v3-daycount-5046>`:
   Type to specify the conventions used to calculate day count fractions. These are used to define
   the interest accrued during each schedule period, for example for a bond or a swap.
-- :ref:`RollConvention <module-daml-finance-interface-types-date-rollconvention-76363>`:
+- :ref:`RollConvention <module-daml-finance-interface-types-date-v3-rollconvention-38965>`:
   Types to define date periods and how to roll dates
-- :ref:`Schedule <module-daml-finance-interface-types-date-schedule-61944>`:
+- :ref:`Schedule <module-daml-finance-interface-types-date-v3-schedule-94670>`:
   Types to define date schedules
 
 Check out the :ref:`Fixed rate bond documentation <fixed-rate-bond-tutorial-section>`

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-util.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-util.rst
@@ -7,13 +7,13 @@ Daml.Finance.Interface.Util.V3
 This package contains the *interface* for the disclosure of contracts and some commonly used
 utility functions. They are defined in these modules:
 
-- :ref:`Disclosure <module-daml-finance-interface-util-disclosure-87755>`:
+- :ref:`Disclosure <module-daml-finance-interface-util-v3-disclosure-50779>`:
   An interface for managing the visibility of contracts for non-authorizing parties
-- :ref:`Lockable <module-daml-finance-interface-util-lockable-80915>`:
+- :ref:`Lockable <module-daml-finance-interface-util-v3-lockable-20339>`:
   An interface for locking contracts, e.g., a holding or account
-- :ref:`InterfaceKeys <module-daml-finance-interface-util-interfacekey-52230>`:
+- :ref:`InterfaceKeys <module-daml-finance-interface-util-v3-interfacekey-20882>`:
   An interface with utility functions for keying interfaces
-- :ref:`Common <module-daml-finance-interface-util-common-43703>`:
+- :ref:`Common <module-daml-finance-interface-util-v3-common-32871>`:
   Different utility functions related to interfaces and assertions
 
 Changelog

--- a/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-util.rst
+++ b/docs/2.10.0/docs/daml-finance/packages/interfaces/daml-finance-interface-util.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Util
-###########################
+Daml.Finance.Interface.Util.V3
+##############################
 
 This package contains the *interface* for the disclosure of contracts and some commonly used
 utility functions. They are defined in these modules:

--- a/docs/2.10.0/docs/daml-finance/reference/patterns.rst
+++ b/docs/2.10.0/docs/daml-finance/reference/patterns.rst
@@ -17,7 +17,7 @@ has to do with application decoupling / upgradeability of your application.
 
 For example, suppose that you are writing Daml code to issue equity instruments. Your workflow
 references the version ``0.2.1`` of the
-:ref:`Equity implementation package <module-daml-finance-instrument-equity-instrument-69265>`
+:ref:`Equity implementation package <module-daml-finance-instrument-equity-v1-instrument-56047>`
 and at some point creates an instrument as follows.
 
 .. code-block:: daml
@@ -33,15 +33,15 @@ Daml code in order to use the new feature and will have to deal with upgrading m
 on the ledger.
 
 A safer approach is for your Daml code to only reference the
-:ref:`Equity interface package <module-daml-finance-interface-instrument-equity-instrument-13224>`,
+:ref:`Equity interface package <module-daml-finance-interface-instrument-equity-v1-instrument-10480>`,
 which contains interface definitions and is updated less frequently.
 
 However, you would now need a way to create equity instruments without referencing
 ``Daml.Finance.Instrument.Equity.V1`` in your main Daml workflow. To do this, you can setup a Script
 to run during ledger initialisation that will create a
-:ref:`factory contract <module-daml-finance-instrument-equity-factory-96899>`
+:ref:`factory contract <module-daml-finance-instrument-equity-v1-factory-43861>`
 and cast it to the corresponding
-:ref:`interface <module-daml-finance-interface-instrument-equity-factory-97140>`.
+:ref:`interface <module-daml-finance-interface-instrument-equity-v1-factory-86676>`.
 You can then use the factory in your main workflow code to create the instruments.
 
 When an upgraded instrument comes along, you would need to write code to archive the old factory and
@@ -61,7 +61,7 @@ when working with interfaces. This is required as there is currently no built-in
 language level for interface keys.
 
 We want for instance to use an
-:ref:`InstrumentKey <constr-daml-finance-interface-types-common-types-instrumentkey-32970>` to
+:ref:`InstrumentKey <constr-daml-finance-interface-types-common-v3-types-instrumentkey-49116>` to
 identify instruments across a number of implementing templates.
 
 To do that, we define a `Reference` template that
@@ -96,14 +96,14 @@ There are different ways to access the data of a contract, for example the terms
    submitting party to be a stakeholder of the contract). It is then possible to use the ``view``
    built-in method to get the interface view.
 #. ``GetView``: by calling this choice on the interface, for example on a
-   :ref:`callable bond <module-daml-finance-interface-instrument-bond-callable-instrument-70617>`,
+   :ref:`callable bond <module-daml-finance-interface-instrument-bond-v3-callable-instrument-14719>`,
    a party can get the view of a contract, without necessarily being a stakeholder of the contract.
    This can be useful in situations where someone needs access to reference data, but should not be
    a stakeholder of the contract. Specifically, if *publicParty* is an observer of an instrumentCid,
    a party would only require readAs rights of *publicParty* in order to exercise ``GetView``. In
    the Daml Finance library, this choice has been implemented not only for instruments but also for
    other types of contracts, e.g.
-   :ref:`Holdings <module-daml-finance-interface-holding-fungible-63712>` and lifecycle related
+   :ref:`Holdings <module-daml-finance-interface-holding-v4-fungible-55495>` and lifecycle related
    contracts like
-   :ref:`Rule <module-daml-finance-interface-lifecycle-rule-lifecycle-50431>` and
-   :ref:`Effect <module-daml-finance-interface-lifecycle-effect-16050>`.
+   :ref:`Rule <module-daml-finance-interface-lifecycle-v4-rule-lifecycle-8270>` and
+   :ref:`Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>`.

--- a/docs/2.10.0/docs/daml-finance/reference/patterns.rst
+++ b/docs/2.10.0/docs/daml-finance/reference/patterns.rst
@@ -37,7 +37,7 @@ A safer approach is for your Daml code to only reference the
 which contains interface definitions and is updated less frequently.
 
 However, you would now need a way to create equity instruments without referencing
-``Daml.Finance.Instrument.Equity`` in your main Daml workflow. To do this, you can setup a Script
+``Daml.Finance.Instrument.Equity.V1`` in your main Daml workflow. To do this, you can setup a Script
 to run during ledger initialisation that will create a
 :ref:`factory contract <module-daml-finance-instrument-equity-factory-96899>`
 and cast it to the corresponding

--- a/docs/2.10.0/docs/daml-finance/tutorials/advanced-topics/instrument-modeling/contingent-claims-instrument.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/advanced-topics/instrument-modeling/contingent-claims-instrument.rst
@@ -32,7 +32,7 @@ Template Definition
 We start by defining a new template for the instrument. Here are the fields used for the fixed
 rate instrument:
 
-.. literalinclude:: ../../../src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
+.. literalinclude:: ../../../src/main/daml/Daml/Finance/Instrument/Bond/V3/FixedRate/Instrument.daml
   :language: daml
   :start-after: -- FIXED_RATE_BOND_TEMPLATE_BEGIN
   :end-before: -- FIXED_RATE_BOND_TEMPLATE_END
@@ -57,7 +57,7 @@ economic terms.
 Here is a high level implementation of the
 :ref:`Claims interface <module-daml-finance-interface-claims-claim-82866>`:
 
-.. literalinclude:: ../../../src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
+.. literalinclude:: ../../../src/main/daml/Daml/Finance/Instrument/Bond/V3/FixedRate/Instrument.daml
   :language: daml
   :start-after: -- FIXED_RATE_BOND_CLAIMS_BEGIN
   :end-before: -- FIXED_RATE_BOND_CLAIMS_END
@@ -78,7 +78,7 @@ How to define the redemption claim
 
 The redemption claim depends on the currency and the maturity date of the bond.
 
-.. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/Util/Builders.daml
+.. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Util/Builders.daml
   :language: daml
   :start-after: -- FIXED_RATE_BOND_REDEMPTION_CLAIM_BEGIN
   :end-before: -- FIXED_RATE_BOND_REDEMPTION_CLAIM_END
@@ -102,7 +102,7 @@ How to define the coupon claims
 The coupon claims are a bit more complicated to define.
 We need to take a schedule of adjusted coupon dates and the day count convention into account.
 
-.. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/Util/Builders.daml
+.. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Util/Builders.daml
   :language: daml
   :start-after: -- FIXED_RATE_BOND_COUPON_CLAIMS_BEGIN
   :end-before: -- FIXED_RATE_BOND_COUPON_CLAIMS_END
@@ -122,7 +122,7 @@ payment.
 Evolution of the instrument over time (and calculation of the corresponding lifecycle effects) can
 be performed using the :ref:`Lifecycle.Rule <module-daml-finance-claims-lifecycle-rule-53980>`
 template provided in the
-:doc:`Daml.Finance.Claims <../../../packages/implementations/daml-finance-claims>` package. This
+:doc:`Daml.Finance.Claims.V3 <../../../packages/implementations/daml-finance-claims>` package. This
 rule is very generic and can be used for all instruments that implement the
 :ref:`Claims interface <module-daml-finance-interface-claims-claim-82866>`.
 
@@ -131,7 +131,7 @@ Let us break its implementation apart to describe what happens in more detail:
 * First, we retrieve the claim tree corresponding to the initial state of the instrument. We do so
   by fetching the ``Claims`` interface we defined for the template.
 
-  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/Lifecycle/Rule.daml
+  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Lifecycle/Rule.daml
     :language: daml
     :start-after: -- BOND_PROCESS_CLOCK_UPDATE_INITAL_CLAIMS_BEGIN
     :end-before: -- BOND_PROCESS_CLOCK_UPDATE_INITAL_CLAIMS_END
@@ -139,7 +139,7 @@ Let us break its implementation apart to describe what happens in more detail:
 * By using the ``lastEventTimestamp`` (in our case: the last time a coupon was paid), we can now
   "fast forward" the claim tree to the current instrument state.
 
-  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/Lifecycle/Rule.daml
+  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Lifecycle/Rule.daml
     :language: daml
     :start-after: -- BOND_PROCESS_CLOCK_UPDATE_LIFECYCLE_FASTFORWARD_BEGIN
     :end-before: -- BOND_PROCESS_CLOCK_UPDATE_LIFECYCLE_FASTFORWARD_END
@@ -149,7 +149,7 @@ Let us break its implementation apart to describe what happens in more detail:
   due), we create a :ref:`Lifecycle Effect <module-daml-finance-lifecycle-effect-1975>` for it,
   which can then be claimed and settled.
 
-  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/Lifecycle/Rule.daml
+  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Lifecycle/Rule.daml
     :language: daml
     :start-after: -- BOND_PROCESS_CLOCK_UPDATE_LIFECYCLE_BEGIN
     :end-before: -- BOND_PROCESS_CLOCK_UPDATE_LIFECYCLE_END
@@ -164,7 +164,7 @@ done by exercising the
 choice of the
 :ref:`Dynamic.Instrument interface <module-daml-finance-interface-claims-claim-82866>`:
 
-  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/Lifecycle/Rule.daml
+  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Lifecycle/Rule.daml
     :language: daml
     :start-after: -- CREATE_NEW_DYNAMIC_INSTRUMENT_VERSION_BEGIN
     :end-before: -- CREATE_NEW_DYNAMIC_INSTRUMENT_VERSION_END
@@ -186,7 +186,7 @@ define the coupon based on a future observation of the reference rate.
 
 In the instrument definition, we need an identifier for the reference rate:
 
-.. literalinclude:: ../../../src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
+.. literalinclude:: ../../../src/main/daml/Daml/Finance/Instrument/Bond/V3/FloatingRate/Instrument.daml
   :language: daml
   :start-after: -- FLOATING_RATE_BOND_TEMPLATE_UNTIL_REFRATE_BEGIN
   :end-before: -- FLOATING_RATE_BOND_TEMPLATE_UNTIL_REFRATE_END
@@ -195,7 +195,7 @@ When we create the claims for the coupon payments, we can then use
 :ref:`ObserveAt <constr-contingentclaims-core-observation-observeat-8418>` to refer to the value of
 the reference rate:
 
-.. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/Util/Builders.daml
+.. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Util/Builders.daml
   :language: daml
   :start-after: -- FLOATING_RATE_BOND_COUPON_CLAIMS_BEGIN
   :end-before: -- FLOATING_RATE_BOND_COUPON_CLAIMS_END

--- a/docs/2.10.0/docs/daml-finance/tutorials/advanced-topics/instrument-modeling/contingent-claims-instrument.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/advanced-topics/instrument-modeling/contingent-claims-instrument.rst
@@ -13,7 +13,7 @@ implementations. The :doc:`Bond <../../../instruments/bond>` and
 behind the scenes to calculate pending coupon payments.
 
 Let us explore in detail how the
-:ref:`fixed rate bond instrument <module-daml-finance-instrument-bond-fixedrate-instrument-67993>`
+:ref:`fixed rate bond instrument <module-daml-finance-instrument-bond-v3-fixedrate-instrument-89221>`
 is implemented in Daml Finance. The goal is for you to learn how to implement and lifecycle your own
 instrument template, should you need an instrument type that is not already implemented in the
 library.
@@ -21,7 +21,7 @@ library.
 To follow the code snippets used in this tutorial in Daml Studio, you can clone the
 `Daml Finance repository <https://github.com/digital-asset/daml-finance>`_ and take a look at how
 the
-:ref:`Bond Instrument template <module-daml-finance-instrument-bond-fixedrate-instrument-67993>`
+:ref:`Bond Instrument template <module-daml-finance-instrument-bond-v3-fixedrate-instrument-89221>`
 is implemented. In order to see how lifecycling is performed, you can run the script in the
 `Instrument/Bond/Test/FixedRate.daml <https://github.com/digital-asset/daml-finance/blob/main/src/test/daml/Daml/Finance/Instrument/Bond/Test/FixedRate.daml>`_
 file.
@@ -49,13 +49,13 @@ Note that the Contingent Claims tree is not a part of the template above, instea
 dynamically upon request.
 
 In order do that, we implement the
-:ref:`Claims interface <module-daml-finance-interface-claims-claim-82866>`.
+:ref:`Claims interface <module-daml-finance-interface-claims-v4-claim-38573>`.
 This interface provides access to a generic mechanism to process coupon payments and redemptions.
 It will work in a similar way for the majority of instrument types, regardless of their specific
 economic terms.
 
 Here is a high level implementation of the
-:ref:`Claims interface <module-daml-finance-interface-claims-claim-82866>`:
+:ref:`Claims interface <module-daml-finance-interface-claims-v4-claim-38573>`:
 
 .. literalinclude:: ../../../src/main/daml/Daml/Finance/Instrument/Bond/V3/FixedRate/Instrument.daml
   :language: daml
@@ -84,13 +84,13 @@ The redemption claim depends on the currency and the maturity date of the bond.
   :end-before: -- FIXED_RATE_BOND_REDEMPTION_CLAIM_END
 
 Keywords like
-:ref:`when <function-contingentclaims-core-claim-when-17123>`,
-:ref:`scale <function-contingentclaims-core-claim-scale-79608>`,
-:ref:`one <function-contingentclaims-core-claim-one-13168>` and
-:ref:`give <function-contingentclaims-core-claim-give-6964>` should be familiar from the
+:ref:`when <function-contingentclaims-core-v3-claim-when-40851>`,
+:ref:`scale <function-contingentclaims-core-v3-claim-scale-39304>`,
+:ref:`one <function-contingentclaims-core-v3-claim-one-90688>` and
+:ref:`give <function-contingentclaims-core-v3-claim-give-33092>` should be familiar from the
 :doc:`Payoff Modeling tutorial <../../payoff-modeling/intro>`.
-:ref:`TimeGte <constr-contingentclaims-core-internal-claim-timegte-91610>` is just a synonym for
-:ref:`at <function-contingentclaims-core-claim-at-6466>`.
+:ref:`TimeGte <constr-contingentclaims-core-v3-internal-claim-timegte-43192>` is just a synonym for
+:ref:`at <function-contingentclaims-core-v3-claim-at-41106>`.
 
 The ``ownerReceives`` flag is used to indicate whether the owner of a holding on the bond is meant
 to receive the redemption payment. When this is set to ``false``, the holding custodian will be
@@ -120,11 +120,11 @@ The ``lastEventTimestamp`` field in our template is used to keep track of the la
 payment.
 
 Evolution of the instrument over time (and calculation of the corresponding lifecycle effects) can
-be performed using the :ref:`Lifecycle.Rule <module-daml-finance-claims-lifecycle-rule-53980>`
+be performed using the :ref:`Lifecycle.Rule <module-daml-finance-claims-v3-lifecycle-rule-196>`
 template provided in the
 :doc:`Daml.Finance.Claims.V3 <../../../packages/implementations/daml-finance-claims>` package. This
 rule is very generic and can be used for all instruments that implement the
-:ref:`Claims interface <module-daml-finance-interface-claims-claim-82866>`.
+:ref:`Claims interface <module-daml-finance-interface-claims-v4-claim-38573>`.
 
 Let us break its implementation apart to describe what happens in more detail:
 
@@ -146,7 +146,7 @@ Let us break its implementation apart to describe what happens in more detail:
 
 * Finally, we lifecycle the current instrument state to calculate pending
   `effects <#lifecycling-effect>`__. If there are such effects (for example when a coupon payment is
-  due), we create a :ref:`Lifecycle Effect <module-daml-finance-lifecycle-effect-1975>` for it,
+  due), we create a :ref:`Lifecycle Effect <module-daml-finance-lifecycle-v4-effect-31424>` for it,
   which can then be claimed and settled.
 
   .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Lifecycle/Rule.daml
@@ -160,9 +160,9 @@ The ``Dynamic.Instrument`` Interface
 In the ``tryCreateNewInstrument`` part above, we create a new version of the instrument containing
 the updated ``lastEventTimestamp`` (and also including all previous events up until now). This is
 done by exercising the
-:ref:`CreateNewVersion <type-daml-finance-interface-claims-dynamic-instrument-createnewversion-36931>`
+:ref:`CreateNewVersion <type-daml-finance-interface-claims-v4-dynamic-instrument-createnewversion-58950>`
 choice of the
-:ref:`Dynamic.Instrument interface <module-daml-finance-interface-claims-claim-82866>`:
+:ref:`Dynamic.Instrument interface <module-daml-finance-interface-claims-v4-claim-38573>`:
 
   .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Lifecycle/Rule.daml
     :language: daml
@@ -192,7 +192,7 @@ In the instrument definition, we need an identifier for the reference rate:
   :end-before: -- FLOATING_RATE_BOND_TEMPLATE_UNTIL_REFRATE_END
 
 When we create the claims for the coupon payments, we can then use
-:ref:`ObserveAt <constr-contingentclaims-core-observation-observeat-8418>` to refer to the value of
+:ref:`ObserveAt <constr-contingentclaims-core-v3-observation-observeat-93788>` to refer to the value of
 the reference rate:
 
 .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Util/Builders.daml

--- a/docs/2.10.0/docs/daml-finance/tutorials/advanced-topics/instrument-modeling/date-utilities.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/advanced-topics/instrument-modeling/date-utilities.rst
@@ -20,10 +20,10 @@ your own custom use cases. For example, you can use these functions to:
 Calendar
 ========
 
-The :ref:`Calendar <module-daml-finance-util-date-calendar-17588>` module contains various utility
+The :ref:`Calendar <module-daml-finance-util-v4-date-calendar-71711>` module contains various utility
 functions related to business days and date adjustments.
 
-To distinguish business days and non-business days, set a holiday calendar. The :ref:`HolidayCalendarData <type-daml-finance-interface-types-date-calendar-holidaycalendardata-60004>`
+To distinguish business days and non-business days, set a holiday calendar. The :ref:`HolidayCalendarData <type-daml-finance-interface-types-date-v3-calendar-holidaycalendardata-87370>`
 type defines the set of non-business days by specifying the days of the week that belong to the
 weekend, as well as the dates of designated holidays. The following example sets Saturday and Sunday
 as weekend days and specifies some additional holidays:
@@ -76,14 +76,14 @@ You can adjust a date according to a business day convention:
   :end-before: -- TEST_ADJUST_DATE_END
 
 For the full list of available conventions, see the
-:ref:`BusinessDayConventionEnum <type-daml-finance-interface-types-date-calendar-businessdayconventionenum-88986>`
+:ref:`BusinessDayConventionEnum <type-daml-finance-interface-types-date-v3-calendar-businessdayconventionenum-14112>`
 reference. Use them to specify how non-business days are adjusted, including when the next or
 previous business day is around the end of the month.
 
 RollConvention
 ==============
 
-The :ref:`RollConvention <module-daml-finance-util-date-rollconvention-88672>` module provides
+The :ref:`RollConvention <module-daml-finance-util-v4-date-rollconvention-61455>` module provides
 utility functions to add a period to a given date.
 
 For example, you can add a day, week, month, or year to a date:
@@ -110,7 +110,7 @@ To *subtract* a period of time, use a negative offset:
 
 You might need to find the start date of the next period according to a specific market
 convention, as described in the
-:ref:`RollConventionEnum <type-daml-finance-interface-types-date-rollconvention-rollconventionenum-73360>`
+:ref:`RollConventionEnum <type-daml-finance-interface-types-date-v3-rollconvention-rollconventionenum-89490>`
 reference.
 The *Roll convention* specifies when the date is rolled.
 
@@ -149,14 +149,14 @@ The following example shows you how to roll to the *previous* period:
   :start-after: -- TEST_PREVIOUS_DOM_FROM_EOFEB_BEGIN
   :end-before: -- TEST_PREVIOUS_DOM_FROM_EOFEB_END
 
-The :ref:`RollConvention <module-daml-finance-util-date-rollconvention-88672>` functions
+The :ref:`RollConvention <module-daml-finance-util-v4-date-rollconvention-61455>` functions
 are often used in the context of rolling out a schedule, as
 explained in the next section.
 
 Schedule
 ========
 
-The :ref:`Schedule <module-daml-finance-util-date-schedule-32303>` module contains functions for
+The :ref:`Schedule <module-daml-finance-util-v4-date-schedule-63724>` module contains functions for
 creating a series of time periods.
 A schedule can be used to represent different aspects of a financial instrument, for example:
 
@@ -181,7 +181,7 @@ correspond to four periods of 3M each:
 Note the distinction between adjusted and unadjusted dates. The unadjusted date is the result of
 adding a specified time period to the start date of the previous schedule period. This date might
 fall on a non-business day. Apply a
-:ref:`BusinessDayAdjustment <type-daml-finance-interface-types-date-calendar-businessdayadjustment-93933>`,
+:ref:`BusinessDayAdjustment <type-daml-finance-interface-types-date-v3-calendar-businessdayadjustment-71551>`,
 to get an adjusted date that falls on a business day.
 
 Now you can roll out the schedule to get the specific start and end date for each period, and
@@ -214,7 +214,7 @@ schedule:
   :end-before: -- CREATE_EXPECTED_SCHEDULE_RESULT_WITH_STUB_END
 
 To configure different stub types, use the
-:ref:`StubPeriodTypeEnum <type-daml-finance-interface-types-date-schedule-stubperiodtypeenum-69372>`
+:ref:`StubPeriodTypeEnum <type-daml-finance-interface-types-date-v3-schedule-stubperiodtypeenum-99734>`
 data type. You can configure whether the stub period should be at the beginning or end of the
 schedule, as well as whether the stub period should be longer or shorter than a regular period.
 
@@ -231,7 +231,7 @@ DayCount
 
 Many instruments that pay interest (often expressed as an annualized rate) require an exact
 definition of how many days of interest belong to each payment period. The
-:ref:`DayCount <module-daml-finance-util-date-daycount-38239>` module provides functions  to support
+:ref:`DayCount <module-daml-finance-util-v4-date-daycount-38488>` module provides functions  to support
 such requirements.
 In particular, you can calculate a *day count fraction* (*dcf*) between two dates. This indicates
 the fraction of a full year between the dates.
@@ -241,7 +241,7 @@ like the one described in the previous section.
 
 This bond does not have the same number of days in each period, which normally results in different
 coupon amounts for each period. Various market conventions address this and are provided in the
-:ref:`DayCountConventionEnum <type-daml-finance-interface-types-date-daycount-daycountconventionenum-67281>`.
+:ref:`DayCountConventionEnum <type-daml-finance-interface-types-date-v3-daycount-daycountconventionenum-31>`.
 
 Consider the schedule with a short initial stub in the previous section. The following example uses
 the ``Act360`` day count convention:
@@ -268,14 +268,14 @@ correspond to 3M instead of 2M. Note that they differ slightly: they do not cont
 exact same number of days.
 
 In addition to ``Act360``, the
-:ref:`DayCountConventionEnum <type-daml-finance-interface-types-date-daycount-daycountconventionenum-67281>`
+:ref:`DayCountConventionEnum <type-daml-finance-interface-types-date-v3-daycount-daycountconventionenum-31>`
 supports several other day count conventions. You can compute some of them with
-:ref:`calcDcf <function-daml-finance-util-date-daycount-calcdcf-20432>`, using only a start and an
+:ref:`calcDcf <function-daml-finance-util-v4-date-daycount-calcdcf-53229>`, using only a start and an
 end date as an input as shown above.
 Others, such as ``ActActISDA``, are a bit more complicated because they require additional
 information.
 You can calculate them using the
-:ref:`calcPeriodDcf <function-daml-finance-util-date-daycount-calcperioddcf-63067>` function
+:ref:`calcPeriodDcf <function-daml-finance-util-v4-date-daycount-calcperioddcf-52338>` function
 instead. This function takes a schedule period (containing stub information) as input, as well as
 the schedule end date and the payment frequency:
 

--- a/docs/2.10.0/docs/daml-finance/tutorials/advanced-topics/lifecycling/intermediated-lifecycling.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/advanced-topics/lifecycling/intermediated-lifecycling.rst
@@ -69,7 +69,7 @@ has been reached:
 Lifecycle the Bond Instrument
 *****************************
 
-Using the :ref:`Lifecycle <module-daml-finance-interface-lifecycle-rule-lifecycle-50431>` interface,
+Using the :ref:`Lifecycle <module-daml-finance-interface-lifecycle-v4-rule-lifecycle-8270>` interface,
 the CSD creates a lifecycle rule contract:
 
 .. literalinclude:: ../../../src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -85,12 +85,12 @@ exercising the ``Evolve`` choice on the coupon date:
   :start-after: -- LIFECYCLE_BOND_BEGIN
   :end-before: -- LIFECYCLE_BOND_END
 
-This internally uses the :ref:`Event <module-daml-finance-interface-lifecycle-event-43586>`
+This internally uses the :ref:`Event <module-daml-finance-interface-lifecycle-v4-event-91777>`
 interface. In our case, the event is a clock update event, since the coupon payment is triggered by
 the passage of time.
 
 The return type of ``effectCid`` is an
-:ref:`Effect <module-daml-finance-interface-lifecycle-effect-16050>` interface.
+:ref:`Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>` interface.
 It will contain the effect(s) of the lifecycling, in this case a coupon payment. If
 there is nothing to lifecycle, for example because there is no coupon to be paid today,
 this would be empty.
@@ -119,7 +119,7 @@ factory:
   :end-before: -- LIFECYCLE_BOND_SETTLEMENT_FACTORY_END
 
 Settlement instructions are created
-by using the :ref:`Claim <module-daml-finance-interface-lifecycle-rule-claim-6739>` interface and
+by using the :ref:`Claim <module-daml-finance-interface-lifecycle-v4-rule-claim-89954>` interface and
 exercising the ``ClaimEffect`` choice:
 
 .. literalinclude:: ../../../src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -175,10 +175,10 @@ What if one party wants to cancel the settlement?
 =================================================
 
 The parties who sign the
-:ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` contract (the instructor
+:ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` contract (the instructor
 and consenters) can exercise the ``Cancel`` choice of the
-:ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` to cancel all associated
-:ref:`Instructions <module-daml-finance-interface-settlement-instruction-10970>`
+:ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` to cancel all associated
+:ref:`Instructions <module-daml-finance-interface-settlement-v4-instruction-71097>`
 atomically.
 
 Settlement can also be obstructed if the responsible parties do not fully allocate

--- a/docs/2.10.0/docs/daml-finance/tutorials/getting-started/holdings.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/getting-started/holdings.rst
@@ -136,7 +136,7 @@ You might be wondering why we use account factories and holding factories instea
 :ref:`Account <module-daml-finance-account-account-19369>` or
 :ref:`Holding <module-daml-finance-holding-transferablefungible-77726>` directly.
 
-This is done to avoid having to reference the ``Daml.Finance.Holding`` package directly in the
+This is done to avoid having to reference the ``Daml.Finance.Holding.V4`` package directly in the
 user workflows (and hence simplify upgrading procedures).
 
 This pattern is described in detail in the :ref:`Daml Finance Patterns <factory-pattern>` page and

--- a/docs/2.10.0/docs/daml-finance/tutorials/getting-started/holdings.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/getting-started/holdings.rst
@@ -38,7 +38,7 @@ because our workflows, such as ``CreateAccount``, do not have any knowledge of c
 implementations.
 
 Similarly, we instantiate a
-:ref:`holding factory <module-daml-finance-holding-factory-11188>`, which is used within an
+:ref:`holding factory <module-daml-finance-holding-v4-factory-50391>`, which is used within an
 account to create (``Credit``) holdings for any instrument.
 
 .. literalinclude:: ../../quickstart-finance/daml/Scripts/Holding.daml
@@ -47,7 +47,7 @@ account to create (``Credit``) holdings for any instrument.
   :end-before: -- CREATE_HOLDING_FACTORY_END
 
 Finally, we create a factory template which is used to instantiate :ref:`token instruments
-<module-daml-finance-instrument-token-instrument-10682>`.
+<module-daml-finance-instrument-token-v4-instrument-53415>`.
 
 .. literalinclude:: ../../quickstart-finance/daml/Scripts/Holding.daml
   :language: daml
@@ -77,7 +77,7 @@ Create the Cash Instrument
 In order to credit Alice’s account with some cash, we first create a cash instrument. An instrument
 is a representation of what it is that we are holding against the Bank. It can be as simple as just
 a textual label (like the
-:ref:`Token Instrument <module-daml-finance-interface-instrument-token-instrument-24425>`
+:ref:`Token Instrument <module-daml-finance-interface-instrument-token-v4-instrument-40238>`
 used in this case) or it can include complex on-ledger lifecycling logic.
 
 .. literalinclude:: ../../quickstart-finance/daml/Scripts/Holding.daml
@@ -93,7 +93,7 @@ Deposit Cash in Alice’s Account
 
 We can now deposit cash in Alice’s account, using the ``CreditAccount`` workflow.
 Alice creates a request to deposit ``USD 1000`` at the Bank, the Bank then accepts the request and
-a corresponding :ref:`Holding <module-daml-finance-interface-holding-holding-64126>` is created.
+a corresponding :ref:`Holding <module-daml-finance-interface-holding-v4-holding-20535>` is created.
 
 .. literalinclude:: ../../quickstart-finance/daml/Scripts/Holding.daml
   :language: daml
@@ -133,8 +133,8 @@ Why do we need factories?
 =========================
 
 You might be wondering why we use account factories and holding factories instead of creating an
-:ref:`Account <module-daml-finance-account-account-19369>` or
-:ref:`Holding <module-daml-finance-holding-transferablefungible-77726>` directly.
+:ref:`Account <module-daml-finance-account-v4-account-5834>` or
+:ref:`Holding <module-daml-finance-holding-v4-transferablefungible-66907>` directly.
 
 This is done to avoid having to reference the ``Daml.Finance.Holding.V4`` package directly in the
 user workflows (and hence simplify upgrading procedures).

--- a/docs/2.10.0/docs/daml-finance/tutorials/getting-started/intro.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/getting-started/intro.rst
@@ -80,6 +80,6 @@ logic in the ``Workflows`` will not need to be modified nor re-compiled to work 
 upgraded (ie., newer versions of) *implementation* packages.
 
 On the other hand, modules in the ``Scripts`` folder depend on both the *interface* packages and
-the *implementation* packages (in this case, ``Daml.Finance.Account``, ``Daml.Finance.Holding``,
-and ``Daml.Finance.Instrument.Token``). This is not problematic as scripts are meant to be run only
+the *implementation* packages (in this case, ``Daml.Finance.Account.V4``, ``Daml.Finance.Holding.V4``,
+and ``Daml.Finance.Instrument.Token.V4``). This is not problematic as scripts are meant to be run only
 once when the application is initialized.

--- a/docs/2.10.0/docs/daml-finance/tutorials/getting-started/lifecycling.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/getting-started/lifecycling.rst
@@ -71,10 +71,10 @@ Next, we create two lifecycle rules:
   :start-after: -- LIFECYCLE_RULES_BEGIN
   :end-before: -- LIFECYCLE_RULES_END
 
-* The :ref:`Distribution Rule <module-daml-finance-lifecycle-rule-distribution-35531>` defines the
+* The :ref:`Distribution Rule <module-daml-finance-lifecycle-v4-rule-distribution-2662>` defines the
   business logic to calculate the resulting lifecycle effect from a given distribution event. It is
   signed by the `Bank` as a provider.
-* The :ref:`Claim Rule <module-daml-finance-lifecycle-rule-claim-99318>` allows a holder of the
+* The :ref:`Claim Rule <module-daml-finance-lifecycle-v4-rule-claim-11721>` allows a holder of the
   target instrument to claim the effect resulting from the distribution event. By presenting their
   holding they can instruct the settlement of the holding transfers described in the effect.
 

--- a/docs/2.10.0/docs/daml-finance/tutorials/getting-started/settlement.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/getting-started/settlement.rst
@@ -10,7 +10,7 @@ purpose is to demonstrate how multiple holding transfers can be executed atomica
 We are going to:
 
 #. create a new ``TOKEN``
-   :ref:`instrument <module-daml-finance-interface-instrument-token-instrument-24425>`
+   :ref:`instrument <module-daml-finance-interface-instrument-token-v4-instrument-40238>`
 #. credit a ``TOKEN`` holding to Alice’s account
 #. setup a delivery-vs-payment (DvP) transaction to give Alice's ``TOKEN`` holding to Bob in
    exchange for a ``USD`` holding
@@ -24,45 +24,45 @@ Overview of the Process
 
 We first give a quick outline of the settlement process:
 
-+--------------------+-----------------------------------------------------------------------------+
-| 1. Define steps to | Two (or more) parties need to first agree on a set of                       |
-|    be settled      | :ref:`steps <type-daml-finance-interface-settlement-types-step-78661>`      |
-|                    | to be settled.                                                              |
-|                    |                                                                             |
-+--------------------+-----------------------------------------------------------------------------+
-| 2. Generate        | :ref:`Instructions                                                          |
-|    settlement      | <module-daml-finance-interface-settlement-instruction-10970>`               |
-|    instructions    | are generated for each step.                                                |
-|                    |                                                                             |
-|                    | An instruction is a contract where the sender can specify its               |
-|                    | :ref:`Allocation                                                            |
-|                    | <type-daml-finance-interface-settlement-types-allocation-46483>`            |
-|                    | preference for the instruction (e.g., the matching holding they wish to     |
-|                    | send). The receiver can specify its :ref:`Approval                          |
-|                    | <type-daml-finance-interface-settlement-types-approval-84286>`              |
-|                    | preference for the instruction (e.g., the account they wish to receive      |
-|                    | the holding to).                                                            |
-|                    |                                                                             |
-|                    | The creation of Instructions is done by first using a :ref:`Route Provider  |
-|                    | <type-daml-finance-interface-settlement-routeprovider-routeprovider-53805>` |
-|                    | and then applying a :ref:`Settlement Factory                                |
-|                    | <module-daml-finance-interface-settlement-factory-75196>`.                  |
-|                    |                                                                             |
-+--------------------+-----------------------------------------------------------------------------+
-| 3. Allocate and    | For every instruction, the sender and the receiver specify their allocation |
-|    approve         | and approval preferences, respectively.                                     |
-|    instructions    |                                                                             |
-|                    |                                                                             |
-+--------------------+-----------------------------------------------------------------------------+
-| 4. Settle the      | A :ref:`Batch <module-daml-finance-interface-settlement-batch-39188>`       |
-|    batch           | contract is used to settle all instructions atomically according to the     |
-|                    | specified preferences (e.g. by transferring all allocated holdings to the   |
-|                    | corresponding receiving accounts).                                          |
-|                    |                                                                             |
-|                    | This batch contract is created in step 2, together with the settlement      |
-|                    | instructions.                                                               |
-|                    |                                                                             |
-+--------------------+-----------------------------------------------------------------------------+
++------------------+-------------------------------------------------------------------------------+
+| 1. Define steps  | Two (or more) parties need to first agree on a set of                         |
+|    to be settled | :ref:`steps <type-daml-finance-interface-settlement-v4-types-step-16302>`     |
+|                  | to be settled.                                                                |
+|                  |                                                                               |
++------------------+-------------------------------------------------------------------------------+
+| 2. Generate      | :ref:`Instructions                                                            |
+|    settlement    | <module-daml-finance-interface-settlement-v4-instruction-71097>`              |
+|    instructions  | are generated for each step.                                                  |
+|                  |                                                                               |
+|                  | An instruction is a contract where the sender can specify its                 |
+|                  | :ref:`Allocation                                                              |
+|                  | <type-daml-finance-interface-settlement-v4-types-allocation-41200>`           |
+|                  | preference for the instruction (e.g., the matching holding they wish to       |
+|                  | send). The receiver can specify its :ref:`Approval                            |
+|                  | <type-daml-finance-interface-settlement-v4-types-approval-77821>`             |
+|                  | preference for the instruction (e.g., the account they wish to receive        |
+|                  | the holding to).                                                              |
+|                  |                                                                               |
+|                  | The creation of Instructions is done by first using a :ref:`Route Provider    |
+|                  | <type-daml-finance-interface-settlement-v4-routeprovider-routeprovider-29628>`|
+|                  | and then applying a :ref:`Settlement Factory                                  |
+|                  | <module-daml-finance-interface-settlement-v4-factory-85379>`.                 |
+|                  |                                                                               |
++------------------+-------------------------------------------------------------------------------+
+| 3. Allocate and  | For every instruction, the sender and the receiver specify their allocation   |
+|    approve       | and approval preferences, respectively.                                       |
+|    instructions  |                                                                               |
+|                  |                                                                               |
++------------------+-------------------------------------------------------------------------------+
+| 4. Settle the    | A :ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>`      |
+|    batch         | contract is used to settle all instructions atomically according to the       |
+|                  | specified preferences (e.g. by transferring all allocated holdings to the     |
+|                  | corresponding receiving accounts).                                            |
+|                  |                                                                               |
+|                  | This batch contract is created in step 2, together with the settlement        |
+|                  | instructions.                                                                 |
+|                  |                                                                               |
++------------------+-------------------------------------------------------------------------------+
 
 Run the Script
 **************
@@ -72,13 +72,13 @@ The code for this tutorial can be executed via the ``runSettlement`` function in
 
 The first part executes the script from the previous :doc:`Transfer <transfer>` tutorial to arrive
 at the initial state for this scenario. We then create an additional ``TOKEN``
-:ref:`instrument <module-daml-finance-interface-instrument-token-instrument-24425>`
+:ref:`instrument <module-daml-finance-interface-instrument-token-v4-instrument-40238>`
 and credit Alice's account with it.
 
 The interesting part begins once Bob proposes the DvP trade to Alice. Before creating the DvP
 proposal, we need to instantiate two contracts:
 
-1. :ref:`Route Provider <type-daml-finance-interface-settlement-routeprovider-routeprovider-53805>`
+1. :ref:`Route Provider <type-daml-finance-interface-settlement-v4-routeprovider-routeprovider-29628>`
 
    .. literalinclude:: ../../quickstart-finance/daml/Scripts/Settlement.daml
      :language: daml
@@ -86,12 +86,12 @@ proposal, we need to instantiate two contracts:
      :end-before: -- ROUTE_PROVIDER_END
 
    This is used to discover a settlement route, i.e.,
-   :ref:`routed steps <type-daml-finance-interface-settlement-types-routedstep-10086>`, for each
-   settlement :ref:`step <type-daml-finance-interface-settlement-types-step-78661>`. In this
+   :ref:`routed steps <type-daml-finance-interface-settlement-v4-types-routedstep-26293>`, for each
+   settlement :ref:`step <type-daml-finance-interface-settlement-v4-types-step-16302>`. In this
    example, the route provider simply converts each step to a routed step using a single custodian
    (the bank).
 
-2. :ref:`Settlement Factory <module-daml-finance-interface-settlement-factory-75196>`
+2. :ref:`Settlement Factory <module-daml-finance-interface-settlement-v4-factory-85379>`
 
    .. literalinclude:: ../../quickstart-finance/daml/Scripts/Settlement.daml
      :language: daml
@@ -99,7 +99,7 @@ proposal, we need to instantiate two contracts:
      :end-before: -- SETTLEMENT_FACTORY_END
 
    This is used to generate the settlement batch and instructions from the
-   :ref:`routed steps <type-daml-finance-interface-settlement-types-routedstep-10086>`.
+   :ref:`routed steps <type-daml-finance-interface-settlement-v4-types-routedstep-26293>`.
 
 Bob creates a ``Dvp.Proposal`` template to propose the exchange of the ``TOKEN`` against ``USD``.
 
@@ -163,11 +163,11 @@ following happens:
   bank)
 - ``USD 100`` are credited to Alice's account at her bank
 
-A single settlement :ref:`Step <type-daml-finance-interface-settlement-types-step-78661>` requires
-three :ref:`RoutedStep <type-daml-finance-interface-settlement-types-routedstep-10086>`\s to settle.
+A single settlement :ref:`Step <type-daml-finance-interface-settlement-v4-types-step-16302>` requires
+three :ref:`RoutedStep <type-daml-finance-interface-settlement-v4-types-routedstep-26293>`\s to settle.
 
 The same dynamics can be reproduced in Daml with a :ref:`Route Provider
-<type-daml-finance-interface-settlement-routeprovider-routeprovider-53805>` implementation, allowing
+<type-daml-finance-interface-settlement-v4-routeprovider-routeprovider-29628>` implementation, allowing
 for on-ledger intermediated settlement. For example, see the
 :doc:`Intermediated Lifecycling <../advanced-topics/lifecycling/intermediated-lifecycling>`
 tutorial.
@@ -176,21 +176,21 @@ Why do we need a settlement factory?
 ====================================
 
 A settlement factory contract is used to generate settlement
-:ref:`Instructions <module-daml-finance-interface-settlement-instruction-10970>` from
-:ref:`RoutedStep <type-daml-finance-interface-settlement-types-routedstep-10086>`\s.
-It also generates a :ref:`Batch <module-daml-finance-interface-settlement-batch-39188>`
+:ref:`Instructions <module-daml-finance-interface-settlement-v4-instruction-71097>` from
+:ref:`RoutedStep <type-daml-finance-interface-settlement-v4-types-routedstep-26293>`\s.
+It also generates a :ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>`
 contract, which is used to settle instructions atomically.
 
 The reason why the factory is needed has already been introduced in the previous tutorial: it
 provides an interface abstraction, so that your workflow does not need to depend on concrete
-implementations of :ref:`Batch <module-daml-finance-interface-settlement-batch-39188>`
-or :ref:`Instructions <module-daml-finance-interface-settlement-instruction-10970>`.
+implementations of :ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>`
+or :ref:`Instructions <module-daml-finance-interface-settlement-v4-instruction-71097>`.
 
 Can we use a different settler?
 ===============================
 
 In our example, Bob triggers the final settlement of the transaction (by exercising the ``Settle``
-choice on the :ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` contract).
+choice on the :ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` contract).
 
 In principle, a different settler could be chosen. The choice of a settler is usually quite
 delicate, as this party acquires visibility on the entire transaction and hence needs to be trusted.
@@ -199,10 +199,10 @@ What if one party wants to cancel the settlement?
 =================================================
 
 The parties who sign the
-:ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` contract (the instructor and
+:ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` contract (the instructor and
 consenters) can exercise the ``Cancel`` choice of the
-:ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` to cancel all associated
-:ref:`Instructions <module-daml-finance-interface-settlement-instruction-10970>`
+:ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` to cancel all associated
+:ref:`Instructions <module-daml-finance-interface-settlement-v4-instruction-71097>`
 atomically.
 
 Summary

--- a/docs/2.10.0/docs/daml-finance/tutorials/getting-started/transfer.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/getting-started/transfer.rst
@@ -45,16 +45,16 @@ If you look at the implementation of the ``Transfer`` workflow, you will notice 
   :end-before: -- DO_TRANSFER_END
 
 The first line converts the holding contract id (of type
-:ref:`ContractId Holding.I <module-daml-finance-interface-holding-holding-64126>`) to the
-:ref:`Transferable.I <module-daml-finance-interface-holding-transferable-88121>`
+:ref:`ContractId Holding.I <module-daml-finance-interface-holding-v4-holding-20535>`) to the
+:ref:`Transferable.I <module-daml-finance-interface-holding-v4-transferable-93054>`
 interface using ``coerceInterfaceContractId``.
 
 Then, the ``Transfer`` choice, defined as part of the
-:ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`
+:ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`
 interface, is exercised.
 
 Finally, the new holding is converted back to a
-:ref:`Holding.I <module-daml-finance-interface-holding-holding-64126>`
+:ref:`Holding.I <module-daml-finance-interface-holding-v4-holding-20535>`
 before it is returned. This is done using ``toInterfaceContractId``.
 
 In order to fully understand these instructions, we need to keep in mind the interface hierarchy
@@ -67,17 +67,17 @@ used by our holding implementation.
         "requires".
 
 We use ``coerceInterfaceContractId`` to convert the
-:ref:`Holding.I <module-daml-finance-interface-holding-holding-64126>`
-to a :ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`.
+:ref:`Holding.I <module-daml-finance-interface-holding-v4-holding-20535>`
+to a :ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`.
 The success of this operation is not guaranteed and will result in a run-time error if the holding
 implementation at hand does not implement
-:ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`.
+:ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`.
 
 We use ``toInterfaceContractId`` to convert back to a
-:ref:`Holding <module-daml-finance-interface-holding-holding-64126>`.
+:ref:`Holding <module-daml-finance-interface-holding-v4-holding-20535>`.
 This is because all
-:ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`\ s
-implement the :ref:`Holding.I <module-daml-finance-interface-holding-holding-64126>`
+:ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`\ s
+implement the :ref:`Holding.I <module-daml-finance-interface-holding-v4-holding-20535>`
 interface, so the validity of this operation is guaranteed at compile-time.
 
 Why is Alice an observer on Bob’s account?
@@ -106,18 +106,18 @@ right amount, because the transfer would otherwise fail. We want the transfer to
 if Alice allocates a holding for a larger amount e.g., ``USD 1500``.
 
 We can leverage the fact that the holding implements the
-:ref:`Fungible <module-daml-finance-interface-holding-fungible-63712>`
+:ref:`Fungible <module-daml-finance-interface-holding-v4-fungible-55495>`
 interface, which makes it possible to ``Split`` it into a holding of ``USD 1000`` and one of
 ``USD 500``. In the implementation of the ``CashTransferRequest_Accept`` choice:
 
 - cast the allocated holding to the :ref:`Fungible
-  <module-daml-finance-interface-holding-fungible-63712>` interface
+  <module-daml-finance-interface-holding-v4-fungible-55495>` interface
 - use the ``Split`` choice to split the larger holding into two holdings
 - execute the transfer, allocating the holding with the correct amount
 
 In the last step, you will need to cast the
-:ref:`Fungible <module-daml-finance-interface-holding-fungible-63712>` to a
-:ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`
+:ref:`Fungible <module-daml-finance-interface-holding-v4-fungible-55495>` to a
+:ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`
 using ``toInterfaceContractId``.
 
 Temporary Account Disclosure
@@ -132,13 +132,13 @@ Modify the original code, such that:
 - When the Transfer is executed, Alice removes herself from the account observers
 
 In order to do that, you can leverage the fact that
-:ref:`Account <module-daml-finance-account-account-19369>`
+:ref:`Account <module-daml-finance-account-v4-account-5834>`
 implements the
-:ref:`Disclosure <module-daml-finance-interface-util-disclosure-87755>`
+:ref:`Disclosure <module-daml-finance-interface-util-v3-disclosure-50779>`
 interface. This interface exposes the ``AddObservers`` and ``RemoveObservers`` choices, which can be
 used to disclose / undisclose Bob's account contract to Alice. In order to exercise these choices,
 you can use the :ref:`Account.exerciseInterfaceByKey
-<function-daml-finance-interface-account-account-exerciseinterfacebykey-13671>` utility function.
+<function-daml-finance-interface-account-v4-account-exerciseinterfacebykey-87310>` utility function.
 
 Summary
 *******

--- a/docs/2.10.0/docs/daml-finance/tutorials/lifecycling/callable-bond.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/lifecycling/callable-bond.rst
@@ -32,9 +32,9 @@ Instrument and Holding
 ======================
 
 In order to demonstrate the
-:ref:`Election <module-daml-finance-interface-lifecycle-election-24570>` concept, we need a suitable
+:ref:`Election <module-daml-finance-interface-lifecycle-v4-election-15483>` concept, we need a suitable
 sample instrument.
-:ref:`Callable bonds <module-daml-finance-instrument-bond-callable-instrument-83330>` pay coupons as
+:ref:`Callable bonds <module-daml-finance-instrument-bond-v3-callable-instrument-35206>` pay coupons as
 long as the bond has not been called by the issuer.
 The :doc:`Bond Instrument packages <../../instruments/bond>` page describes this
 instrument in more detail. Here, we briefly show how to create the bond instrument using a factory:
@@ -67,7 +67,7 @@ We start by creating an Election factory, which can be used to create elections:
   :start-after: -- CREATE_ELECTION_FACTORY_BEGIN
   :end-before: -- CREATE_ELECTION_FACTORY_END
 
-An :ref:`Election <module-daml-finance-interface-lifecycle-election-24570>` contains three main
+An :ref:`Election <module-daml-finance-interface-lifecycle-v4-election-15483>` contains three main
 pieces of information:
 
 - the election tag (e.g. "CALLED")
@@ -101,7 +101,7 @@ In order to lifecycle the coupon payment above, we need a lifecycle rule that de
 all election events. The lifecycle rule from the previous tutorial can be reused for this, if we
 first convert it to an ``Election.Exercisable``, as described above.
 
-A :ref:`Claim Rule <module-daml-finance-lifecycle-rule-claim-99318>` allows the elector to claim the
+A :ref:`Claim Rule <module-daml-finance-lifecycle-v4-rule-claim-11721>` allows the elector to claim the
 effect resulting from the election event:
 
 .. literalinclude:: ../../finance-lifecycling/daml/Scripts/CallableBond.daml

--- a/docs/2.10.0/docs/daml-finance/tutorials/lifecycling/callable-bond.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/lifecycling/callable-bond.rst
@@ -67,7 +67,6 @@ We start by creating an Election factory, which can be used to create elections:
   :start-after: -- CREATE_ELECTION_FACTORY_BEGIN
   :end-before: -- CREATE_ELECTION_FACTORY_END
 
-
 An :ref:`Election <module-daml-finance-interface-lifecycle-election-24570>` contains three main
 pieces of information:
 

--- a/docs/2.10.0/docs/daml-finance/tutorials/lifecycling/fixed-rate-bond.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/lifecycling/fixed-rate-bond.rst
@@ -43,7 +43,7 @@ Instrument and Holding
 ======================
 
 For the purpose of showcasing time-based lifecycling, we need a suitable sample instrument.
-:ref:`Fixed rate bonds <module-daml-finance-instrument-bond-fixedrate-instrument-67993>`
+:ref:`Fixed rate bonds <module-daml-finance-instrument-bond-v3-fixedrate-instrument-89221>`
 pay a constant coupon rate at the end of each coupon period. The
 :doc:`Bond Instrument packages <../../instruments/bond>` page describes this instrument
 in more detail. Here, we briefly show how to create the bond instrument using a factory:
@@ -87,9 +87,9 @@ first coupon:
   :end-before: -- CREATE_CLOCK_UPDATE_EVENT_END
 
 Note that it is the bank that actively creates a
-:ref:`DateClockUpdateEvent <module-daml-finance-data-time-dateclockupdate-48859>`.
+:ref:`DateClockUpdateEvent <module-daml-finance-data-v4-time-dateclockupdate-59678>`.
 This results in more control when to actually process the coupon payment. One could also use
-:ref:`LedgerTime <module-daml-finance-data-time-ledgertime-84639>`,
+:ref:`LedgerTime <module-daml-finance-data-v4-time-ledgertime-80144>`,
 but that could cause problems in some scenarios, for example:
 
 - The system is down when the coupon should be processed. Processing it the next day is difficult if
@@ -108,16 +108,16 @@ rule is exercised to process the time event:
   :start-after: -- LIFECYCLE_BOND_BEGIN
   :end-before: -- LIFECYCLE_BOND_END
 
-Both the :ref:`LedgerTime <module-daml-finance-data-time-ledgertime-84639>` and the
-:ref:`DateClock <module-daml-finance-data-time-dateclock-65212>` implement the
-:ref:`TimeObservable <module-daml-finance-interface-lifecycle-observable-timeobservable-45971>`
+Both the :ref:`LedgerTime <module-daml-finance-data-v4-time-ledgertime-80144>` and the
+:ref:`DateClock <module-daml-finance-data-v4-time-dateclock-1389>` implement the
+:ref:`TimeObservable <module-daml-finance-interface-lifecycle-v4-observable-timeobservable-64296>`
 interface, which is used by ``Evolve`` to specify the current time for the lifecycling.
 
 The result of this is an effect describing the per-unit asset movements to be executed for bond
 holders. Each holder can now present their holding to *claim* the effect and instruct settlement of
 the associated entitlements.
 
-A :ref:`Claim Rule <module-daml-finance-lifecycle-rule-claim-99318>` allows a holder of the
+A :ref:`Claim Rule <module-daml-finance-lifecycle-v4-rule-claim-11721>` allows a holder of the
 target instrument to claim the effect resulting from the time event:
 
 .. literalinclude:: ../../finance-lifecycling/daml/Scripts/FixedRateBond.daml

--- a/docs/2.10.0/docs/daml-finance/tutorials/lifecycling/floating-rate-bond.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/lifecycling/floating-rate-bond.rst
@@ -30,9 +30,9 @@ Instrument and Holding
 ======================
 
 For the purpose of showcasing the
-:ref:`Observation <module-daml-finance-data-numeric-observation-78761>` concept,
+:ref:`Observation <module-daml-finance-data-v4-numeric-observation-19522>` concept,
 we need a suitable sample instrument.
-:ref:`Floating rate bonds <module-daml-finance-instrument-bond-floatingrate-instrument-98586>`
+:ref:`Floating rate bonds <module-daml-finance-instrument-bond-v3-floatingrate-instrument-82370>`
 pay a coupon which is determined by a reference rate, e.g. 3M Libor. The
 :doc:`Bond Instrument packages <../../instruments/bond>` page describes this instrument
 in more detail. Here, we briefly show how to create the bond instrument using a factory:
@@ -58,7 +58,7 @@ Now, we have both an instrument definition and a holding. Let us proceed to life
 Lifecycle Events and Rule
 =========================
 
-An :ref:`Observation <module-daml-finance-data-numeric-observation-78761>` of a reference rate
+An :ref:`Observation <module-daml-finance-data-v4-numeric-observation-19522>` of a reference rate
 contains two pieces of information: the interest rate level and the date to which it applies. The
 rate level can be positive or negative. In our example, we have a negative interest rate:
 
@@ -68,8 +68,8 @@ rate level can be positive or negative. In our example, we have a negative inter
   :end-before: -- CREATE_FLOATING_RATE_OBSERVATIONS_END
 
 In our case, the bank then creates the observation on the ledger.
-The :ref:`Observation <module-daml-finance-data-numeric-observation-78761>` implements the
-:ref:`NumericObservable <module-daml-finance-interface-lifecycle-observable-numericobservable-67288>`
+The :ref:`Observation <module-daml-finance-data-v4-numeric-observation-19522>` implements the
+:ref:`NumericObservable <module-daml-finance-interface-lifecycle-v4-observable-numericobservable-50817>`
 interface, which is used during lifecycling.
 
 In order to lifecycle a coupon payment, we need a lifecycle rule that defines how to process all

--- a/docs/2.10.0/docs/daml-finance/tutorials/settlement/internal.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/settlement/internal.rst
@@ -21,15 +21,15 @@ Understanding Internal Settlement with Examples
 
 To start, let us briefly revisit the settlement process which was explained in the
 :doc:`Settlement <../../concepts/settlement>` section.
-A :ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` consists of one or
-more :ref:`Instructions <module-daml-finance-interface-settlement-instruction-10970>`.
+A :ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` consists of one or
+more :ref:`Instructions <module-daml-finance-interface-settlement-v4-instruction-71097>`.
 Each instruction signifies a
-:ref:`RoutedStep <type-daml-finance-interface-settlement-types-routedstep-10086>`, delineating the
+:ref:`RoutedStep <type-daml-finance-interface-settlement-v4-types-routedstep-26293>`, delineating the
 quantity of an instrument to be transferred from a sender to a receiver at a specific custodian. For
 an instruction to be prepared for settlement (or execution), the sender-side must furnish an
-:ref:`Allocation <type-daml-finance-interface-settlement-types-allocation-46483>`, and the
+:ref:`Allocation <type-daml-finance-interface-settlement-v4-types-allocation-41200>`, and the
 receiver-side must provide an
-:ref:`Approval <type-daml-finance-interface-settlement-types-approval-84286>`.
+:ref:`Approval <type-daml-finance-interface-settlement-v4-types-approval-77821>`.
 
 This tutorial will walk you through three example scripts for settling instructions at a single
 custodian: ``runWrappedTransferSettlement``, ``runCreditDebitSettlement``, and

--- a/docs/2.10.0/docs/daml-finance/tutorials/settlement/transfer.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/settlement/transfer.rst
@@ -25,7 +25,7 @@ transfers (credits) and outgoing transfers (debits) of holdings to an account.
 Configuring Account Controllers
 *******************************
 
-The :ref:`Controllers <type-daml-finance-interface-account-account-controllers-36430>` data type
+The :ref:`Controllers <type-daml-finance-interface-account-v4-account-controllers-59817>` data type
 specifies the parties that need to authorize incoming and outgoing transfers to an account.
 
 For this tutorial, we provide four example scripts illustrating various incoming and outgoing

--- a/docs/2.10.0/docs/daml-finance/tutorials/upgrade/account.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/upgrade/account.rst
@@ -5,24 +5,24 @@ Account Upgrade
 ###############
 
 This tutorial presents a scenario where a custodian offers its clients the option to *voluntarily*
-upgrade their "old" :ref:`Account <module-daml-finance-account-account-19369>` contracts to a
+upgrade their "old" :ref:`Account <module-daml-finance-account-v4-account-5834>` contracts to a
 "new" version. The focus is on demonstrating the process of such a voluntary upgrade.
 
 We are going to:
 
 #. Introduce ``MyAccount``, a custom account implementation for the custodian. It differs from
-   the standard Daml Finance :ref:`Account <module-daml-finance-account-account-19369>`
+   the standard Daml Finance :ref:`Account <module-daml-finance-account-v4-account-5834>`
    implementation in that it does not implement the
-   :ref:`Lockable <module-daml-finance-interface-util-lockable-80915>`
+   :ref:`Lockable <module-daml-finance-interface-util-v3-lockable-20339>`
    interface, making it a non-freezable account.
 #. Prevent the custodian from creating old
-   :ref:`Account <module-daml-finance-account-account-19369>` instances, by archiving its
+   :ref:`Account <module-daml-finance-account-v4-account-5834>` instances, by archiving its
    existing
-   :ref:`AccountFactory <module-daml-finance-account-account-19369>`.
+   :ref:`AccountFactory <module-daml-finance-account-v4-account-5834>`.
 #. Instantiate a new account factory, ``MyAccountFactory``, which can create ``MyAccount``
    instances.
 #. Provide a ``MyAccountUpgradeRule`` instance for clients, permitting them to upgrade their
-   existing :ref:`Account <module-daml-finance-account-account-19369>` instances to new
+   existing :ref:`Account <module-daml-finance-account-v4-account-5834>` instances to new
    ``MyAccount`` instances.
 #. Upgrade the accounts for the clients.
 

--- a/docs/2.10.0/docs/daml-finance/tutorials/upgrade/holding.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/upgrade/holding.rst
@@ -11,10 +11,10 @@ manner. Specifically, the upgrade occurs seamlessly during a client's transfer a
 We are going to:
 
 #. Introduce a new holding implementation, ``MyTransferable``, which extends the Daml Finance
-   :ref:`Transferable <module-daml-finance-holding-transferable-43388>` holding
+   :ref:`Transferable <module-daml-finance-holding-v4-transferable-38649>` holding
    implementation. This new implementation differs in that it creates a
    ``MyTransferableTransferEvent`` contract instance with each transfer.
-#. Replace the existing :ref:`HoldingFactory <module-daml-finance-holding-factory-11188>`
+#. Replace the existing :ref:`HoldingFactory <module-daml-finance-holding-v4-factory-50391>`
    instance of the custodian with a new, compatible ``MyHoldingFactory`` for the ``MyTransferable``
    holding implementation.
 #. Demonstrate that an upgrade happens upon a transfer of an old holding.

--- a/docs/2.10.0/docs/daml-finance/tutorials/upgrade/intro.rst
+++ b/docs/2.10.0/docs/daml-finance/tutorials/upgrade/intro.rst
@@ -28,9 +28,9 @@ We offer the following tutorials to guide you through the upgrade process:
 
 * :doc:`Holding Upgrade Tutorial <holding>`:
   Here, we walk you through a scenario where a custodian upgrades the
-  :ref:`Transferable <module-daml-finance-holding-transferable-43388>` holding
+  :ref:`Transferable <module-daml-finance-holding-v4-transferable-38649>` holding
   implementation to a custom, enhanced version, and its
-  :ref:`HoldingFactory <module-daml-finance-holding-factory-11188>` accordingly. As a result,
+  :ref:`HoldingFactory <module-daml-finance-holding-v4-factory-50391>` accordingly. As a result,
   existing holding instances (of the :ref:`Transferable <holding-standards>` holding standard) will
   be automatically upgraded to the new version during the next transfer. This serves as a practical
   example of a mandatory upgrade carried out in a lazy manner.

--- a/docs/2.10.0/versions.json
+++ b/docs/2.10.0/versions.json
@@ -1,6 +1,6 @@
 {
   "daml": "2.10.0-snapshot.20241113.13071.0.vf716891b",
   "canton": "2.10.0-adhoc.20241120.12348.0.ve0fbd745",
-  "daml_finance": "1.5.0",
+  "daml_finance": "1.6.0",
   "canton_drivers": "2.10.0-snapshot.20240708.12144.0.v22fb89b5"
 }

--- a/docs/2.8.11/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
+++ b/docs/2.8.11/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
@@ -4,10 +4,6 @@
 Daml.Finance.Interface.Data - Changelog
 #######################################
 
-- Update of SDK version and dependencies.
-
-- Added new day-count conventions: Act365NL, Basis30365, and Basis30E2360.
-
 Version 3.1.0
 *************
 

--- a/docs/2.9.5/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
+++ b/docs/2.9.5/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
@@ -4,10 +4,6 @@
 Daml.Finance.Interface.Data - Changelog
 #######################################
 
-- Update of SDK version and dependencies.
-
-- Added new day-count conventions: Act365NL, Basis30365, and Basis30E2360.
-
 Version 3.1.0
 *************
 

--- a/docs/3.1/_toc.yml
+++ b/docs/3.1/_toc.yml
@@ -353,7 +353,7 @@ subtrees:
           maxdepth: 1
           entries:
           - file: daml-finance/packages/interfaces/daml-finance-interface-holding
-            title: "Daml.Finance.Interface.Holding"
+            title: "Daml.Finance.Interface.Holding.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -362,7 +362,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-holding.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-account
-            title: "Daml.Finance.Interface.Account"
+            title: "Daml.Finance.Interface.Account.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -371,7 +371,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-account.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-settlement
-            title: "Daml.Finance.Interface.Settlement"
+            title: "Daml.Finance.Interface.Settlement.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -380,7 +380,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-settlement.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-lifecycle
-            title: "Daml.Finance.Interface.Lifecycle"
+            title: "Daml.Finance.Interface.Lifecycle.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -389,7 +389,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-lifecycle.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-base
-            title: "Daml.Finance.Interface.Instrument.Base"
+            title: "Daml.Finance.Interface.Instrument.Base.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -398,7 +398,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-base.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-claims
-            title: "Daml.Finance.Interface.Claims"
+            title: "Daml.Finance.Interface.Claims.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -407,7 +407,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-claims.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-data
-            title: "Daml.Finance.Interface.Data"
+            title: "Daml.Finance.Interface.Data.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -416,7 +416,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-types-common
-            title: "Daml.Finance.Interface.Types.Common"
+            title: "Daml.Finance.Interface.Types.Common.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -425,7 +425,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-common.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-types-date
-            title: "Daml.Finance.Interface.Types.Date"
+            title: "Daml.Finance.Interface.Types.Date.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -434,7 +434,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-date.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-util
-            title: "Daml.Finance.Interface.Util"
+            title: "Daml.Finance.Interface.Util.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -443,7 +443,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-util.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/contingent-claims-core
-            title: "ContingentClaims.Core"
+            title: "ContingentClaims.Core.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -452,7 +452,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/contingent-claims-core.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-bond
-            title: "Daml.Finance.Interface.Instrument.Bond"
+            title: "Daml.Finance.Interface.Instrument.Bond.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -461,7 +461,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-bond.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-equity
-            title: "Daml.Finance.Interface.Instrument.Equity"
+            title: "Daml.Finance.Interface.Instrument.Equity.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -470,7 +470,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-equity.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-generic
-            title: "Daml.Finance.Interface.Instrument.Generic"
+            title: "Daml.Finance.Interface.Instrument.Generic.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -479,7 +479,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-generic.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-option
-            title: "Daml.Finance.Interface.Instrument.Option"
+            title: "Daml.Finance.Interface.Instrument.Option.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -488,7 +488,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-option.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-structuredproduct
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct"
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -497,7 +497,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-structuredproduct.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-swap
-            title: "Daml.Finance.Interface.Instrument.Swap"
+            title: "Daml.Finance.Interface.Instrument.Swap.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -506,7 +506,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-swap.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-token
-            title: "Daml.Finance.Interface.Instrument.Token"
+            title: "Daml.Finance.Interface.Instrument.Token.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -515,7 +515,7 @@ subtrees:
               - file: daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-token.rst
                 title: "Changelog"
           - file: daml-finance/packages/interfaces/daml-finance-interface-instrument-types
-            title: "Daml.Finance.Interface.Instrument.Types"
+            title: "Daml.Finance.Interface.Instrument.Types.V2"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -531,7 +531,7 @@ subtrees:
           maxdepth: 1
           entries:
           - file: daml-finance/packages/implementations/daml-finance-holding
-            title: "Daml.Finance.Holding"
+            title: "Daml.Finance.Holding.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -540,7 +540,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-holding.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-account
-            title: "Daml.Finance.Account"
+            title: "Daml.Finance.Account.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -549,7 +549,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-account.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-settlement
-            title: "Daml.Finance.Settlement"
+            title: "Daml.Finance.Settlement.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -558,7 +558,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-settlement.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-lifecycle
-            title: "Daml.Finance.Lifecycle"
+            title: "Daml.Finance.Lifecycle.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -567,7 +567,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-lifecycle.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-data
-            title: "Daml.Finance.Data"
+            title: "Daml.Finance.Data.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -576,7 +576,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-data.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-claims
-            title: "Daml.Finance.Claims"
+            title: "Daml.Finance.Claims.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -585,7 +585,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-claims.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-util
-            title: "Daml.Finance.Util"
+            title: "Daml.Finance.Util.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -594,7 +594,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-util.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/contingent-claims-lifecycle
-            title: "ContingentClaims.Lifecycle"
+            title: "ContingentClaims.Lifecycle.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -603,7 +603,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/contingent-claims-lifecycle.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/contingent-claims-valuation
-            title: "ContingentClaims.Valuation"
+            title: "ContingentClaims.Valuation.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -612,7 +612,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/contingent-claims-valuation.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-instrument-bond
-            title: "Daml.Finance.Instrument.Bond"
+            title: "Daml.Finance.Instrument.Bond.V3"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -621,7 +621,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-instrument-bond.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-instrument-equity
-            title: "Daml.Finance.Instrument.Equity"
+            title: "Daml.Finance.Instrument.Equity.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -630,7 +630,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-instrument-equity.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-instrument-generic
-            title: "Daml.Finance.Instrument.Generic"
+            title: "Daml.Finance.Instrument.Generic.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -639,7 +639,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-instrument-generic.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-instrument-option
-            title: "Daml.Finance.Instrument.Option"
+            title: "Daml.Finance.Instrument.Option.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -648,7 +648,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-instrument-option.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-instrument-structuredproduct
-            title: "Daml.Finance.Instrument.StructuredProduct"
+            title: "Daml.Finance.Instrument.StructuredProduct.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -657,7 +657,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-instrument-structuredproduct.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-instrument-swap
-            title: "Daml.Finance.Instrument.Swap"
+            title: "Daml.Finance.Instrument.Swap.V1"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -666,7 +666,7 @@ subtrees:
               - file: daml-finance/packages/implementations/changelogs/daml-finance-instrument-swap.rst
                 title: "Changelog"
           - file: daml-finance/packages/implementations/daml-finance-instrument-token
-            title: "Daml.Finance.Instrument.Token"
+            title: "Daml.Finance.Instrument.Token.V4"
             subtrees:
             - hidden: False
               titlesonly: True
@@ -750,410 +750,410 @@ subtrees:
           titlesonly: True
           maxdepth: 3
           entries:
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Builders
-            title: "ContingentClaims.Core.Builders"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Claim
-            title: "ContingentClaims.Core.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Internal-Claim
-            title: "ContingentClaims.Core.Internal.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Observation
-            title: "ContingentClaims.Core.Observation"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-Util-Recursion
-            title: "ContingentClaims.Core.Util.Recursion"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Lifecycle-Lifecycle
-            title: "ContingentClaims.Lifecycle.Lifecycle"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Lifecycle-Util
-            title: "ContingentClaims.Lifecycle.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Valuation-MathML
-            title: "ContingentClaims.Valuation.MathML"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Valuation-Stochastic
-            title: "ContingentClaims.Valuation.Stochastic"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Account-Account
-            title: "Daml.Finance.Account.Account"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Lifecycle-Rule
-            title: "Daml.Finance.Claims.Lifecycle.Rule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Util
-            title: "Daml.Finance.Claims.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Util-Builders
-            title: "Daml.Finance.Claims.Util.Builders"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Util-Date
-            title: "Daml.Finance.Claims.Util.Date"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-Util-Lifecycle
-            title: "Daml.Finance.Claims.Util.Lifecycle"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Numeric-Observation
-            title: "Daml.Finance.Data.Numeric.Observation"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Reference-HolidayCalendar
-            title: "Daml.Finance.Data.Reference.HolidayCalendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-DateClock
-            title: "Daml.Finance.Data.Time.DateClock"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-DateClock-Types
-            title: "Daml.Finance.Data.Time.DateClock.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-DateClockUpdate
-            title: "Daml.Finance.Data.Time.DateClockUpdate"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-Time-LedgerTime
-            title: "Daml.Finance.Data.Time.LedgerTime"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-BaseHolding
-            title: "Daml.Finance.Holding.BaseHolding"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-Factory
-            title: "Daml.Finance.Holding.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-Fungible
-            title: "Daml.Finance.Holding.Fungible"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-Transferable
-            title: "Daml.Finance.Holding.Transferable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-TransferableFungible
-            title: "Daml.Finance.Holding.TransferableFungible"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-Util
-            title: "Daml.Finance.Holding.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-Callable-Factory
-            title: "Daml.Finance.Instrument.Bond.Callable.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-Callable-Instrument
-            title: "Daml.Finance.Instrument.Bond.Callable.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FixedRate-Factory
-            title: "Daml.Finance.Instrument.Bond.FixedRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FixedRate-Instrument
-            title: "Daml.Finance.Instrument.Bond.FixedRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FloatingRate-Factory
-            title: "Daml.Finance.Instrument.Bond.FloatingRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-FloatingRate-Instrument
-            title: "Daml.Finance.Instrument.Bond.FloatingRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-InflationLinked-Factory
-            title: "Daml.Finance.Instrument.Bond.InflationLinked.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-InflationLinked-Instrument
-            title: "Daml.Finance.Instrument.Bond.InflationLinked.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-Util
-            title: "Daml.Finance.Instrument.Bond.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-ZeroCoupon-Factory
-            title: "Daml.Finance.Instrument.Bond.ZeroCoupon.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-ZeroCoupon-Instrument
-            title: "Daml.Finance.Instrument.Bond.ZeroCoupon.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Equity-Factory
-            title: "Daml.Finance.Instrument.Equity.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Equity-Instrument
-            title: "Daml.Finance.Instrument.Equity.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-Factory
-            title: "Daml.Finance.Instrument.Generic.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-Instrument
-            title: "Daml.Finance.Instrument.Generic.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-Lifecycle-Rule
-            title: "Daml.Finance.Instrument.Generic.Lifecycle.Rule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-BarrierEuropeanCash-Factory
-            title: "Daml.Finance.Instrument.Option.BarrierEuropeanCash.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-BarrierEuropeanCash-Instrument
-            title: "Daml.Finance.Instrument.Option.BarrierEuropeanCash.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-Dividend-Factory
-            title: "Daml.Finance.Instrument.Option.Dividend.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-Dividend-Instrument
-            title: "Daml.Finance.Instrument.Option.Dividend.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-Dividend-Election
-            title: "Daml.Finance.Instrument.Option.Dividend.Election"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-EuropeanCash-Factory
-            title: "Daml.Finance.Instrument.Option.EuropeanCash.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-EuropeanCash-Instrument
-            title: "Daml.Finance.Instrument.Option.EuropeanCash.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-EuropeanPhysical-Factory
-            title: "Daml.Finance.Instrument.Option.EuropeanPhysical.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-EuropeanPhysical-Instrument
-            title: "Daml.Finance.Instrument.Option.EuropeanPhysical.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-AutoCallable-Factory
-            title: "Daml.Finance.Instrument.StructuredProduct.AutoCallable.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-AutoCallable-Instrument
-            title: "Daml.Finance.Instrument.StructuredProduct.AutoCallable.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-BarrierReverseConvertible-Factory
-            title: "Daml.Finance.Instrument.StructuredProduct.BarrierReverseConvertible.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-BarrierReverseConvertible-Instrument
-            title: "Daml.Finance.Instrument.StructuredProduct.BarrierReverseConvertible.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-Util
-            title: "Daml.Finance.Instrument.StructuredProduct.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Asset-Factory
-            title: "Daml.Finance.Instrument.Swap.Asset.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Asset-Instrument
-            title: "Daml.Finance.Instrument.Swap.Asset.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Asset-DistributionRule
-            title: "Daml.Finance.Instrument.Swap.Asset.DistributionRule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-CreditDefault-Factory
-            title: "Daml.Finance.Instrument.Swap.CreditDefault.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-CreditDefault-Instrument
-            title: "Daml.Finance.Instrument.Swap.CreditDefault.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Currency-Factory
-            title: "Daml.Finance.Instrument.Swap.Currency.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Currency-Instrument
-            title: "Daml.Finance.Instrument.Swap.Currency.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-ForeignExchange-Factory
-            title: "Daml.Finance.Instrument.Swap.ForeignExchange.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-ForeignExchange-Instrument
-            title: "Daml.Finance.Instrument.Swap.ForeignExchange.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Fpml-Factory
-            title: "Daml.Finance.Instrument.Swap.Fpml.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Fpml-Instrument
-            title: "Daml.Finance.Instrument.Swap.Fpml.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-Fpml-Util
-            title: "Daml.Finance.Instrument.Swap.Fpml.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-InterestRate-Factory
-            title: "Daml.Finance.Instrument.Swap.InterestRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-InterestRate-Instrument
-            title: "Daml.Finance.Instrument.Swap.InterestRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Token-Factory
-            title: "Daml.Finance.Instrument.Token.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Token-Instrument
-            title: "Daml.Finance.Instrument.Token.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-Account
-            title: "Daml.Finance.Interface.Account.Account"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-Factory
-            title: "Daml.Finance.Interface.Account.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-Util
-            title: "Daml.Finance.Interface.Account.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-Claim
-            title: "Daml.Finance.Interface.Claims.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-Dynamic-Instrument
-            title: "Daml.Finance.Interface.Claims.Dynamic.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-Types
-            title: "Daml.Finance.Interface.Claims.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Numeric-Observation
-            title: "Daml.Finance.Interface.Data.Numeric.Observation"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Numeric-Observation-Factory
-            title: "Daml.Finance.Interface.Data.Numeric.Observation.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Reference-HolidayCalendar
-            title: "Daml.Finance.Interface.Data.Reference.HolidayCalendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Reference-HolidayCalendar-Factory
-            title: "Daml.Finance.Interface.Data.Reference.HolidayCalendar.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-Reference-Time
-            title: "Daml.Finance.Interface.Data.Reference.Time"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Factory
-            title: "Daml.Finance.Interface.Holding.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Fungible
-            title: "Daml.Finance.Interface.Holding.Fungible"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Holding
-            title: "Daml.Finance.Interface.Holding.Holding"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Transferable
-            title: "Daml.Finance.Interface.Holding.Transferable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-Util
-            title: "Daml.Finance.Interface.Holding.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Base-Instrument
-            title: "Daml.Finance.Interface.Instrument.Base.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-Callable-Factory
-            title: "Daml.Finance.Interface.Instrument.Bond.Callable.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-Callable-Instrument
-            title: "Daml.Finance.Interface.Instrument.Bond.Callable.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-Callable-Types
-            title: "Daml.Finance.Interface.Instrument.Bond.Callable.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FixedRate-Factory
-            title: "Daml.Finance.Interface.Instrument.Bond.FixedRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FixedRate-Instrument
-            title: "Daml.Finance.Interface.Instrument.Bond.FixedRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FixedRate-Types
-            title: "Daml.Finance.Interface.Instrument.Bond.FixedRate.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Factory
-            title: "Daml.Finance.Interface.Instrument.Bond.FloatingRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Instrument
-            title: "Daml.Finance.Interface.Instrument.Bond.FloatingRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-FloatingRate-Types
-            title: "Daml.Finance.Interface.Instrument.Bond.FloatingRate.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Factory
-            title: "Daml.Finance.Interface.Instrument.Bond.InflationLinked.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Instrument
-            title: "Daml.Finance.Interface.Instrument.Bond.InflationLinked.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-InflationLinked-Types
-            title: "Daml.Finance.Interface.Instrument.Bond.InflationLinked.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Factory
-            title: "Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Instrument
-            title: "Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-ZeroCoupon-Types
-            title: "Daml.Finance.Interface.Instrument.Bond.ZeroCoupon.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Equity-Factory
-            title: "Daml.Finance.Interface.Instrument.Equity.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Equity-Instrument
-            title: "Daml.Finance.Interface.Instrument.Equity.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-Factory
-            title: "Daml.Finance.Interface.Instrument.Generic.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-Instrument
-            title: "Daml.Finance.Interface.Instrument.Generic.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-BarrierEuropeanCash-Factory
-            title: "Daml.Finance.Interface.Instrument.Option.BarrierEuropeanCash.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-BarrierEuropeanCash-Instrument
-            title: "Daml.Finance.Interface.Instrument.Option.BarrierEuropeanCash.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-BarrierEuropeanCash-Types
-            title: "Daml.Finance.Interface.Instrument.Option.BarrierEuropeanCash.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-Dividend-Factory
-            title: "Daml.Finance.Interface.Instrument.Option.Dividend.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-Dividend-Instrument
-            title: "Daml.Finance.Interface.Instrument.Option.Dividend.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-Dividend-Types
-            title: "Daml.Finance.Interface.Instrument.Option.Dividend.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-Dividend-Election-Factory
-            title: "Daml.Finance.Interface.Instrument.Option.Dividend.Election.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-EuropeanCash-Factory
-            title: "Daml.Finance.Interface.Instrument.Option.EuropeanCash.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-EuropeanCash-Instrument
-            title: "Daml.Finance.Interface.Instrument.Option.EuropeanCash.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-EuropeanCash-Types
-            title: "Daml.Finance.Interface.Instrument.Option.EuropeanCash.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-EuropeanPhysical-Factory
-            title: "Daml.Finance.Interface.Instrument.Option.EuropeanPhysical.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-EuropeanPhysical-Instrument
-            title: "Daml.Finance.Interface.Instrument.Option.EuropeanPhysical.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-EuropeanPhysical-Types
-            title: "Daml.Finance.Interface.Instrument.Option.EuropeanPhysical.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-Types
-            title: "Daml.Finance.Interface.Instrument.Option.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-AutoCallable-Factory
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct.AutoCallable.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-AutoCallable-Instrument
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct.AutoCallable.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-AutoCallable-Types
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct.AutoCallable.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-BarrierReverseConvertible-Factory
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvertible.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-BarrierReverseConvertible-Instrument
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvertible.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-BarrierReverseConvertible-Types
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct.BarrierReverseConvertible.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-Types
-            title: "Daml.Finance.Interface.Instrument.StructuredProduct.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Asset-Factory
-            title: "Daml.Finance.Interface.Instrument.Swap.Asset.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Asset-Instrument
-            title: "Daml.Finance.Interface.Instrument.Swap.Asset.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Asset-Types
-            title: "Daml.Finance.Interface.Instrument.Swap.Asset.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Factory
-            title: "Daml.Finance.Interface.Instrument.Swap.CreditDefault.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Instrument
-            title: "Daml.Finance.Interface.Instrument.Swap.CreditDefault.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-CreditDefault-Types
-            title: "Daml.Finance.Interface.Instrument.Swap.CreditDefault.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Currency-Factory
-            title: "Daml.Finance.Interface.Instrument.Swap.Currency.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Currency-Instrument
-            title: "Daml.Finance.Interface.Instrument.Swap.Currency.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Currency-Types
-            title: "Daml.Finance.Interface.Instrument.Swap.Currency.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Factory
-            title: "Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Instrument
-            title: "Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-ForeignExchange-Types
-            title: "Daml.Finance.Interface.Instrument.Swap.ForeignExchange.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-Factory
-            title: "Daml.Finance.Interface.Instrument.Swap.Fpml.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-FpmlTypes
-            title: "Daml.Finance.Interface.Instrument.Swap.Fpml.FpmlTypes"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-Instrument
-            title: "Daml.Finance.Interface.Instrument.Swap.Fpml.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-Fpml-Types
-            title: "Daml.Finance.Interface.Instrument.Swap.Fpml.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-InterestRate-Factory
-            title: "Daml.Finance.Interface.Instrument.Swap.InterestRate.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-InterestRate-Instrument
-            title: "Daml.Finance.Interface.Instrument.Swap.InterestRate.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-InterestRate-Types
-            title: "Daml.Finance.Interface.Instrument.Swap.InterestRate.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-Factory
-            title: "Daml.Finance.Interface.Instrument.Token.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-Instrument
-            title: "Daml.Finance.Interface.Instrument.Token.Instrument"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-Types
-            title: "Daml.Finance.Interface.Instrument.Token.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Types-FloatingRate
-            title: "Daml.Finance.Interface.Instrument.Types.FloatingRate"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Effect
-            title: "Daml.Finance.Interface.Lifecycle.Effect"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Election
-            title: "Daml.Finance.Interface.Lifecycle.Election"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Election-Factory
-            title: "Daml.Finance.Interface.Lifecycle.Election.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event
-            title: "Daml.Finance.Interface.Lifecycle.Event"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event-Distribution
-            title: "Daml.Finance.Interface.Lifecycle.Event.Distribution"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event-Replacement
-            title: "Daml.Finance.Interface.Lifecycle.Event.Replacement"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Event-Time
-            title: "Daml.Finance.Interface.Lifecycle.Event.Time"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Observable-NumericObservable
-            title: "Daml.Finance.Interface.Lifecycle.Observable.NumericObservable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Observable-TimeObservable
-            title: "Daml.Finance.Interface.Lifecycle.Observable.TimeObservable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Rule-Claim
-            title: "Daml.Finance.Interface.Lifecycle.Rule.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-Rule-Lifecycle
-            title: "Daml.Finance.Interface.Lifecycle.Rule.Lifecycle"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Batch
-            title: "Daml.Finance.Interface.Settlement.Batch"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Factory
-            title: "Daml.Finance.Interface.Settlement.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Instruction
-            title: "Daml.Finance.Interface.Settlement.Instruction"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-RouteProvider
-            title: "Daml.Finance.Interface.Settlement.RouteProvider"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-Types
-            title: "Daml.Finance.Interface.Settlement.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Common-Types
-            title: "Daml.Finance.Interface.Types.Common.Types"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-Calendar
-            title: "Daml.Finance.Interface.Types.Date.Calendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-Classes
-            title: "Daml.Finance.Interface.Types.Date.Classes"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-DateOffset
-            title: "Daml.Finance.Interface.Types.Date.DateOffset"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-DayCount
-            title: "Daml.Finance.Interface.Types.Date.DayCount"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-RollConvention
-            title: "Daml.Finance.Interface.Types.Date.RollConvention"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-Schedule
-            title: "Daml.Finance.Interface.Types.Date.Schedule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-Common
-            title: "Daml.Finance.Interface.Util.Common"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-Disclosure
-            title: "Daml.Finance.Interface.Util.Disclosure"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-InterfaceKey
-            title: "Daml.Finance.Interface.Util.InterfaceKey"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-Lockable
-            title: "Daml.Finance.Interface.Util.Lockable"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Effect
-            title: "Daml.Finance.Lifecycle.Effect"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Election
-            title: "Daml.Finance.Lifecycle.Election"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-ElectionEffect
-            title: "Daml.Finance.Lifecycle.ElectionEffect"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Event-Distribution
-            title: "Daml.Finance.Lifecycle.Event.Distribution"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Event-Replacement
-            title: "Daml.Finance.Lifecycle.Event.Replacement"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Claim
-            title: "Daml.Finance.Lifecycle.Rule.Claim"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Distribution
-            title: "Daml.Finance.Lifecycle.Rule.Distribution"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Replacement
-            title: "Daml.Finance.Lifecycle.Rule.Replacement"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-Rule-Util
-            title: "Daml.Finance.Lifecycle.Rule.Util"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Batch
-            title: "Daml.Finance.Settlement.Batch"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Factory
-            title: "Daml.Finance.Settlement.Factory"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Hierarchy
-            title: "Daml.Finance.Settlement.Hierarchy"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-Instruction
-            title: "Daml.Finance.Settlement.Instruction"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-RouteProvider-IntermediatedStatic
-            title: "Daml.Finance.Settlement.RouteProvider.IntermediatedStatic"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-RouteProvider-SingleCustodian
-            title: "Daml.Finance.Settlement.RouteProvider.SingleCustodian"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Common
-            title: "Daml.Finance.Util.Common"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-Calendar
-            title: "Daml.Finance.Util.Date.Calendar"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-DayCount
-            title: "Daml.Finance.Util.Date.DayCount"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-RollConvention
-            title: "Daml.Finance.Util.Date.RollConvention"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Date-Schedule
-            title: "Daml.Finance.Util.Date.Schedule"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Disclosure
-            title: "Daml.Finance.Util.Disclosure"
-          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-Lockable
-            title: "Daml.Finance.Util.Lockable"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-V3-Builders
+            title: "ContingentClaims.Core.V3.Builders"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-V3-Claim
+            title: "ContingentClaims.Core.V3.Claim"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-V3-Internal-Claim
+            title: "ContingentClaims.Core.V3.Internal.Claim"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-V3-Observation
+            title: "ContingentClaims.Core.V3.Observation"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Core-V3-Util-Recursion
+            title: "ContingentClaims.Core.V3.Util.Recursion"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Lifecycle-V3-Lifecycle
+            title: "ContingentClaims.Lifecycle.V3.Lifecycle"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Lifecycle-V3-Util
+            title: "ContingentClaims.Lifecycle.V3.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Valuation-V1-MathML
+            title: "ContingentClaims.Valuation.V1.MathML"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/ContingentClaims-Valuation-V1-Stochastic
+            title: "ContingentClaims.Valuation.V1.Stochastic"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Account-V4-Account
+            title: "Daml.Finance.Account.V4.Account"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-V3-Lifecycle-Rule
+            title: "Daml.Finance.Claims.V3.Lifecycle.Rule"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-V3-Util
+            title: "Daml.Finance.Claims.V3.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-V3-Util-Builders
+            title: "Daml.Finance.Claims.V3.Util.Builders"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-V3-Util-Date
+            title: "Daml.Finance.Claims.V3.Util.Date"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Claims-V3-Util-Lifecycle
+            title: "Daml.Finance.Claims.V3.Util.Lifecycle"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-V4-Numeric-Observation
+            title: "Daml.Finance.Data.V4.Numeric.Observation"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-V4-Reference-HolidayCalendar
+            title: "Daml.Finance.Data.V4.Reference.HolidayCalendar"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-V4-Time-DateClock
+            title: "Daml.Finance.Data.V4.Time.DateClock"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-V4-Time-DateClock-Types
+            title: "Daml.Finance.Data.V4.Time.DateClock.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-V4-Time-DateClockUpdate
+            title: "Daml.Finance.Data.V4.Time.DateClockUpdate"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Data-V4-Time-LedgerTime
+            title: "Daml.Finance.Data.V4.Time.LedgerTime"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-V4-BaseHolding
+            title: "Daml.Finance.Holding.V4.BaseHolding"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-V4-Factory
+            title: "Daml.Finance.Holding.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-V4-Fungible
+            title: "Daml.Finance.Holding.V4.Fungible"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-V4-Transferable
+            title: "Daml.Finance.Holding.V4.Transferable"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-V4-TransferableFungible
+            title: "Daml.Finance.Holding.V4.TransferableFungible"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Holding-V4-Util
+            title: "Daml.Finance.Holding.V4.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-Callable-Factory
+            title: "Daml.Finance.Instrument.Bond.V3.Callable.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-Callable-Instrument
+            title: "Daml.Finance.Instrument.Bond.V3.Callable.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-FixedRate-Factory
+            title: "Daml.Finance.Instrument.Bond.V3.FixedRate.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-FixedRate-Instrument
+            title: "Daml.Finance.Instrument.Bond.V3.FixedRate.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-FloatingRate-Factory
+            title: "Daml.Finance.Instrument.Bond.V3.FloatingRate.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-FloatingRate-Instrument
+            title: "Daml.Finance.Instrument.Bond.V3.FloatingRate.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-InflationLinked-Factory
+            title: "Daml.Finance.Instrument.Bond.V3.InflationLinked.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-InflationLinked-Instrument
+            title: "Daml.Finance.Instrument.Bond.V3.InflationLinked.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-Util
+            title: "Daml.Finance.Instrument.Bond.V3.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-ZeroCoupon-Factory
+            title: "Daml.Finance.Instrument.Bond.V3.ZeroCoupon.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Bond-V3-ZeroCoupon-Instrument
+            title: "Daml.Finance.Instrument.Bond.V3.ZeroCoupon.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Equity-V1-Factory
+            title: "Daml.Finance.Instrument.Equity.V1.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Equity-V1-Instrument
+            title: "Daml.Finance.Instrument.Equity.V1.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-V4-Factory
+            title: "Daml.Finance.Instrument.Generic.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-V4-Instrument
+            title: "Daml.Finance.Instrument.Generic.V4.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Generic-V4-Lifecycle-Rule
+            title: "Daml.Finance.Instrument.Generic.V4.Lifecycle.Rule"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-BarrierEuropeanCash-Factory
+            title: "Daml.Finance.Instrument.Option.V1.BarrierEuropeanCash.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-BarrierEuropeanCash-Instrument
+            title: "Daml.Finance.Instrument.Option.V1.BarrierEuropeanCash.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-Dividend-Factory
+            title: "Daml.Finance.Instrument.Option.V1.Dividend.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-Dividend-Instrument
+            title: "Daml.Finance.Instrument.Option.V1.Dividend.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-Dividend-Election
+            title: "Daml.Finance.Instrument.Option.V1.Dividend.Election"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-EuropeanCash-Factory
+            title: "Daml.Finance.Instrument.Option.V1.EuropeanCash.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-EuropeanCash-Instrument
+            title: "Daml.Finance.Instrument.Option.V1.EuropeanCash.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-EuropeanPhysical-Factory
+            title: "Daml.Finance.Instrument.Option.V1.EuropeanPhysical.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Option-V1-EuropeanPhysical-Instrument
+            title: "Daml.Finance.Instrument.Option.V1.EuropeanPhysical.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-V1-AutoCallable-Factory
+            title: "Daml.Finance.Instrument.StructuredProduct.V1.AutoCallable.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-V1-AutoCallable-Instrument
+            title: "Daml.Finance.Instrument.StructuredProduct.V1.AutoCallable.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-V1-BarrierReverseConvertible-Factory
+            title: "Daml.Finance.Instrument.StructuredProduct.V1.BarrierReverseConvertible.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-V1-BarrierReverseConvertible-Instrument
+            title: "Daml.Finance.Instrument.StructuredProduct.V1.BarrierReverseConvertible.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-StructuredProduct-V1-Util
+            title: "Daml.Finance.Instrument.StructuredProduct.V1.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Asset-Factory
+            title: "Daml.Finance.Instrument.Swap.V1.Asset.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Asset-Instrument
+            title: "Daml.Finance.Instrument.Swap.V1.Asset.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Asset-DistributionRule
+            title: "Daml.Finance.Instrument.Swap.V1.Asset.DistributionRule"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-CreditDefault-Factory
+            title: "Daml.Finance.Instrument.Swap.V1.CreditDefault.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-CreditDefault-Instrument
+            title: "Daml.Finance.Instrument.Swap.V1.CreditDefault.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Currency-Factory
+            title: "Daml.Finance.Instrument.Swap.V1.Currency.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Currency-Instrument
+            title: "Daml.Finance.Instrument.Swap.V1.Currency.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-ForeignExchange-Factory
+            title: "Daml.Finance.Instrument.Swap.V1.ForeignExchange.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-ForeignExchange-Instrument
+            title: "Daml.Finance.Instrument.Swap.V1.ForeignExchange.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Fpml-Factory
+            title: "Daml.Finance.Instrument.Swap.V1.Fpml.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Fpml-Instrument
+            title: "Daml.Finance.Instrument.Swap.V1.Fpml.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-Fpml-Util
+            title: "Daml.Finance.Instrument.Swap.V1.Fpml.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-InterestRate-Factory
+            title: "Daml.Finance.Instrument.Swap.V1.InterestRate.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Swap-V1-InterestRate-Instrument
+            title: "Daml.Finance.Instrument.Swap.V1.InterestRate.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Token-V4-Factory
+            title: "Daml.Finance.Instrument.Token.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Instrument-Token-V4-Instrument
+            title: "Daml.Finance.Instrument.Token.V4.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-V4-Account
+            title: "Daml.Finance.Interface.Account.V4.Account"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-V4-Factory
+            title: "Daml.Finance.Interface.Account.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Account-V4-Util
+            title: "Daml.Finance.Interface.Account.V4.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-V4-Claim
+            title: "Daml.Finance.Interface.Claims.V4.Claim"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-V4-Dynamic-Instrument
+            title: "Daml.Finance.Interface.Claims.V4.Dynamic.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Claims-V4-Types
+            title: "Daml.Finance.Interface.Claims.V4.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-V4-Numeric-Observation
+            title: "Daml.Finance.Interface.Data.V4.Numeric.Observation"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-V4-Numeric-Observation-Factory
+            title: "Daml.Finance.Interface.Data.V4.Numeric.Observation.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-V4-Reference-HolidayCalendar
+            title: "Daml.Finance.Interface.Data.V4.Reference.HolidayCalendar"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-V4-Reference-HolidayCalendar-Factory
+            title: "Daml.Finance.Interface.Data.V4.Reference.HolidayCalendar.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Data-V4-Reference-Time
+            title: "Daml.Finance.Interface.Data.V4.Reference.Time"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-V4-Factory
+            title: "Daml.Finance.Interface.Holding.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-V4-Fungible
+            title: "Daml.Finance.Interface.Holding.V4.Fungible"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-V4-Holding
+            title: "Daml.Finance.Interface.Holding.V4.Holding"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-V4-Transferable
+            title: "Daml.Finance.Interface.Holding.V4.Transferable"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Holding-V4-Util
+            title: "Daml.Finance.Interface.Holding.V4.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Base-V4-Instrument
+            title: "Daml.Finance.Interface.Instrument.Base.V4.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-Callable-Factory
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.Callable.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-Callable-Instrument
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.Callable.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-Callable-Types
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.Callable.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-FixedRate-Factory
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.FixedRate.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-FixedRate-Instrument
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.FixedRate.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-FixedRate-Types
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.FixedRate.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-FloatingRate-Factory
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.FloatingRate.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-FloatingRate-Instrument
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.FloatingRate.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-FloatingRate-Types
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.FloatingRate.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-InflationLinked-Factory
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.InflationLinked.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-InflationLinked-Instrument
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.InflationLinked.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-InflationLinked-Types
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.InflationLinked.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-ZeroCoupon-Factory
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.ZeroCoupon.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-ZeroCoupon-Instrument
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.ZeroCoupon.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Bond-V3-ZeroCoupon-Types
+            title: "Daml.Finance.Interface.Instrument.Bond.V3.ZeroCoupon.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Equity-V1-Factory
+            title: "Daml.Finance.Interface.Instrument.Equity.V1.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Equity-V1-Instrument
+            title: "Daml.Finance.Interface.Instrument.Equity.V1.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-V4-Factory
+            title: "Daml.Finance.Interface.Instrument.Generic.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Generic-V4-Instrument
+            title: "Daml.Finance.Interface.Instrument.Generic.V4.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-BarrierEuropeanCash-Factory
+            title: "Daml.Finance.Interface.Instrument.Option.V1.BarrierEuropeanCash.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-BarrierEuropeanCash-Instrument
+            title: "Daml.Finance.Interface.Instrument.Option.V1.BarrierEuropeanCash.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-BarrierEuropeanCash-Types
+            title: "Daml.Finance.Interface.Instrument.Option.V1.BarrierEuropeanCash.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-Dividend-Factory
+            title: "Daml.Finance.Interface.Instrument.Option.V1.Dividend.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-Dividend-Instrument
+            title: "Daml.Finance.Interface.Instrument.Option.V1.Dividend.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-Dividend-Types
+            title: "Daml.Finance.Interface.Instrument.Option.V1.Dividend.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-Dividend-Election-Factory
+            title: "Daml.Finance.Interface.Instrument.Option.V1.Dividend.Election.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-EuropeanCash-Factory
+            title: "Daml.Finance.Interface.Instrument.Option.V1.EuropeanCash.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-EuropeanCash-Instrument
+            title: "Daml.Finance.Interface.Instrument.Option.V1.EuropeanCash.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-EuropeanCash-Types
+            title: "Daml.Finance.Interface.Instrument.Option.V1.EuropeanCash.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-EuropeanPhysical-Factory
+            title: "Daml.Finance.Interface.Instrument.Option.V1.EuropeanPhysical.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-EuropeanPhysical-Instrument
+            title: "Daml.Finance.Interface.Instrument.Option.V1.EuropeanPhysical.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-EuropeanPhysical-Types
+            title: "Daml.Finance.Interface.Instrument.Option.V1.EuropeanPhysical.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Option-V1-Types
+            title: "Daml.Finance.Interface.Instrument.Option.V1.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-V1-AutoCallable-Factory
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1.AutoCallable.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-V1-AutoCallable-Instrument
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1.AutoCallable.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-V1-AutoCallable-Types
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1.AutoCallable.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-V1-BarrierReverseConvertible-Factory
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1.BarrierReverseConvertible.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-V1-BarrierReverseConvertible-Instrument
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1.BarrierReverseConvertible.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-V1-BarrierReverseConvertible-Types
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1.BarrierReverseConvertible.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-StructuredProduct-V1-Types
+            title: "Daml.Finance.Interface.Instrument.StructuredProduct.V1.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Asset-Factory
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Asset.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Asset-Instrument
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Asset.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Asset-Types
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Asset.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-CreditDefault-Factory
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.CreditDefault.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-CreditDefault-Instrument
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.CreditDefault.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-CreditDefault-Types
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.CreditDefault.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Currency-Factory
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Currency.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Currency-Instrument
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Currency.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Currency-Types
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Currency.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-ForeignExchange-Factory
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.ForeignExchange.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-ForeignExchange-Instrument
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.ForeignExchange.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-ForeignExchange-Types
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.ForeignExchange.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Fpml-Factory
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Fpml.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Fpml-FpmlTypes
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Fpml.FpmlTypes"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Fpml-Instrument
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Fpml.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-Fpml-Types
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.Fpml.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-InterestRate-Factory
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.InterestRate.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-InterestRate-Instrument
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.InterestRate.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Swap-V1-InterestRate-Types
+            title: "Daml.Finance.Interface.Instrument.Swap.V1.InterestRate.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-V4-Factory
+            title: "Daml.Finance.Interface.Instrument.Token.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-V4-Instrument
+            title: "Daml.Finance.Interface.Instrument.Token.V4.Instrument"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Token-V4-Types
+            title: "Daml.Finance.Interface.Instrument.Token.V4.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Instrument-Types-V2-FloatingRate
+            title: "Daml.Finance.Interface.Instrument.Types.V2.FloatingRate"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Effect
+            title: "Daml.Finance.Interface.Lifecycle.V4.Effect"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Election
+            title: "Daml.Finance.Interface.Lifecycle.V4.Election"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Election-Factory
+            title: "Daml.Finance.Interface.Lifecycle.V4.Election.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Event
+            title: "Daml.Finance.Interface.Lifecycle.V4.Event"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Event-Distribution
+            title: "Daml.Finance.Interface.Lifecycle.V4.Event.Distribution"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Event-Replacement
+            title: "Daml.Finance.Interface.Lifecycle.V4.Event.Replacement"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Event-Time
+            title: "Daml.Finance.Interface.Lifecycle.V4.Event.Time"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Observable-NumericObservable
+            title: "Daml.Finance.Interface.Lifecycle.V4.Observable.NumericObservable"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Observable-TimeObservable
+            title: "Daml.Finance.Interface.Lifecycle.V4.Observable.TimeObservable"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Rule-Claim
+            title: "Daml.Finance.Interface.Lifecycle.V4.Rule.Claim"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Lifecycle-V4-Rule-Lifecycle
+            title: "Daml.Finance.Interface.Lifecycle.V4.Rule.Lifecycle"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-V4-Batch
+            title: "Daml.Finance.Interface.Settlement.V4.Batch"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-V4-Factory
+            title: "Daml.Finance.Interface.Settlement.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-V4-Instruction
+            title: "Daml.Finance.Interface.Settlement.V4.Instruction"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-V4-RouteProvider
+            title: "Daml.Finance.Interface.Settlement.V4.RouteProvider"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Settlement-V4-Types
+            title: "Daml.Finance.Interface.Settlement.V4.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Common-V3-Types
+            title: "Daml.Finance.Interface.Types.Common.V3.Types"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-V3-Calendar
+            title: "Daml.Finance.Interface.Types.Date.V3.Calendar"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-V3-Classes
+            title: "Daml.Finance.Interface.Types.Date.V3.Classes"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-V3-DateOffset
+            title: "Daml.Finance.Interface.Types.Date.V3.DateOffset"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-V3-DayCount
+            title: "Daml.Finance.Interface.Types.Date.V3.DayCount"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-V3-RollConvention
+            title: "Daml.Finance.Interface.Types.Date.V3.RollConvention"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Types-Date-V3-Schedule
+            title: "Daml.Finance.Interface.Types.Date.V3.Schedule"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-V3-Common
+            title: "Daml.Finance.Interface.Util.V3.Common"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-V3-Disclosure
+            title: "Daml.Finance.Interface.Util.V3.Disclosure"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-V3-InterfaceKey
+            title: "Daml.Finance.Interface.Util.V3.InterfaceKey"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Interface-Util-V3-Lockable
+            title: "Daml.Finance.Interface.Util.V3.Lockable"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Effect
+            title: "Daml.Finance.Lifecycle.V4.Effect"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Election
+            title: "Daml.Finance.Lifecycle.V4.Election"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-ElectionEffect
+            title: "Daml.Finance.Lifecycle.V4.ElectionEffect"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Event-Distribution
+            title: "Daml.Finance.Lifecycle.V4.Event.Distribution"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Event-Replacement
+            title: "Daml.Finance.Lifecycle.V4.Event.Replacement"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Rule-Claim
+            title: "Daml.Finance.Lifecycle.V4.Rule.Claim"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Rule-Distribution
+            title: "Daml.Finance.Lifecycle.V4.Rule.Distribution"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Rule-Replacement
+            title: "Daml.Finance.Lifecycle.V4.Rule.Replacement"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Lifecycle-V4-Rule-Util
+            title: "Daml.Finance.Lifecycle.V4.Rule.Util"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-V4-Batch
+            title: "Daml.Finance.Settlement.V4.Batch"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-V4-Factory
+            title: "Daml.Finance.Settlement.V4.Factory"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-V4-Hierarchy
+            title: "Daml.Finance.Settlement.V4.Hierarchy"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-V4-Instruction
+            title: "Daml.Finance.Settlement.V4.Instruction"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-V4-RouteProvider-IntermediatedStatic
+            title: "Daml.Finance.Settlement.V4.RouteProvider.IntermediatedStatic"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Settlement-V4-RouteProvider-SingleCustodian
+            title: "Daml.Finance.Settlement.V4.RouteProvider.SingleCustodian"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-V4-Common
+            title: "Daml.Finance.Util.V4.Common"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-V4-Date-Calendar
+            title: "Daml.Finance.Util.V4.Date.Calendar"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-V4-Date-DayCount
+            title: "Daml.Finance.Util.V4.Date.DayCount"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-V4-Date-RollConvention
+            title: "Daml.Finance.Util.V4.Date.RollConvention"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-V4-Date-Schedule
+            title: "Daml.Finance.Util.V4.Date.Schedule"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-V4-Disclosure
+            title: "Daml.Finance.Util.V4.Disclosure"
+          - file: daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Util-V4-Lockable
+            title: "Daml.Finance.Util.V4.Lockable"
 
 - caption: "Operate a Daml Ledger"
   entries:

--- a/docs/3.1/bin/daml-finance/update_tags.sh
+++ b/docs/3.1/bin/daml-finance/update_tags.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# Script: update_tags.sh (Daml Finance)
+#
+# Description:
+# Upgrades versioned references in the documentation from one version to another.
+#
+# Example:
+#   Updates `type-daml-finance-lifecycle-v4-event-replacement-event-23525` to
+#   `type-daml-finance-lifecycle-v5-event-replacement-event-53425` when upgrading to v5.
+#
+# Functionality:
+# 1. **Extract References**: Scans all files in the reference directory (`REF_DIR`) for lines
+#    starting with `.. _module`, `.. _type`, `.. _function`, or `.. _constr`.
+# 2. **Update References**:
+#    - Locates corresponding references in the target directory (`TRGT_DIR`).
+#    - Updates the version segment from the old version (e.g., `v4`) to the new version (e.g., `v5`).
+#    - Changes the numerical identifier to ensure uniqueness.
+#
+# Prerequisites:
+# - **Build Workdir**: Ensure the working directory (`workdir`) is fully built to have up-to-date
+#   reference files.
+#
+# Usage:
+# 1. **Set Directories**:
+#    - Define `REF_DIR` with the path to current reference files.
+#    - Define `TRGT_DIR` with the path where references should be updated.
+# 2. **Execute Script**:
+#    - Run the script in the terminal to automatically scan and update all relevant references based
+#      on the new version.
+
+# Get the directory where the script is located, to ensure paths are correct no matter where it's called from
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Set the reference directory (contains canonical _module, _type, _function, _constr lines)
+REF_DIR="${SCRIPT_DIR}/../../workdir/build/source/source/daml-finance/reference/code-documentation/daml-finance-rst"
+
+# Set the target directory (where we need to replace occurrences)
+TRGT_DIR="${SCRIPT_DIR}/../../docs/daml-finance"
+
+echo "Reference directory: $REF_DIR"
+echo "Target directory: $TRGT_DIR"
+
+tmpfile=$(mktemp)
+echo "Temporary file: $tmpfile"
+
+# Regex explanation:
+# .. _module-daml-finance-account-v4-account-[0-9]+$ : Match lines with the format 'module-<any number>'
+grep -hEr '..[[:space:]]+_(module|type|function|constr).*-[0-9]+:$' "$REF_DIR" > "$tmpfile" || true
+
+line_count=$(wc -l < "$tmpfile")
+echo "Found $line_count canonical lines."
+
+while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    echo "Processing line: $line"
+
+    # Remove everything before '.. _' and trailing ':'
+    line_no_prefix="${line##*.. _}"
+    base="${line_no_prefix%:}"
+
+    # Extract the last number
+    number="${base##*-}"
+
+    # Extract everything before the number as the pattern
+    pattern="${base%-*}"
+
+    echo "  Pattern: $pattern"
+    echo "  Number: $number"
+
+    # Check if the pattern contains a version segment like -vX- (e.g. -v4-)
+    # Example pattern: type-daml-finance-lifecycle-v4-event-replacement-event
+    if [[ $pattern =~ ^(.*)(-v[0-9]+)(-.*)$ ]]; then
+        pattern_before="${BASH_REMATCH[1]}"  # up to and including 'v'
+        pattern_version="${BASH_REMATCH[2]}" # the version digits
+        pattern_after="${BASH_REMATCH[3]}"   # the rest after the version
+
+        echo "  Detected version segment: $pattern_version"
+        echo "  Pattern before version: $pattern_before"
+        echo "  Pattern after version: $pattern_after"
+
+        # In target files,
+        # 1. Override any version number (say "-v3" or ""), with the current one (say "-v4").
+        # 2. Override the reference number with the current one.
+        # Using '#' as sed delimiter to avoid conflicts with '-'.
+        find "$TRGT_DIR" -type f -exec sed -i "s#${pattern_before}\(-v[0-9]\\{1,\\}\)\?${pattern_after}-[0-9]\\{1,\\}#${pattern_before}${pattern_version}${pattern_after}-${number}#g" {} +
+
+    else
+        # No version found, do the standard replacement
+        find "$TRGT_DIR" -type f -exec sed -i "s#${pattern}-[0-9]\\{1,\\}#${pattern}-${number}#g" {} +
+    fi
+
+    echo "  Done processing this pattern."
+    echo
+done < "$tmpfile"
+
+rm "$tmpfile"
+echo "All done."

--- a/docs/3.1/docs/daml-finance/concepts/asset-model.rst
+++ b/docs/3.1/docs/daml-finance/concepts/asset-model.rst
@@ -142,7 +142,7 @@ the interfaces :ref:`holding <module-daml-finance-interface-holding-holding-6412
 Implementations
 ===============
 
-``Daml.Finance.Holding`` provides implementations for each holding standard:
+``Daml.Finance.Holding.V4`` provides implementations for each holding standard:
 
 - :ref:`fungible only <module-daml-finance-holding-fungible-7201>`
 - :ref:`transferable only <module-daml-finance-holding-transferable-43388>`

--- a/docs/3.1/docs/daml-finance/concepts/asset-model.rst
+++ b/docs/3.1/docs/daml-finance/concepts/asset-model.rst
@@ -36,7 +36,7 @@ Keys and Versioning
 ===================
 
 Instruments are keyed by an
-:ref:`InstrumentKey <constr-daml-finance-interface-types-common-types-instrumentkey-32970>`,
+:ref:`InstrumentKey <constr-daml-finance-interface-types-common-v3-types-instrumentkey-49116>`,
 which comprises:
 
 - the instrument ``issuer``
@@ -55,21 +55,21 @@ Interfaces
 Instrument interfaces are defined in the ``Daml.Finance.Interface.Instrument.*`` packages.
 
 All instruments must implement the base interface, defined in
-:ref:`Daml.Finance.Interface.Instrument.Base <module-daml-finance-interface-instrument-base-instrument-57320>`.
+:ref:`Daml.Finance.Interface.Instrument.Base.V4 <module-daml-finance-interface-instrument-base-v4-instrument-47185>`.
 
 Implementations
 ===============
 
 A base implementation is provided in
-:ref:`Daml.Finance.Instrument.Token <module-daml-finance-instrument-token-instrument-10682>`.
+:ref:`Daml.Finance.Instrument.Token.V4 <module-daml-finance-instrument-token-v4-instrument-53415>`.
 
 This template does not define any lifecycling logic and is suitable to model contracts that are
 likely to stay stable, such as currency instruments.
 
 The extension packages provide additional business-specific implementations, such as an
-:ref:`Equity <module-daml-finance-instrument-equity-instrument-69265>`
+:ref:`Equity <module-daml-finance-instrument-equity-v1-instrument-56047>`
 instrument (where the issuer can pay dividends) or a
-:ref:`Bond <module-daml-finance-instrument-bond-fixedrate-instrument-67993>`
+:ref:`Bond <module-daml-finance-instrument-bond-v3-fixedrate-instrument-89221>`
 instrument (which includes coupon payments).
 
 The expectation is that customers define their own instruments suiting the use-case they are
@@ -117,12 +117,12 @@ When, for instance, a holding is transferable, the ownership can be transferred 
 at the same custodian.
 
 These properties are exposed by letting a holding template implement the corresponding interfaces
-(:ref:`Fungible <module-daml-finance-interface-holding-fungible-63712>` and
-:ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`,
+(:ref:`Fungible <module-daml-finance-interface-holding-v4-fungible-55495>` and
+:ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`,
 respectively).
 
 The library distinguishes four types of holdings, referred to as :ref:`Holding Standard
-<type-daml-finance-interface-types-common-types-holdingstandard-38061>`\s, namely:
+<type-daml-finance-interface-types-common-v3-types-holdingstandard-63293>`\s, namely:
 
 1. `Fungible`: Holdings that are fungible only.
 2. `Transferable`: Holdings that are transferable only.
@@ -132,10 +132,10 @@ The library distinguishes four types of holdings, referred to as :ref:`Holding S
 Interfaces
 ==========
 
-Holding interfaces are defined in the ``Daml.Finance.Interface.Holding`` package. It consists of
-the interfaces :ref:`holding <module-daml-finance-interface-holding-holding-64126>`,
-:ref:`transferable <module-daml-finance-interface-holding-transferable-88121>`, and
-:ref:`fungible <module-daml-finance-interface-holding-fungible-63712>`.
+Holding interfaces are defined in the ``Daml.Finance.Interface.Holding.V4`` package. It consists of
+the interfaces :ref:`holding <module-daml-finance-interface-holding-v4-holding-20535>`,
+:ref:`transferable <module-daml-finance-interface-holding-v4-transferable-93054>`, and
+:ref:`fungible <module-daml-finance-interface-holding-v4-fungible-55495>`.
 
 .. _implementations-1:
 
@@ -144,10 +144,10 @@ Implementations
 
 ``Daml.Finance.Holding.V4`` provides implementations for each holding standard:
 
-- :ref:`fungible only <module-daml-finance-holding-fungible-7201>`
-- :ref:`transferable only <module-daml-finance-holding-transferable-43388>`
-- :ref:`both transferable and fungible <module-daml-finance-holding-transferablefungible-77726>`
-- :ref:`neither transferable nor fungible <module-daml-finance-holding-baseholding-57062>`
+- :ref:`fungible only <module-daml-finance-holding-v4-fungible-60188>`
+- :ref:`transferable only <module-daml-finance-holding-v4-transferable-38649>`
+- :ref:`both transferable and fungible <module-daml-finance-holding-v4-transferablefungible-66907>`
+- :ref:`neither transferable nor fungible <module-daml-finance-holding-v4-baseholding-28133>`
 
 Account
 *******
@@ -162,7 +162,7 @@ bank’s services.
 
 The account contract also controls which parties are authorized to transfer holdings in and out of
 the account. To be more precise, the
-:ref:`controllers <type-daml-finance-interface-account-account-controllers-36430>`
+:ref:`controllers <type-daml-finance-interface-account-v4-account-controllers-59817>`
 field of the account contains:
 
 - ``outgoing``: a set of parties authorizing outgoing transfers
@@ -195,7 +195,7 @@ Keys
 ====
 
 Accounts are keyed by an
-:ref:`AccountKey <type-daml-finance-interface-types-common-types-accountkey-41482>`, which
+:ref:`AccountKey <type-daml-finance-interface-types-common-v3-types-accountkey-55962>`, which
 comprises:
 
 - the account ``owner``
@@ -208,22 +208,22 @@ Interfaces
 ==========
 
 The account interface is defined in the
-:ref:`Daml.Finance.Interface.Account <module-daml-finance-interface-account-account-92922>`
+:ref:`Daml.Finance.Interface.Account.V4 <module-daml-finance-interface-account-v4-account-30007>`
 package.
 
 Implementations
 ===============
 
 A base account implementation is provided in
-:ref:`Daml.Finance.Account <module-daml-finance-account-account-19369>`.
+:ref:`Daml.Finance.Account.V4 <module-daml-finance-account-v4-account-5834>`.
 
 The account can be created with arbitrary
-:ref:`controllers <type-daml-finance-interface-account-account-controllers-36430>`
+:ref:`controllers <type-daml-finance-interface-account-v4-account-controllers-59817>`
 (for incoming and outgoing transfers). Our examples typically let accounts be owners-controlled,
 i.e., both the current owner and the new owner must authorize transfers.
 
 The account also implements
-the :ref:`Lockable <module-daml-finance-interface-util-lockable-80915>` interface, enabling the
+the :ref:`Lockable <module-daml-finance-interface-util-v3-lockable-20339>` interface, enabling the
 freezing of an account, thus disabling credits and debits.
 
 Example setups
@@ -241,15 +241,15 @@ a Commercial Bank, and a Retail Client.
 The Central Bank defines the economic terms of the currency asset and is generally a highly trusted
 entity, therefore it acts as ``issuer`` as well as ``depository`` of the corresponding instrument.
 
-We can use the :ref:`Token <module-daml-finance-instrument-token-instrument-10682>`
+We can use the :ref:`Token <module-daml-finance-instrument-token-v4-instrument-53415>`
 instrument implementation for a currency asset, as we do not need any lifecycling logic.
 
 The Retail Client has an
-:ref:`Account <module-daml-finance-interface-account-account-92922>` at the Commercial Bank, with
+:ref:`Account <module-daml-finance-interface-account-v4-account-30007>` at the Commercial Bank, with
 the former acting as ``owner`` and the latter as ``custodian``.
 
 Finally, the Retail Client is ``owner`` of a
-:ref:`transferable and fungible holding <module-daml-finance-holding-transferablefungible-77726>` at
+:ref:`transferable and fungible holding <module-daml-finance-holding-v4-transferablefungible-66907>` at
 the Commercial Bank (i.e., the ``custodian`` in the contract). The holding references the currency
 instrument and the account.
 
@@ -268,7 +268,7 @@ We now model units of shares held by an investor. There are three parties involv
 Entity, a Securities Depository, and an Investor.
 
 The Issuing Entity acts as ``issuer`` of the :ref:`Equity Instrument
-<module-daml-finance-instrument-equity-instrument-69265>`. The Securities Depository acts
+<module-daml-finance-instrument-equity-v1-instrument-56047>`. The Securities Depository acts
 as ``depository`` of the instrument, thus preventing the Issuing Entity from single-handedly
 modifying details of the instrument (such as the share's nominal value).
 
@@ -289,7 +289,7 @@ OTC Swap
 
 Finally, we model an OTC (over-the-counter) fixed vs. floating interest rate swap agreement between
 two parties, namely Party A and Party B. We can use the :ref:`Interest Rate Swap
-<module-daml-finance-instrument-swap-interestrate-instrument-86260>` instrument template
+<module-daml-finance-instrument-swap-v1-interestrate-instrument-25554>` instrument template
 for this purpose.
 
 In this case, all contracts are agreed and co-signed by both parties. In the instrument contract,

--- a/docs/3.1/docs/daml-finance/concepts/lifecycling.rst
+++ b/docs/3.1/docs/daml-finance/concepts/lifecycling.rst
@@ -10,8 +10,8 @@ cashflows, as well as discretionary events, like dividends and other corporate a
 provides a standard mechanism for processing such events across different instruments. The output is
 not limited to cash but can also include the distribution of other asset types.
 
-The interfaces for lifecycling are defined in the ``Daml.Finance.Interface.Lifecycle`` package, and
-several default implementations are provided in the ``Daml.Finance.Lifecycle`` package.
+The interfaces for lifecycling are defined in the ``Daml.Finance.Interface.Lifecycle.V4`` package, and
+several default implementations are provided in the ``Daml.Finance.Lifecycle.V4`` package.
 
 In this section, we first motivate the particular approach to lifecycling in Daml Finance. We then
 explain the process in detail using the example of a cash dividend event. Finally, we describe each
@@ -179,7 +179,6 @@ Events
 An event contract is used to indicate that a certain action has occurred, which might trigger
 the lifecycling of certain instruments. In the context of the dividend example above, this is the
 Issuer declaring a "Cash Dividend" to be paid on a specific stock.
-
 
 Events implement the :ref:`Event <module-daml-finance-interface-lifecycle-event-43586>`
 interface, which describes basic properties of a lifecycle event:

--- a/docs/3.1/docs/daml-finance/concepts/lifecycling.rst
+++ b/docs/3.1/docs/daml-finance/concepts/lifecycling.rst
@@ -87,7 +87,7 @@ step.
 
 Now, the issuer creates a lifecycle event defining the terms of dividend. In our example we can
 use the ``DistributeDividend`` choice on the
-:ref:`Equity <module-daml-finance-interface-instrument-equity-instrument-13224>` instrument
+:ref:`Equity <module-daml-finance-interface-instrument-equity-v1-instrument-10480>` instrument
 to create such an event. This is merely a convenience choice available for equities, any workflow
 can be used to create new instrument versions and associated lifecycle events.
 
@@ -102,8 +102,8 @@ Processing the event
 =====================
 
 The event is now passed into a
-:ref:`Distribution Rule <module-daml-finance-lifecycle-rule-distribution-35531>`, which
-generates the :ref:`Lifecycle Effect <module-daml-finance-interface-lifecycle-effect-16050>`
+:ref:`Distribution Rule <module-daml-finance-lifecycle-v4-rule-distribution-2662>`, which
+generates the :ref:`Lifecycle Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>`
 describing the distribution of assets per unit of ``ACME`` stock. The effect refers to a
 ``targetInstrument``, which is the version of the instrument that can be used by stock holders to
 claim the cash dividend according to the number of stocks held. By being tied to a specific version
@@ -122,8 +122,8 @@ Claiming the effect
 ===================
 
 The investor can now present its holding of ``ACME`` stock along with the corresponding
-:ref:`Effect <module-daml-finance-interface-lifecycle-effect-16050>` to a
-:ref:`Claim Rule <module-daml-finance-interface-lifecycle-rule-claim-6739>`. This will
+:ref:`Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>` to a
+:ref:`Claim Rule <module-daml-finance-interface-lifecycle-v4-rule-claim-89954>`. This will
 instruct settlement for:
 
 - The exchange of ``ACME`` stock versions held: the investor sends back the old version, and
@@ -131,7 +131,7 @@ instruct settlement for:
 - The payment of the cash dividend amount corresponding to the number of stocks held
 
 Both legs of this settlement are grouped in a
-:ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` to provide atomicity. The
+:ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` to provide atomicity. The
 goal of the batch is to exchange a holding on the v1 instrument for a holding on the v2 instrument
 + $10 (for each share held). This ensures that the investor can never claim a dividend twice, as
 after settlement they only hold the new version of the stock, which is not entitled to the dividend
@@ -142,7 +142,7 @@ anymore.
          holding. This produces a batch and settlement instructions.
 
 Note that the party responsible for claiming an effect can be specified flexibly in the
-:ref:`Claim Rule <module-daml-finance-interface-lifecycle-rule-claim-6739>` contract. Through
+:ref:`Claim Rule <module-daml-finance-interface-lifecycle-v4-rule-claim-89954>` contract. Through
 this contract, custodians can be given the authority to push a given corporate action to the asset
 holder as is common in current operating procedures.
 
@@ -180,7 +180,7 @@ An event contract is used to indicate that a certain action has occurred, which 
 the lifecycling of certain instruments. In the context of the dividend example above, this is the
 Issuer declaring a "Cash Dividend" to be paid on a specific stock.
 
-Events implement the :ref:`Event <module-daml-finance-interface-lifecycle-event-43586>`
+Events implement the :ref:`Event <module-daml-finance-interface-lifecycle-v4-event-91777>`
 interface, which describes basic properties of a lifecycle event:
 
 - The event providers
@@ -189,10 +189,10 @@ interface, which describes basic properties of a lifecycle event:
 
 Different implementations exist to cover typical corporate actions:
 
-- The :ref:`Distribution <module-daml-finance-lifecycle-event-distribution-17302>` event can be
+- The :ref:`Distribution <module-daml-finance-lifecycle-v4-event-distribution-38493>` event can be
   used to distribute assets to holders of an instrument. This covers cash-, share-, and mixed
   dividends, rights issues, or the distribution of voting rights.
-- The :ref:`Replacement <module-daml-finance-lifecycle-event-replacement-51859>` event handles
+- The :ref:`Replacement <module-daml-finance-lifecycle-v4-event-replacement-94706>` event handles
   replacements of one instrument for another with support for a factor. This covers corporate
   actions like (reverse) stock splits, mergers, and spin-offs.
 
@@ -201,17 +201,17 @@ A single event can be used as a trigger to lifecycle multiple instruments.
 Lifecycle Rule
 ==============
 
-A :ref:`Lifecycle Rule <module-daml-finance-interface-lifecycle-rule-lifecycle-50431>` is
+A :ref:`Lifecycle Rule <module-daml-finance-interface-lifecycle-v4-rule-lifecycle-8270>` is
 used to process an event for a certain instrument and calculate the resulting lifecycle effects.
 
 A lifecycle rule can either
 assume that a new version of the instrument has already been created (as is the case for the
-:ref:`Distribution <module-daml-finance-lifecycle-rule-distribution-35531>` and
-:ref:`Replacement <module-daml-finance-lifecycle-rule-replacement-6984>` rules), or it can create
+:ref:`Distribution <module-daml-finance-lifecycle-v4-rule-distribution-2662>` and
+:ref:`Replacement <module-daml-finance-lifecycle-v4-rule-replacement-25183>` rules), or it can create
 the new version of the instrument as part of its implementation. The latter can be useful if
 information required to create the new version is only available upon processing of the event, as is
 the case for the evolution of the
-:ref:`Generic Instrument <module-daml-finance-interface-instrument-generic-instrument-53275>`, as
+:ref:`Generic Instrument <module-daml-finance-interface-instrument-generic-v4-instrument-7928>`, as
 well as other :doc:`Contingent Claims <../instruments/generic/contingent-claims>` based instruments.
 
 .. _time-vs-election-lifecycling:
@@ -241,7 +241,7 @@ bond that is callable only on some of the coupon dates.
 Effects
 =======
 
-An :ref:`Effect <module-daml-finance-interface-lifecycle-effect-16050>` describes the asset
+An :ref:`Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>` describes the asset
 movements resulting from a particular event. It specifies these movements per unit of a target
 instrument and version.
 
@@ -257,7 +257,7 @@ effect, which results in the required asset movements to be instructed.
 Claim Rule
 ==========
 
-The :ref:`Claim Rule <module-daml-finance-interface-lifecycle-rule-claim-6739>` is used by
+The :ref:`Claim Rule <module-daml-finance-interface-lifecycle-v4-rule-claim-89954>` is used by
 instrument holders to claim lifecycle effects and instruct settlement of the resulting asset
 movements.
 
@@ -269,8 +269,8 @@ serves as proof of ownership such that there is no need for an issuer to take a 
 of holdings as of a specific date.
 
 The output of the claim rule is a
-:ref:`Settlement Batch <module-daml-finance-interface-settlement-batch-39188>` and a set of
-:ref:`Instruction <module-daml-finance-interface-settlement-instruction-10970>` s that
+:ref:`Settlement Batch <module-daml-finance-interface-settlement-v4-batch-88127>` and a set of
+:ref:`Instruction <module-daml-finance-interface-settlement-v4-instruction-71097>` s that
 settle the asset movements atomically.
 
 Note that multiple holdings can be passed into the claim rule in order to instruct intermediated

--- a/docs/3.1/docs/daml-finance/concepts/settlement.rst
+++ b/docs/3.1/docs/daml-finance/concepts/settlement.rst
@@ -8,8 +8,8 @@ Settlement
 financial transaction.
 
 Daml Finance provides facilities to execute these transfers atomically (i.e., within the same Daml
-transaction). Interfaces are defined in the ``Daml.Finance.Interface.Settlement`` package, whereas
-implementations are provided in the ``Daml.Finance.Settlement`` package.
+transaction). Interfaces are defined in the ``Daml.Finance.Interface.Settlement.V4`` package, whereas
+implementations are provided in the ``Daml.Finance.Settlement.V4`` package.
 
 In this section, we first illustrate the settlement workflow with the help of an example FX
 transaction, where Alice transfers a EUR-denominated holding to Bob, in exchange for a

--- a/docs/3.1/docs/daml-finance/concepts/settlement.rst
+++ b/docs/3.1/docs/daml-finance/concepts/settlement.rst
@@ -37,11 +37,11 @@ Alice and Bob want to exchange their holdings and agree to enter into the transa
 signatories on a transaction contract. Settlement can then be instructed which results in 3
 contract instances being created:
 
-#. an :ref:`Instruction <module-daml-finance-settlement-instruction-87187>`
+#. an :ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>`
    to transfer EUR 1000 from Alice to Bob
-#. an :ref:`Instruction <module-daml-finance-settlement-instruction-87187>`
+#. an :ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>`
    to transfer USD 1000 from Bob to Alice
-#. a :ref:`Batch <module-daml-finance-settlement-batch-95573>`
+#. a :ref:`Batch <module-daml-finance-settlement-v4-batch-88124>`
    used to execute the above Instructions
 
 .. image:: ../images/settlement_instructed.png
@@ -59,9 +59,9 @@ In order to execute the FX transaction, we first need to:
 - approve, i.e., specify to which account the asset should be transferred
 
 Allocation and approval is required for
-each :ref:`Instruction <module-daml-finance-settlement-instruction-87187>`.
+each :ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>`.
 
-Alice :ref:`allocates <module-daml-finance-interface-settlement-instruction-10970>` the instruction
+Alice :ref:`allocates <module-daml-finance-interface-settlement-v4-instruction-71097>` the instruction
 where she is the sender by pledging her holding. Bob does the same on the instruction where he is
 the sender.
 
@@ -69,7 +69,7 @@ the sender.
    :alt: Settlement is allocated.
 
 Each receiver can then specify to which account the holding should be sent by
-:ref:`approving <module-daml-finance-interface-settlement-instruction-10970>`
+:ref:`approving <module-daml-finance-interface-settlement-v4-instruction-71097>`
 the corresponding instruction.
 
 .. image:: ../images/settlement_allocated_approved.png
@@ -79,8 +79,8 @@ Execute
 =======
 
 Once both instructions are allocated and approved, a Settler party uses the
-:ref:`Batch <module-daml-finance-settlement-batch-95573>` contract to
-:ref:`execute <module-daml-finance-interface-settlement-instruction-10970>`
+:ref:`Batch <module-daml-finance-settlement-v4-batch-88124>` contract to
+:ref:`execute <module-daml-finance-interface-settlement-v4-instruction-71097>`
 them and finalize settlement in one atomic transaction.
 
 .. image:: ../images/settlement_executed.png
@@ -96,7 +96,7 @@ There are some assumptions that need to hold in order for the settlement to work
 - Bob needs to have an account at the custodian where Alice's holding is held and vice versa (for
   an example with intermediaries, see `Route provider`_ below.
 - Both holdings need to be
-  :ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`
+  :ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`
 - The transfer must be fully authorized (i.e., the parties allocating and approving an instruction
   must be the controllers of outgoing and incoming transfers of the corresponding accounts,
   respectively)
@@ -110,7 +110,7 @@ Route provider
 ==============
 
 When a transfer requires intermediaries to be involved, the role of a
-:ref:`Route Provider <type-daml-finance-interface-settlement-routeprovider-routeprovider-53805>`
+:ref:`Route Provider <type-daml-finance-interface-settlement-v4-routeprovider-routeprovider-29628>`
 becomes important. Let us assume, for instance, that Alice's EUR holding in the example above is
 held at Bank A, whereas Bob has a EUR account at Bank B. Bank A and Bank B both have accounts at the
 Central Bank.
@@ -120,9 +120,9 @@ Central Bank.
          Bank B. Bank A and Bank B have an account at the Central Bank.
 
 In this case, a direct holding transfer from Alice to Bob cannot generally be instructed. The
-original :ref:`Instruction <module-daml-finance-settlement-instruction-87187>`
+original :ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>`
 between Alice and Bob needs to be replaced by three separate
-:ref:`Instructions <module-daml-finance-settlement-instruction-87187>`:
+:ref:`Instructions <module-daml-finance-settlement-v4-instruction-73130>`:
 
 - **1A**: Alice sends EUR 1000 (held at Bank A) to Bank A
 - **1B**: Bank A sends EUR 1000 (held at the Central Bank) to Bank B.
@@ -135,40 +135,40 @@ between Alice and Bob needs to be replaced by three separate
 We refer to this scenario as *settlement with intermediaries*, or just *intermediated settlement*.
 
 The Route Provider is used to discover a settlement route, i.e.,
-:ref:`routed steps <type-daml-finance-interface-settlement-types-routedstep-10086>`, for each
-settlement :ref:`step <type-daml-finance-interface-settlement-types-step-78661>`.
+:ref:`routed steps <type-daml-finance-interface-settlement-v4-types-routedstep-26293>`, for each
+settlement :ref:`step <type-daml-finance-interface-settlement-v4-types-step-16302>`.
 
 Settlement factory
 ==================
 
-The :ref:`Settlement Factory <module-daml-finance-interface-settlement-factory-75196>` is used
-to instruct settlement, i.e., create the :ref:`Batch <module-daml-finance-settlement-batch-95573>`
-contract and the settlement :ref:`Instructions <module-daml-finance-settlement-instruction-87187>`,
-from :ref:`routed steps <type-daml-finance-interface-settlement-types-routedstep-10086>`, so that
+The :ref:`Settlement Factory <module-daml-finance-interface-settlement-v4-factory-85379>` is used
+to instruct settlement, i.e., create the :ref:`Batch <module-daml-finance-settlement-v4-batch-88124>`
+contract and the settlement :ref:`Instructions <module-daml-finance-settlement-v4-instruction-73130>`,
+from :ref:`routed steps <type-daml-finance-interface-settlement-v4-types-routedstep-26293>`, so that
 they can be allocated and approved by the respective parties.
 
 Instruction
 ===========
 
-The :ref:`Instruction <module-daml-finance-interface-settlement-instruction-10970>` is
+The :ref:`Instruction <module-daml-finance-interface-settlement-v4-instruction-71097>` is
 used to settle a single holding transfer at a specific custodian, once it is ``allocated`` and
 ``approved``.
 
-In the :ref:`Allocation <type-daml-finance-interface-settlement-types-allocation-46483>` step, the
+In the :ref:`Allocation <type-daml-finance-interface-settlement-v4-types-allocation-41200>` step, the
 sender acknowledges the transfer and determines how to send the holding. This is usually done by
-allocating with a :ref:`Pledge <constr-daml-finance-interface-settlement-types-pledge-99803>`
+allocating with a :ref:`Pledge <constr-daml-finance-interface-settlement-v4-types-pledge-57866>`
 of the sender's existing holding (which has the correct instrument quantity) at the custodian. When
 the sender is also the custodian, the instruction can be allocated with
-:ref:`CreditReceiver <constr-daml-finance-interface-settlement-types-creditreceiver-50700>`. In this
+:ref:`CreditReceiver <constr-daml-finance-interface-settlement-v4-types-creditreceiver-33781>`. In this
 case, a new holding is directly credited into the receiver's account.
 
-In the :ref:`Approval <type-daml-finance-interface-settlement-types-approval-84286>` step, the
+In the :ref:`Approval <type-daml-finance-interface-settlement-v4-types-approval-77821>` step, the
 receiver acknowledges the transfer and determines how to receive the holding. This is usually done
 by approving with
-:ref:`TakeDelivery <constr-daml-finance-interface-settlement-types-takedelivery-14079>` to one of
+:ref:`TakeDelivery <constr-daml-finance-interface-settlement-v4-types-takedelivery-31030>` to one of
 the receiver's accounts at the custodian. When the receiver is also the incoming holding's
 custodian, the instruction can be approved with
-:ref:`DebitSender <constr-daml-finance-interface-settlement-types-debitsender-39086>`. In this case,
+:ref:`DebitSender <constr-daml-finance-interface-settlement-v4-types-debitsender-18125>`. In this case,
 the holding is directly debited from the sender's account. A holding owned by the custodian at the
 custodian has no economical value, it is a liability against themselves and can therefore be
 archived without consequence.
@@ -189,33 +189,33 @@ be allocated / approved.
 |                                                    | with CreditReceiver  | to his account       |
 +----------------------------------------------------+----------------------+----------------------+
 
-Finally, the :ref:`Instruction <module-daml-finance-settlement-instruction-87187>` supports two
+Finally, the :ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>` supports two
 additional settlement modes:
 
 - Any instruction can settle off-ledger (if the stakeholders agree to do so). For this to work, we
   require the custodian and the sender to jointly allocate the instruction with a
-  :ref:`SettleOffledger <constr-daml-finance-interface-settlement-types-settleoffledger-15836>`,
+  :ref:`SettleOffledger <constr-daml-finance-interface-settlement-v4-types-settleoffledger-82795>`,
   and the custodian and the receiver to jointly approve the instruction with a
   :ref:`SettleOffledgerAcknowledge
-  <constr-daml-finance-interface-settlement-types-settleoffledgeracknowledge-98269>`.
+  <constr-daml-finance-interface-settlement-v4-types-settleoffledgeracknowledge-65556>`.
 - A special case occurs when a transfer happens via an intermediary at the same custodian, i.e., we
   have 2 instructions having the same custodian and instrument quantity (in a batch), and the
   receiver of the first instruction is the same as the sender of the second instruction. In this
   case, we allow the holding received from the first instruction to be passed through to settle the
   second instruction, i.e., without using any pre-existing holding of the intermediary. For this to
   work, the first instruction is approved with
-  :ref:`PassThroughTo <constr-daml-finance-interface-settlement-types-passthroughto-68260>` (i.e.,
+  :ref:`PassThroughTo <constr-daml-finance-interface-settlement-v4-types-passthroughto-8399>` (i.e.,
   pass through to the second instruction), and the second instruction is allocated with
-  :ref:`PassThroughFrom <constr-daml-finance-interface-settlement-types-passthroughfrom-69429>`
+  :ref:`PassThroughFrom <constr-daml-finance-interface-settlement-v4-types-passthroughfrom-2474>`
   (i.e., pass through from the first instruction). An intermediary account used for the passthrough
   is thereby also to be specified.
 
 Batch
 =====
 
-The :ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` is used to execute a set
+The :ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` is used to execute a set
 of instructions atomically. Execution will fail if any of the
-:ref:`Instructions <module-daml-finance-settlement-instruction-87187>` is not fully allocated
+:ref:`Instructions <module-daml-finance-settlement-v4-instruction-73130>` is not fully allocated
 / approved, or if the transfer is unsuccessful.
 
 Settlement Time
@@ -227,8 +227,8 @@ transaction date plus one, two, or three business days, respectively. Some marke
 real-time settlement options. It's also common for certain trades between parties to have unique,
 mutually agreed-upon settlement periods.
 
-The :ref:`Batch <module-daml-finance-settlement-batch-95573>` and
-:ref:`Instruction <module-daml-finance-settlement-instruction-87187>`
+The :ref:`Batch <module-daml-finance-settlement-v4-batch-88124>` and
+:ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>`
 implementations are designed to allow the optional setting of a preferred settlement time, without
 any mechanisms that enforce a specific settlement time. This design choice offers several
 advantages:
@@ -239,15 +239,15 @@ advantages:
 
 - **Avoidance of Early Settlement:** Parties involved in sending or receiving a holding may opt to
   delay their
-  :ref:`allocation <module-daml-finance-interface-settlement-instruction-10970>` or
-  :ref:`approval <module-daml-finance-interface-settlement-instruction-10970>` of an instruction
+  :ref:`allocation <module-daml-finance-interface-settlement-v4-instruction-71097>` or
+  :ref:`approval <module-daml-finance-interface-settlement-v4-instruction-71097>` of an instruction
   until just prior to the settlement time. This strategy prevents the
-  :ref:`Batch <module-daml-finance-settlement-batch-95573>` from settling prematurely.
+  :ref:`Batch <module-daml-finance-settlement-v4-batch-88124>` from settling prematurely.
 
 - **Handling of Late Settlements:** To address cases where parties fail to settle by the desired
   time, we propose using a separate custom contract instance. This contact could facilitate the
-  rolling of a :ref:`Batch <module-daml-finance-settlement-batch-95573>` (along with its
-  :ref:`Instruction <module-daml-finance-settlement-instruction-87187>`\s) into a subsequent
+  rolling of a :ref:`Batch <module-daml-finance-settlement-v4-batch-88124>` (along with its
+  :ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>`\s) into a subsequent
   settlement cycle if the initial settlement period lapses. Additionally, the contract could allow
   for imposing penalties on parties that fail to allocate or approve the transaction in a timely
   manner.

--- a/docs/3.1/docs/daml-finance/index.rst
+++ b/docs/3.1/docs/daml-finance/index.rst
@@ -62,7 +62,7 @@ Finance:
 Current Release
 ===============
 
-Daml SDK 2.9.4
+Daml SDK 2.10.0
 
 This section details the list of released and deprecated packages, with status information provided
 for each package according to the
@@ -72,100 +72,29 @@ the last release.
 
 **Important Note**: The current Daml Finance release requires the use of Daml SDK v2.5 or later.
 
-Major Updates
--------------
+Smart Contract Upgradeability
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The main driver for this release has been to optimize the library for useability, maintainability,
-and upgradability. Along with code changes, new documentation and tutorials have been added to
-streamline the learning process for new users.
+Daml Finance is now smart contract upgradeable by relying on Daml SDK 2.10.0 and Daml LF 1.17. As
+part of this change, each package incorporates its major version number (Vx) into its path, package
+name, and module name. Consequently, the major version for all Daml Finance packages has been
+incremented.
 
-This section outlines the major changes and reasons behind them. The technical changelog for each
-package can be found as a sub-page under :doc:`Packages <packages/index>`.
+Context-Aware Semaphore Lock Release
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Enhanced Upgradeability, Extensibility, and Interoperability
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A fix added to the Daml.Finance.Util package ensures that a holding protected by a semaphore lock
+will only be released if the lock's context matches the provided unlock context. This prevents
+inadvertent releases.
 
-The core asset model (``Account``, ``Holding``, and ``Instrument`` interfaces) has been enhanced to
-streamline upgrade processes, enhance extensibility, and improve interoperability:
+New AutoCallable Instrument
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. The ``Account`` now links to its ``Daml.Finance.Interface.Holding.V4.Factory`` by key, a
-   ``HoldingFactoryKey``, instead of a ``ContractId``. This facilitates the upgrading of a
-   ``HoldingFactory`` without the need to modify existing ``Account`` contract instances. It also
-   enables a "lazy" upgrade approach for holdings, as detailed the
-   :doc:`Holding Upgrade Tutorial <./tutorials/upgrade/holding>`.
-
-#. In anticipation of the need for standardization when implementing composed workflows across
-   applications, the notion of a ``HoldingStandard`` was introduced (as part of the
-   ``InstrumenKey``). It categorizes holdings into four distinct classes, each defined by the
-   combination of holding interfaces (``Transferable``, ``Fungible``, and ``Holding``) they
-   implement. This new standard has guided the renaming and structuring of holding implementations.
-   The ``Fungible`` interface no longer requires the ``Transferable`` interface. However, both
-   ``Transferable`` and ``Fungible`` continue to require the implementation of the ``Holding``
-   interface (renamed from ``Base`` following customer feedback). Moreover, the settlement process
-   has been refined to require only a matching ``HoldingStandard``, allowing for implementation
-   variations.
-
-#. A unified ``HoldingFactory`` capable of creating holdings for any specified ``HoldingStandard``
-   has been adopted. In particular, this enables multiple holdings (of various ``HoldingStandards``)
-   to be credited to the same account.
-
-Foreseeing future integration with Daml 3.0 and the Canton Network
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In order to ease future transitions to Daml 3.0 and the Canton Network, there is a shift to
-single-maintainer contract keys:
-
-#. The `issuer : Party` of the ``InstrumentKey`` is now the single maintainer for the ``Instrument``
-   key.
-
-#. For ``Batch`` and ``Instruction``, the `requestors : Parties` field has been divided into a
-   single-maintainer `instructor : Party` for the ``Instruction`` key, alongside additional
-   signatories `consenters : Parties`. Corresponding changes have been made to the ``Batch`` and
-   ``Instruction`` views. In the ``Daml.Finance.Lifecycle.V4.Rule.Claim`` implementation,
-   `providers : Parties` has been replaced with a single `provider : Party` (to facilitate assigning
-   the `provider` as a settlement `instructor : Party`).
-
-#. The LedgerTime key has been completely removed, as it was redundant.
-
-Streamlining Interface Archival
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Previously, our factory contracts featured a ``Remove`` choice for archiving interface instances.
-With Daml now supporting direct archival of interface instances, these choices have been removed. To
-facilitate the simultaneous archival of ``Account``, ``Instrument``, and ``HoldingFactory``
-interfaces with their related ``Reference`` contract instance, a ``Remove`` choice has been added to
-the ``Account``, base ``Instrument``, and ``HoldingFactory`` interfaces.
-
-New Interface Lockable
-~~~~~~~~~~~~~~~~~~~~~~
-
-The locking mechanism has been separated from the base ``Holding`` interface into a new ``Lockable``
-interface (which the ``Holding`` now requires). That makes ``Lockable`` available for broader use;
-while the ``Account`` also implements ``Lockable`` allowing to freeze an account, it’s not required.
-
-Additionally, the implementations of ``Transfer``, ``Split``, ``Merge``, and ``Debit`` have been
-adjusted to require unlocking before they can be used when in the locked state.
-
-New Instruments
-~~~~~~~~~~~~~~~
-
-The library's functionality has been broadened by introducing new financial instruments,
-such as structured products and multi-underlying asset swap instruments (both early access).
-
-Usability Improvements
-~~~~~~~~~~~~~~~~~~~~~~
-
-Finally, a large number (around 50 tickets) of smaller improvements addressing customer feedback
-were made. These improvements range from the consistency of naming conventions (for example, the type
-synonym ``F`` for factories has been renamed to ``T`` for factory templates and ``I`` for factory
-interfaces) in the library to didactical improvements in our docs and tutorials.
-
-Additional Changes
-~~~~~~~~~~~~~~~~~~
-
-The ``Calculate`` choice in the ``Effect`` interface now accepts a quantity as an argument instead
-of a ``ContractId Holding``. This change enhances privacy by minimizing unnecessary data exposure.
-
+A new AutoCallable instrument
+:ref:`AutoCallable <module-daml-finance-instrument-structuredproduct-v1-autocallable-instrument-89951>`
+has been added to the experimental
+Daml.Finance.Instrument.StructuredProduct.V1 package. This addition expands the set of available
+structured product instruments.
 
 Stable Packages
 ---------------

--- a/docs/3.1/docs/daml-finance/index.rst
+++ b/docs/3.1/docs/daml-finance/index.rst
@@ -88,7 +88,7 @@ Enhanced Upgradeability, Extensibility, and Interoperability
 The core asset model (``Account``, ``Holding``, and ``Instrument`` interfaces) has been enhanced to
 streamline upgrade processes, enhance extensibility, and improve interoperability:
 
-#. The ``Account`` now links to its ``Daml.Finance.Interface.Holding.Factory`` by key, a
+#. The ``Account`` now links to its ``Daml.Finance.Interface.Holding.V4.Factory`` by key, a
    ``HoldingFactoryKey``, instead of a ``ContractId``. This facilitates the upgrading of a
    ``HoldingFactory`` without the need to modify existing ``Account`` contract instances. It also
    enables a "lazy" upgrade approach for holdings, as detailed the
@@ -121,7 +121,7 @@ single-maintainer contract keys:
 #. For ``Batch`` and ``Instruction``, the `requestors : Parties` field has been divided into a
    single-maintainer `instructor : Party` for the ``Instruction`` key, alongside additional
    signatories `consenters : Parties`. Corresponding changes have been made to the ``Batch`` and
-   ``Instruction`` views. In the ``Daml.Finance.Lifecycle.Rule.Claim`` implementation,
+   ``Instruction`` views. In the ``Daml.Finance.Lifecycle.V4.Rule.Claim`` implementation,
    `providers : Parties` has been replaced with a single `provider : Party` (to facilitate assigning
    the `provider` as a settlement `instructor : Party`).
 
@@ -170,132 +170,132 @@ of a ``ContractId Holding``. This change enhances privacy by minimizing unnecess
 Stable Packages
 ---------------
 
-+-------------------------------------------+---------+--------+
-| Package                                   | Version | Status |
-+===========================================+=========+========+
-| ContingentClaims.Core                     | 2.0.1   | Stable |
-+-------------------------------------------+---------+--------+
-| ContingentClaims.Lifecycle                | 2.0.1   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Account                      | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Claims                       | 2.1.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Data                         | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Holding                      | 3.0.1   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Bond              | 2.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Generic           | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Token             | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Account            | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Claims             | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Data               | 3.1.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Holding            | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Base    | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Bond    | 2.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Generic | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Token   | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Types   | 1.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Lifecycle          | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Settlement         | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Types.Common       | 2.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Types.Date         | 2.1.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Util               | 2.1.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Lifecycle                    | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Settlement                   | 3.0.0   | Stable |
-+-------------------------------------------+---------+--------+
-| Daml.Finance.Util                         | 3.1.0   | Stable |
-+-------------------------------------------+---------+--------+
++----------------------------------------------+---------+--------+
+| Package                                      | Version | Status |
++==============================================+=========+========+
+| ContingentClaims.Core.V3                     | 2.0.1   | Stable |
++----------------------------------------------+---------+--------+
+| ContingentClaims.Lifecycle.V3                | 2.0.1   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Account.V4                      | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Claims.V3                       | 2.1.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Data.V4                         | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Holding.V4                      | 3.0.1   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Instrument.Bond.V3              | 2.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Instrument.Generic.V4           | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Instrument.Token.V4             | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Account.V4            | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Claims.V4             | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Data.V4               | 3.1.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Holding.V4            | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Base.V4    | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Bond.V3    | 2.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Generic.V4 | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Token.V4   | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Types.V2   | 1.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Lifecycle.V4          | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Settlement.V4         | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Types.Common.V3       | 2.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Types.Date.V3         | 2.1.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Util.V3               | 2.1.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Lifecycle.V4                    | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Settlement.V4                   | 3.0.0   | Stable |
++----------------------------------------------+---------+--------+
+| Daml.Finance.Util.V4                         | 3.1.0   | Stable |
++----------------------------------------------+---------+--------+
 
 Early Access Packages
 ---------------------
 
-+-----------------------------------------------------+---------+--------+
-| Package                                             | Version | Status |
-+=====================================================+=========+========+
-| ContingentClaims.Valuation                          | 0.2.2   | Labs   |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Equity                      | 0.4.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Option                      | 0.3.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.StructuredProduct           | 0.1.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Swap                        | 0.4.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Equity            | 0.4.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Option            | 0.3.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.StructuredProduct | 0.1.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Swap              | 0.4.0   | Alpha  |
-+-----------------------------------------------------+---------+--------+
++--------------------------------------------------------+---------+--------+
+| Package                                                | Version | Status |
++========================================================+=========+========+
+| ContingentClaims.Valuation.V1                          | 0.2.2   | Labs   |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Instrument.Equity.V1                      | 0.4.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Instrument.Option.V1                      | 0.3.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Instrument.StructuredProduct.V1           | 0.1.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Instrument.Swap.V1                        | 0.4.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Equity.V1            | 0.4.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Option.V1            | 0.3.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.StructuredProduct.V1 | 0.1.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
+| Daml.Finance.Interface.Instrument.Swap.V1              | 0.4.0   | Alpha  |
++--------------------------------------------------------+---------+--------+
 
 Deprecated Packages
 -------------------
 
-+--------------------------------------------+--------------------+--------+
-| Package                                    | Version            | Status |
-+============================================+====================+========+
-| ContingentClaims.Core                      | 1.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| ContingentClaims.Lifecycle                 | 1.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Account                       | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Claims                        | 1.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Data                          | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Holding                       | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Instrument.Generic            | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Instrument.Token              | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Account             | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Claims              | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Data                | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Holding             | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Instrument.Base     | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Instrument.Generic  | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Instrument.Token    | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Lifecycle           | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Settlement          | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Util                | 1.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Lifecycle                     | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Settlement                    | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
-| Daml.Finance.Util                          | 2.*                | Depr.  |
-+--------------------------------------------+--------------------+--------+
++-----------------------------------------------+--------------------+--------+
+| Package                                       | Version            | Status |
++===============================================+====================+========+
+| ContingentClaims.Core.V3                      | 1.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| ContingentClaims.Lifecycle.V3                 | 1.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Account.V4                       | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Claims.V3                        | 1.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Data.V4                          | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Holding.V4                       | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Instrument.Generic.V4            | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Instrument.Token.V4              | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Account.V4             | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Claims.V4              | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Data.V4                | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Holding.V4             | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Instrument.Base.V4     | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Instrument.Generic.V4  | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Instrument.Token.V4    | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Lifecycle.V4           | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Settlement.V4          | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Interface.Util.V3                | 1.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Lifecycle.V4                     | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Settlement.V4                    | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+
+| Daml.Finance.Util.V4                          | 2.*                | Depr.  |
++-----------------------------------------------+--------------------+--------+

--- a/docs/3.1/docs/daml-finance/index.rst
+++ b/docs/3.1/docs/daml-finance/index.rst
@@ -173,57 +173,57 @@ Stable Packages
 +----------------------------------------------+---------+--------+
 | Package                                      | Version | Status |
 +==============================================+=========+========+
-| ContingentClaims.Core.V3                     | 2.0.1   | Stable |
+| ContingentClaims.Core.V3                     | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| ContingentClaims.Lifecycle.V3                | 2.0.1   | Stable |
+| ContingentClaims.Lifecycle.V3                | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Account.V4                      | 3.0.0   | Stable |
+| Daml.Finance.Account.V4                      | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Claims.V3                       | 2.1.0   | Stable |
+| Daml.Finance.Claims.V3                       | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Data.V4                         | 3.0.0   | Stable |
+| Daml.Finance.Data.V4                         | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Holding.V4                      | 3.0.1   | Stable |
+| Daml.Finance.Holding.V4                      | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Bond.V3              | 2.0.0   | Stable |
+| Daml.Finance.Instrument.Bond.V3              | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Generic.V4           | 3.0.0   | Stable |
+| Daml.Finance.Instrument.Generic.V4           | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Token.V4             | 3.0.0   | Stable |
+| Daml.Finance.Instrument.Token.V4             | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Account.V4            | 3.0.0   | Stable |
+| Daml.Finance.Interface.Account.V4            | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Claims.V4             | 3.0.0   | Stable |
+| Daml.Finance.Interface.Claims.V4             | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Data.V4               | 3.1.0   | Stable |
+| Daml.Finance.Interface.Data.V4               | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Holding.V4            | 3.0.0   | Stable |
+| Daml.Finance.Interface.Holding.V4            | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Base.V4    | 3.0.0   | Stable |
+| Daml.Finance.Interface.Instrument.Base.V4    | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Bond.V3    | 2.0.0   | Stable |
+| Daml.Finance.Interface.Instrument.Bond.V3    | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Generic.V4 | 3.0.0   | Stable |
+| Daml.Finance.Interface.Instrument.Generic.V4 | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Token.V4   | 3.0.0   | Stable |
+| Daml.Finance.Interface.Instrument.Token.V4   | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Types.V2   | 1.0.0   | Stable |
+| Daml.Finance.Interface.Instrument.Types.V2   | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Lifecycle.V4          | 3.0.0   | Stable |
+| Daml.Finance.Interface.Lifecycle.V4          | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Settlement.V4         | 3.0.0   | Stable |
+| Daml.Finance.Interface.Settlement.V4         | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Types.Common.V3       | 2.0.0   | Stable |
+| Daml.Finance.Interface.Types.Common.V3       | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Types.Date.V3         | 2.1.0   | Stable |
+| Daml.Finance.Interface.Types.Date.V3         | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Util.V3               | 2.1.0   | Stable |
+| Daml.Finance.Interface.Util.V3               | 3.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Lifecycle.V4                    | 3.0.0   | Stable |
+| Daml.Finance.Lifecycle.V4                    | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Settlement.V4                   | 3.0.0   | Stable |
+| Daml.Finance.Settlement.V4                   | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
-| Daml.Finance.Util.V4                         | 3.1.0   | Stable |
+| Daml.Finance.Util.V4                         | 4.0.0   | Stable |
 +----------------------------------------------+---------+--------+
 
 Early Access Packages
@@ -232,23 +232,23 @@ Early Access Packages
 +--------------------------------------------------------+---------+--------+
 | Package                                                | Version | Status |
 +========================================================+=========+========+
-| ContingentClaims.Valuation.V1                          | 0.2.2   | Labs   |
+| ContingentClaims.Valuation.V1                          | 1.0.0   | Labs   |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Equity.V1                      | 0.4.0   | Alpha  |
+| Daml.Finance.Instrument.Equity.V1                      | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Option.V1                      | 0.3.0   | Alpha  |
+| Daml.Finance.Instrument.Option.V1                      | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.StructuredProduct.V1           | 0.1.0   | Alpha  |
+| Daml.Finance.Instrument.StructuredProduct.V1           | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Instrument.Swap.V1                        | 0.4.0   | Alpha  |
+| Daml.Finance.Instrument.Swap.V1                        | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Equity.V1            | 0.4.0   | Alpha  |
+| Daml.Finance.Interface.Instrument.Equity.V1            | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Option.V1            | 0.3.0   | Alpha  |
+| Daml.Finance.Interface.Instrument.Option.V1            | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.StructuredProduct.V1 | 0.1.0   | Alpha  |
+| Daml.Finance.Interface.Instrument.StructuredProduct.V1 | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
-| Daml.Finance.Interface.Instrument.Swap.V1              | 0.4.0   | Alpha  |
+| Daml.Finance.Interface.Instrument.Swap.V1              | 1.0.0   | Alpha  |
 +--------------------------------------------------------+---------+--------+
 
 Deprecated Packages
@@ -257,45 +257,46 @@ Deprecated Packages
 +-----------------------------------------------+--------------------+--------+
 | Package                                       | Version            | Status |
 +===============================================+====================+========+
-| ContingentClaims.Core.V3                      | 1.*                | Depr.  |
+| ContingentClaims.Core                         | 2.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| ContingentClaims.Lifecycle.V3                 | 1.*                | Depr.  |
+| ContingentClaims.Lifecycle                    | 2.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Account.V4                       | 2.*                | Depr.  |
+| Daml.Finance.Account                          | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Claims.V3                        | 1.*                | Depr.  |
+| Daml.Finance.Claims                           | 2.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Data.V4                          | 2.*                | Depr.  |
+| Daml.Finance.Data                             | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Holding.V4                       | 2.*                | Depr.  |
+| Daml.Finance.Holding                          | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Instrument.Generic.V4            | 2.*                | Depr.  |
+| Daml.Finance.Instrument.Generic               | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Instrument.Token.V4              | 2.*                | Depr.  |
+| Daml.Finance.Instrument.Token                 | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Account.V4             | 2.*                | Depr.  |
+| Daml.Finance.Interface.Account                | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Claims.V4              | 2.*                | Depr.  |
+| Daml.Finance.Interface.Claims                 | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Data.V4                | 2.*                | Depr.  |
+| Daml.Finance.Interface.Data                   | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Holding.V4             | 2.*                | Depr.  |
+| Daml.Finance.Interface.Holding                | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Instrument.Base.V4     | 2.*                | Depr.  |
+| Daml.Finance.Interface.Instrument.Base        | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Instrument.Generic.V4  | 2.*                | Depr.  |
+| Daml.Finance.Interface.Instrument.Generic     | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Instrument.Token.V4    | 2.*                | Depr.  |
+| Daml.Finance.Interface.Instrument.Token       | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Lifecycle.V4           | 2.*                | Depr.  |
+| Daml.Finance.Interface.Lifecycle              | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Settlement.V4          | 2.*                | Depr.  |
+| Daml.Finance.Interface.Settlement             | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Interface.Util.V3                | 1.*                | Depr.  |
+| Daml.Finance.Interface.Util                   | 2.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Lifecycle.V4                     | 2.*                | Depr.  |
+| Daml.Finance.Lifecycle                        | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Settlement.V4                    | 2.*                | Depr.  |
+| Daml.Finance.Settlement                       | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
-| Daml.Finance.Util.V4                          | 2.*                | Depr.  |
+| Daml.Finance.Util                             | 3.*                | Depr.  |
 +-----------------------------------------------+--------------------+--------+
+

--- a/docs/3.1/docs/daml-finance/index.rst
+++ b/docs/3.1/docs/daml-finance/index.rst
@@ -72,13 +72,16 @@ the last release.
 
 **Important Note**: The current Daml Finance release requires the use of Daml SDK v2.5 or later.
 
-Smart Contract Upgradeability
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Smart Contract Upgradeability (SCU)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Daml Finance is now smart contract upgradeable by relying on Daml SDK 2.10.0 and Daml LF 1.17. As
-part of this change, each package incorporates its major version number (Vx) into its path, package
-name, and module name. Consequently, the major version for all Daml Finance packages has been
-incremented.
+Daml Finance is now SCU compatible by relying on Daml SDK 2.10.0 and Daml LF 1.17. As part of this
+change, each package incorporates its major version number (Vx) into its path, package name, and
+module name. Consequently, the major version for all Daml Finance packages has been incremented.
+
+.. NOTE::
+   By default, SDK 2.10.0 uses LF 1.15. Enabling SCU support requires building with LF 1.17. To
+   ensure SCU compatibility within Daml Finance, we consistently use LF 1.17.
 
 Context-Aware Semaphore Lock Release
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/3.1/docs/daml-finance/instruments/bond.rst
+++ b/docs/3.1/docs/daml-finance/instruments/bond.rst
@@ -35,7 +35,7 @@ currently supports the following bond types:
 Fixed Rate
 ==========
 
-:ref:`Fixed rate bonds <module-daml-finance-instrument-bond-fixedrate-instrument-67993>`
+:ref:`Fixed rate bonds <module-daml-finance-instrument-bond-v3-fixedrate-instrument-89221>`
 pay a constant coupon rate at the end of each coupon period. The coupon is quoted on a yearly basis
 (per annum, p.a.), but it could be paid more frequently (e.g. quarterly). For example, a bond could
 have a 2% p.a. coupon and a 6M coupon period. That would mean a 1% coupon is paid twice a year.
@@ -52,17 +52,17 @@ We start by defining the terms:
   :start-after: -- CREATE_FIXED_RATE_BOND_VARIABLES_BEGIN
   :end-before: -- CREATE_FIXED_RATE_BOND_VARIABLES_END
 
-The :ref:`day count convention <type-daml-finance-interface-types-date-daycount-daycountconventionenum-67281>`
+The :ref:`day count convention <type-daml-finance-interface-types-date-v3-daycount-daycountconventionenum-31>`
 is used to determine how many days, i.e., what fraction of a full year, each coupon period has. This
 will determine the exact coupon amount that will be paid each period.
 
-The :ref:`business day convention <type-daml-finance-interface-types-date-calendar-businessdayconventionenum-88986>`
+The :ref:`business day convention <type-daml-finance-interface-types-date-v3-calendar-businessdayconventionenum-14112>`
 determines *how* a coupon date is adjusted if it falls on a non-business day.
 
 We also need holiday calendars, which determine *when* to adjust dates.
 
 We can use these variables to create a
-:ref:`PeriodicSchedule <constr-daml-finance-interface-types-date-schedule-periodicschedule-99705>`:
+:ref:`PeriodicSchedule <constr-daml-finance-interface-types-date-v3-schedule-periodicschedule-24577>`:
 
 .. literalinclude:: ../src/test/daml/Daml/Finance/Test/Util/Time.daml
   :language: daml
@@ -72,10 +72,10 @@ We can use these variables to create a
 This is used to determine the periods that are used to calculate the coupon. There are a few things
 to note here:
 
-- The :ref:`RollConventionEnum <type-daml-finance-interface-types-date-rollconvention-rollconventionenum-73360>`
+- The :ref:`RollConventionEnum <type-daml-finance-interface-types-date-v3-rollconvention-rollconventionenum-89490>`
   defines whether dates are rolled at the end of the month or on a given date of the month. In our
   example above, we went for the latter option.
-- The :ref:`StubPeriodTypeEnum <type-daml-finance-interface-types-date-schedule-stubperiodtypeenum-69372>`
+- The :ref:`StubPeriodTypeEnum <type-daml-finance-interface-types-date-v3-schedule-stubperiodtypeenum-99734>`
   allows you to explicitly specify what kind of stub period the bond should have. This is optional
   and not used in the example above. Instead, we defined the stub implicitly by specifying a
   ``firstRegularPeriodStartDate``: since the time between the issue date and the first regular
@@ -93,12 +93,12 @@ Now that we have defined the terms we can create the bond instrument:
   :end-before: -- CREATE_FIXED_RATE_BOND_INSTRUMENT_END
 
 Once this is done, you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 
 Floating Rate
 =============
 
-:ref:`Floating rate bonds <module-daml-finance-instrument-bond-floatingrate-instrument-98586>`
+:ref:`Floating rate bonds <module-daml-finance-instrument-bond-v3-floatingrate-instrument-82370>`
 pay a coupon which is determined by a reference rate.
 There is also a rate spread, which is paid in addition to the reference rate.
 
@@ -110,7 +110,7 @@ Here is an example of a bond paying Euribor 3M + 1.1% p.a. with a 3M coupon peri
   :end-before: -- CREATE_FLOATING_RATE_BOND_VARIABLES_END
 
 The instrument supports two types of reference rates, which are configurable using the
-:ref:`ReferenceRateTypeEnum <type-daml-finance-interface-instrument-types-floatingrate-referenceratetypeenum-97197>`:
+:ref:`ReferenceRateTypeEnum <type-daml-finance-interface-instrument-types-v2-floatingrate-referenceratetypeenum-15522>`:
 
 - Libor/Euribor style rates with a single fixing
 - SOFR style reference rates (using a compounded index)
@@ -128,7 +128,7 @@ for the coupon payment at the end of that period.
 Callable
 ========
 
-:ref:`Callable bonds <module-daml-finance-instrument-bond-callable-instrument-83330>` are similar to
+:ref:`Callable bonds <module-daml-finance-instrument-bond-v3-callable-instrument-35206>` are similar to
 the bonds above, but in addition they can be redeemed by the issuer before maturity. The callability
 is restricted to some (or all) of the coupon dates. In other words, these bonds have a *Bermudan*
 style embedded call option.
@@ -147,7 +147,7 @@ The coupon rate in this example also has a 0% floor and a 1.5% cap. This is conf
 the cap or floor to *None* if it does not apply.
 
 The fixed rate is fairly simple to define, but the floating rate requires more inputs. A
-:ref:`FloatingRate <type-daml-finance-interface-instrument-types-floatingrate-floatingrate-77836>`
+:ref:`FloatingRate <type-daml-finance-interface-instrument-types-v2-floatingrate-floatingrate-56149>`
 data type is used to specify which reference rate should be used and on which date the reference
 rate is fixed for each coupon period.
 
@@ -166,7 +166,7 @@ amount).
 In addition to the Libor/Euribor style reference rates, compounded SOFR and similar reference rates
 are also supported. In order to optimize performance, these compounded rates are calculated via a
 (pre-computed) continuously compounded index, as described in the
-:ref:`ReferenceRateTypeEnum <type-daml-finance-interface-instrument-types-floatingrate-referenceratetypeenum-97197>`.
+:ref:`ReferenceRateTypeEnum <type-daml-finance-interface-instrument-types-v2-floatingrate-referenceratetypeenum-15522>`.
 For example, here is how *daily compounded SOFR* can be specified using the *SOFR Index*:
 
 .. literalinclude:: ../src/test/daml/Daml/Finance/Instrument/Bond/Test/Callable.daml
@@ -216,7 +216,7 @@ Inflation-Linked
 ================
 
 There are different types of inflation-linked bonds in the marketplace. The
-:ref:`Inflation-linked bonds <module-daml-finance-instrument-bond-inflationlinked-instrument-30250>`
+:ref:`Inflation-linked bonds <module-daml-finance-instrument-bond-v3-inflationlinked-instrument-99606>`
 currently supported in Daml Finance pay a fixed coupon rate at the end of every coupon period. This
 corresponds to the payoff of e.g. Treasury Inflation-Protected Securities (TIPS) that are issued by
 the U.S. Treasury. The coupon is calculated based on a principal that is adjusted according to an
@@ -244,7 +244,7 @@ specified coupon rate but the original principal would still be redeemed at matu
 Zero Coupon
 ===========
 
-A :ref:`zero coupon bond <module-daml-finance-instrument-bond-zerocoupon-instrument-52804>`
+A :ref:`zero coupon bond <module-daml-finance-instrument-bond-v3-zerocoupon-instrument-96672>`
 does not pay any coupons at all. It only pays the redemption amount at maturity.
 
 Here is an example of a zero coupon bond:

--- a/docs/3.1/docs/daml-finance/instruments/equity.rst
+++ b/docs/3.1/docs/daml-finance/instruments/equity.rst
@@ -27,7 +27,7 @@ The Equity Interface
 
 The equity instrument supports different lifecycle events, such as dividends, stock
 splits and mergers. These are modeled using the choices on the
-:ref:`Equity interface <module-daml-finance-interface-instrument-equity-instrument-13224>`,
+:ref:`Equity interface <module-daml-finance-interface-instrument-equity-v1-instrument-10480>`,
 namely ``DeclareDistribution``, ``DeclareReplacement`` and ``DeclareStockSplit``. We will now
 demonstrate each one with a concrete lifecycle event.
 
@@ -37,11 +37,11 @@ Dividend
 The most common lifecycle event of an equity is probably dividends. This normally means that
 the holder of a stock receives a given amount of cash for each stock held. This is modeled using
 the ``DeclareDistribution`` choice. It creates a
-:ref:`Distribution Event <module-daml-finance-lifecycle-event-distribution-17302>`,
+:ref:`Distribution Event <module-daml-finance-lifecycle-v4-event-distribution-38493>`,
 which allows you to specify distribution per share. In the case of a cash dividend, this would be a
 cash instrument. However, the company can also choose to distribute additional stock or even stock
 options. Since the
-:ref:`Distribution Event <module-daml-finance-lifecycle-event-distribution-17302>`
+:ref:`Distribution Event <module-daml-finance-lifecycle-v4-event-distribution-38493>`
 supports an arbitrary ``perUnitDistribution`` instrument, it can be used to model those use cases as
 well.
 
@@ -122,7 +122,7 @@ The preferred way is to model this using the following two components:
 
 - A dividend option instrument, which describes the economic terms of the rights a shareholder
   receives. The page on the :doc:`Option Instrument package <option>` describes how to
-  create a physically settled :ref:`Dividend <module-daml-finance-instrument-option-dividend-instrument-7333>`
+  create a physically settled :ref:`Dividend <module-daml-finance-instrument-option-v1-dividend-instrument-35111>`
   option.
 - The ``DeclareDistribution`` choice to distribute the above option instrument in the correct
   proportion (e.g. 1 option contract for each share held). This can be done in the same way as the
@@ -214,7 +214,7 @@ means that a shareholder will have two shares after the split for every share he
 This is modeled using the ``DeclareStockSplit`` choice, which has an ``adjustmentFactor`` argument.
 
 The ``DeclareStockSplit`` choice creates a
-:ref:`Replacement Event <module-daml-finance-lifecycle-event-replacement-51859>`,
+:ref:`Replacement Event <module-daml-finance-lifecycle-v4-event-replacement-94706>`,
 which allows you to replace units of an instrument with another instrument (or a basket of other
 instruments). Consequently, this interface can also be used for other types of corporate actions
 (for example, see the *merger* scenario below).
@@ -265,7 +265,7 @@ Merger
 
 The merger scenario models the case when one company acquires another company and pays for it using
 its own shares. This is modeled using the ``DeclareReplacement`` choice, which also uses the
-:ref:`Replacement Event <module-daml-finance-lifecycle-event-replacement-51859>`
+:ref:`Replacement Event <module-daml-finance-lifecycle-v4-event-replacement-94706>`
 (like the *stock split* scenario above).
 This is a mandatory exchange offer: no election is required (or possible) by the shareholder.
 

--- a/docs/3.1/docs/daml-finance/instruments/generic.rst
+++ b/docs/3.1/docs/daml-finance/instruments/generic.rst
@@ -56,7 +56,7 @@ Alternatively, if you want to model a European Option instead, you can define th
   :start-after: -- CREATE_CC_OPTION_INSTRUMENT_VARIABLES_BEGIN
   :end-before: -- CREATE_CC_OPTION_INSTRUMENT_VARIABLES_END
 
-This uses the :ref:`european <function-contingentclaims-core-builders-european-99265>` builder
+This uses the :ref:`european <function-contingentclaims-core-v3-builders-european-38509>` builder
 function, which is included in :doc:`Contingent Claims <generic/contingent-claims>`.
 
 Compared to the bond, where the passage of time results in a coupon payment being due, the
@@ -134,7 +134,7 @@ Daml Finance library. There can be different processes to create the Election, s
 application specific. Still, in order to showcase one way how this could be done, this workflow is
 included here for convenience.
 
-The :ref:`Election <module-daml-finance-interface-lifecycle-election-24570>`
+The :ref:`Election <module-daml-finance-interface-lifecycle-v4-election-15483>`
 has a flag *electorIsOwner*, which indicates whether the election is on behalf of the owner of the
 holding. This is typically the case for options, where the option holder has the right, but not the
 obligation, to exercise the option. On the other hand, for callable bonds it is not the holding

--- a/docs/3.1/docs/daml-finance/instruments/generic/contingent-claims.rst
+++ b/docs/3.1/docs/daml-finance/instruments/generic/contingent-claims.rst
@@ -8,7 +8,7 @@ Introduction
 ************
 
 Contingent Claims is a library for modeling financial instruments in Daml. An instrument is
-represented by a tree of :ref:`Claims <type-contingentclaims-core-internal-claim-claim-35538>`,
+represented by a tree of :ref:`Claims <type-contingentclaims-core-v3-internal-claim-claim-83050>`,
 which describe future contractual events (cashflows and other `effects <#lifecycling-effect>`__)
 between two parties as well as the conditions under which these contractual events occur.
 
@@ -40,7 +40,7 @@ intervals (the small arrows), and a single repayment of the loan at maturity (th
 right). So how do we go about modelling this?
 
 We use the following data type, slightly simplified from
-:ref:`Claim <type-contingentclaims-core-internal-claim-claim-35538>`:
+:ref:`Claim <type-contingentclaims-core-v3-internal-claim-claim-83050>`:
 
 .. code-block:: daml
 
@@ -113,7 +113,7 @@ wish to avoid repeating ourselves. Hence, we could write functions to re-use sub
 tree. But which parts should we factor out? It turns out that Finance 101 comes to the rescue
 again. Fixed income practitioners will typically model a fixed-rate bond as a sum of zero-coupon
 bonds. That’s how we model them in :ref:`Claims.Util.Builders
-<module-daml-finance-claims-util-builders-48637>`. Below are slightly simplified versions:
+<module-daml-finance-claims-v3-util-builders-30825>`. Below are slightly simplified versions:
 
 .. code:: daml
 
@@ -225,7 +225,7 @@ a different use case: the lifecycling (aka safekeeping, processing corporate act
 instruments.
 
 Let’s go back to our fixed-rate bond example, above. We want to process the coupon payments. There
-is a function in the :ref:`Lifecycle module <module-contingentclaims-lifecycle-lifecycle-72039>`
+is a function in the :ref:`Lifecycle module <module-contingentclaims-lifecycle-v3-lifecycle-61551>`
 for doing exactly this:
 
 .. literalinclude:: ../../src/main/daml/ContingentClaims/Lifecycle/V3/Lifecycle.daml
@@ -268,7 +268,7 @@ Pricing (Experimental)
 
 This is an *experimental* feature. Expect breaking changes.
 
-The :ref:`ContigentClaims.Valuation.Stochastic <module-contingentclaims-valuation-stochastic-37844>`
+The :ref:`ContigentClaims.Valuation.Stochastic <module-contingentclaims-valuation-v1-stochastic-86240>`
 module can be used for valuation. There is a ``fapf``
 function which is used to derive a *fundamental asset pricing formula* for an arbitrary ``Claim``
 tree. The resulting AST is represented by ``Expr``, but can be rendered as XML/MathML with the

--- a/docs/3.1/docs/daml-finance/instruments/generic/contingent-claims.rst
+++ b/docs/3.1/docs/daml-finance/instruments/generic/contingent-claims.rst
@@ -228,7 +228,7 @@ Let’s go back to our fixed-rate bond example, above. We want to process the co
 is a function in the :ref:`Lifecycle module <module-contingentclaims-lifecycle-lifecycle-72039>`
 for doing exactly this:
 
-.. literalinclude:: ../../src/main/daml/ContingentClaims/Lifecycle/Lifecycle.daml
+.. literalinclude:: ../../src/main/daml/ContingentClaims/Lifecycle/V3/Lifecycle.daml
   :language: daml
   :start-after: -- CLAIMS_LIFECYCLE_BEGIN
   :end-before: -- CLAIMS_LIFECYCLE_END

--- a/docs/3.1/docs/daml-finance/instruments/option.rst
+++ b/docs/3.1/docs/daml-finance/instruments/option.rst
@@ -32,7 +32,7 @@ Physically settled European Option
 ----------------------------------
 
 The
-:ref:`EuropeanPhysical <module-daml-finance-instrument-option-europeanphysical-instrument-71708>`
+:ref:`EuropeanPhysical <module-daml-finance-instrument-option-v1-europeanphysical-instrument-98774>`
 instrument models physically settled call or put options.
 
 There are two important characteristics of this instrument:
@@ -65,14 +65,14 @@ Now that the terms have been defined, you can create the option instrument:
   :end-before: -- CREATE_EUROPEAN_PHYSICAL_OPTION_INSTRUMENT_END
 
 Once this is done, you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 
 Cash-settled European Option
 ----------------------------
 
-The  :ref:`EuropeanCash <module-daml-finance-instrument-option-europeancash-instrument-22074>`
+The  :ref:`EuropeanCash <module-daml-finance-instrument-option-v1-europeancash-instrument-97900>`
 instrument models cash-settled, auto-exercising call or put options. They are similar to the
-:ref:`EuropeanPhysical <module-daml-finance-instrument-option-europeancash-instrument-22074>`
+:ref:`EuropeanPhysical <module-daml-finance-instrument-option-v1-europeancash-instrument-97900>`
 instrument described above, but there are two important differences:
 
 #. *cash settlement*: This means that the underlying asset will not change hands. Instead, a cash
@@ -100,7 +100,7 @@ Now that the terms have been defined, you can create the option instrument:
   :end-before: -- CREATE_EUROPEAN_OPTION_INSTRUMENT_END
 
 Once this is done, you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 
 If the close price of AAPL on the expiry date is above the *strike* price, the option holder would
 profit from exercising the option and buying the stock at the strike price. The value of the option
@@ -123,18 +123,18 @@ Barrier Option
 ==============
 
 The
-:ref:`BarrierEuropeanCash <module-daml-finance-interface-instrument-option-barriereuropeancash-instrument-61159>`
+:ref:`BarrierEuropeanCash <module-daml-finance-interface-instrument-option-v1-barriereuropeancash-instrument-53071>`
 instrument models barrier options. They are similar to the
-:ref:`EuropeanCash <module-daml-finance-instrument-option-europeancash-instrument-22074>`
+:ref:`EuropeanCash <module-daml-finance-instrument-option-v1-europeancash-instrument-97900>`
 instrument described above, but also contain a barrier that is used to activate (or, alternatively,
 knock out) the option. The
-:ref:`BarrierTypeEnum <type-daml-finance-interface-instrument-option-types-barriertypeenum-80356>`
+:ref:`BarrierTypeEnum <type-daml-finance-interface-instrument-option-v1-types-barriertypeenum-4880>`
 describes which barrier types are supported.
 
 As an example, consider an option instrument that gives the holder the right to buy AAPL stock
 at a given price. However, if AAPL ever trades at or below a given barrier level, the option is
 knocked out (which means that it expires worthless). In other words, this describes a
-:ref:`DownAndOut <constr-daml-finance-interface-instrument-option-types-downandout-16889>` option.
+:ref:`DownAndOut <constr-daml-finance-interface-instrument-option-v1-types-downandout-65367>` option.
 This example is taken from
 `Instrument/Option/Test/BarrierEuropeanCash.daml <https://github.com/digital-asset/daml-finance/blob/main/src/test/daml/Daml/Finance/Instrument/Option/Test/BarrierEuropeanCash.daml>`_
 , where all the details are available.
@@ -154,10 +154,10 @@ Now that the terms have been defined, you can create the option instrument:
   :end-before: -- CREATE_BARRIER_EUROPEAN_OPTION_INSTRUMENT_END
 
 Once this is done, you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 
 Compared to the
-:ref:`EuropeanCash option <module-daml-finance-instrument-option-europeancash-instrument-22074>`
+:ref:`EuropeanCash option <module-daml-finance-instrument-option-v1-europeancash-instrument-97900>`
 this instrument needs to be lifecycled not only at expiry but also during its lifetime in case of a
 barrier hit. This is done in the same way as lifecycling at maturity, i.e. an *Observation* is
 provided for the reference asset identifier, containing the date and the underlying price.
@@ -165,7 +165,7 @@ provided for the reference asset identifier, containing the date and the underly
 Dividend Option
 ===============
 
-The :ref:`Dividend <module-daml-finance-instrument-option-dividend-instrument-7333>`
+The :ref:`Dividend <module-daml-finance-instrument-option-v1-dividend-instrument-35111>`
 instrument models physically settled, manually exercised dividend options. For reference, a
 dividend option gives the holder the right to choose one out of several dividend payouts, on a
 specific *expiry* date in the future. The following payout types are supported:
@@ -196,7 +196,7 @@ Now that the terms have been defined, you can create the option instrument:
   :end-before: -- CREATE_DIVIDEND_OPTION_INSTRUMENT_END
 
 Once this is done, you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 
 On the expiry date, the option holder will make an *Election* out of the available choices. The
 lifecycling of this option works in the same way as for

--- a/docs/3.1/docs/daml-finance/instruments/structured-product.rst
+++ b/docs/3.1/docs/daml-finance/instruments/structured-product.rst
@@ -22,7 +22,7 @@ Barrier Reverse Convertible
 ===========================
 
 The
-:ref:`BarrierReverseConvertible <module-daml-finance-instrument-structuredproduct-barrierreverseconvertible-instrument-95793>`
+:ref:`BarrierReverseConvertible <module-daml-finance-instrument-structuredproduct-v1-barrierreverseconvertible-instrument-16231>`
 instrument models cash-settled, auto-exercising barrier reverse convertible (BRC) instruments. It
 can be seen as a long fixed coupon bond and a short Down-And-In put option.
 
@@ -49,7 +49,7 @@ Now that the terms have been defined, you can create the BRC instrument:
   :end-before: -- CREATE_BARRIER_REVERSE_CONVERTIBLE_INSTRUMENT_END
 
 Once this is done, you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 
 This BRC instrument is automatically exercised. This means that the decision whether or not to
 exercise the embedded option is done automatically by comparing observations of the underlying to
@@ -68,7 +68,7 @@ Auto-Callable
 =============
 
 The
-:ref:`AutoCallable <module-daml-finance-interface-instrument-structuredproduct-autocallable-instrument-66988>`
+:ref:`AutoCallable <module-daml-finance-interface-instrument-structuredproduct-v1-autocallable-instrument-15420>`
 instrument models a single-underlying auto-callable note that pays a conditional coupon.
 
 Coupon payment
@@ -118,7 +118,7 @@ Now that the terms have been defined, you can create the AutoCallable instrument
   :end-before: -- CREATE_AUTO_CALLABLE_INSTRUMENT_END
 
 Then you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 
 This instrument is automatically called. This means that the decision whether or not to exercise the
 embedded option is done automatically using the observations of the underlying asset.

--- a/docs/3.1/docs/daml-finance/instruments/swap.rst
+++ b/docs/3.1/docs/daml-finance/instruments/swap.rst
@@ -29,7 +29,7 @@ currently supports the following types of swaps:
 Interest Rate
 =============
 
-:ref:`Interest rate swap <module-daml-finance-instrument-swap-interestrate-instrument-86260>`
+:ref:`Interest rate swap <module-daml-finance-instrument-swap-v1-interestrate-instrument-25554>`
 is the type of swap that shares most similarities with a bond. It has two legs:
 one which pays a fix rate and another one which pays a floating rate. These rates are paid at the
 end of every payment period.
@@ -47,9 +47,9 @@ We start by defining the terms:
   :end-before: -- CREATE_INTEREST_RATE_SWAP_VARIABLES_END
 
 The floating leg depends on a reference rate, which is specified in the
-:ref:`FloatingRate <type-daml-finance-interface-instrument-types-floatingrate-floatingrate-77836>`
+:ref:`FloatingRate <type-daml-finance-interface-instrument-types-v2-floatingrate-floatingrate-56149>`
 data structure. It supports two types of reference rates, which are configurable using the
-:ref:`ReferenceRateTypeEnum <type-daml-finance-interface-instrument-types-floatingrate-referenceratetypeenum-97197>`:
+:ref:`ReferenceRateTypeEnum <type-daml-finance-interface-instrument-types-v2-floatingrate-referenceratetypeenum-15522>`:
 
 - Libor/Euribor style rates with a single fixing
 - SOFR style reference rates (using a compounded index)
@@ -62,7 +62,7 @@ issuer to the holder). However, in the case of a swap with two counterparties A 
 the holding owner receives the floating leg.
 
 Just as for bonds, we can use these variables to create a
-:ref:`PeriodicSchedule <constr-daml-finance-interface-types-date-schedule-periodicschedule-99705>`:
+:ref:`PeriodicSchedule <constr-daml-finance-interface-types-date-v3-schedule-periodicschedule-24577>`:
 
 .. literalinclude:: ../src/test/daml/Daml/Finance/Test/Util/Time.daml
   :language: daml
@@ -89,13 +89,13 @@ Now that we have defined the terms we can create the swap instrument:
   :end-before: -- CREATE_INTEREST_RATE_SWAP_INSTRUMENT_END
 
 Once this is done, you can create a holding on it using
-:ref:`Account.Credit <module-daml-finance-interface-account-account-92922>`.
+:ref:`Account.Credit <module-daml-finance-interface-account-v4-account-30007>`.
 The owner of the holding receives the floating leg (and pays the fix leg).
 
 Currency
 ========
 
-:ref:`Currency swaps <module-daml-finance-instrument-swap-currency-instrument-67721>`
+:ref:`Currency swaps <module-daml-finance-instrument-swap-v1-currency-instrument-73211>`
 are quite similar to interest rate swaps, except that the two legs are in different
 currencies. Consequently, we need to create two cash instruments:
 
@@ -138,7 +138,7 @@ Foreign Exchange
 ================
 
 Despite the similarities in name,
-:ref:`foreign exchange swaps <module-daml-finance-instrument-swap-foreignexchange-instrument-43394>`
+:ref:`foreign exchange swaps <module-daml-finance-instrument-swap-v1-foreignexchange-instrument-82256>`
 (or FX swaps) are quite different from currency swaps.
 An FX swap does not pay or receive interest. Instead, the two legs define an initial
 FX transaction and a final FX transaction. Each transaction requires an FX rate and a transaction
@@ -178,7 +178,7 @@ the foreign currency in the initial transaction. In the final transaction the si
 Credit Default
 ==============
 
-A :ref:`credit default swap <module-daml-finance-instrument-swap-creditdefault-instrument-88725>`
+A :ref:`credit default swap <module-daml-finance-instrument-swap-v1-creditdefault-instrument-52131>`
 (CDS) pays a protection amount in case of a credit default event, in exchange
 for a fix rate at the end of every payment period. The protection amount is defined as
 *1-recoveryRate*. The *recoveryRate* is defined as the amount recovered when a borrower defaults,
@@ -218,7 +218,7 @@ holding receives the protection leg (and pays the fix leg).
 Asset
 =====
 
-An :ref:`asset swap <module-daml-finance-instrument-swap-asset-instrument-28127>`
+An :ref:`asset swap <module-daml-finance-instrument-swap-v1-asset-instrument-35945>`
 is a general type of swap with two legs: one which pays an interest rate and another one
 which pays the performance of an asset (or a basket of assets). It can be used to model:
 
@@ -268,7 +268,7 @@ FpML
 ====
 
 Unlike the other swap types above, the
-:ref:`FpML swap <module-daml-finance-instrument-swap-fpml-instrument-17241>` template is
+:ref:`FpML swap <module-daml-finance-instrument-swap-v1-fpml-instrument-78235>` template is
 not a new type of payoff. Instead, it allows you to input other types of swaps using the
 `FpML schema <https://www.fpml.org/spec/fpml-5-11-3-lcwd-1/html/confirmation/schemaDocumentation/schemas/fpml-ird-5-11_xsd/complexTypes/Swap.html>`_.
 Currently, interest rate swaps and currency swaps are supported.
@@ -298,7 +298,7 @@ schema:
   :end-before: -- CREATE_FPML_SWAP_FIX_LEG_END
 
 As you can see, the
-:ref:`Daml SwapStream data type <type-daml-finance-interface-instrument-swap-fpml-fpmltypes-swapstream-38811>`
+:ref:`Daml SwapStream data type <type-daml-finance-interface-instrument-swap-v1-fpml-fpmltypes-swapstream-11715>`
 matches the `swapStream FpML schema <https://www.fpml.org/spec/fpml-5-11-3-lcwd-1/html/confirmation/schemaDocumentation/schemas/fpml-ird-5-11_xsd/complexTypes/Swap/swapStream.html>`_.
 Please note that the actual parsing from FpML to Daml is not done by this template. It has to be
 implemented on the client side.
@@ -313,11 +313,11 @@ Similarly, the floating leg of the swap is defined like this:
 There are three main ways to define which interest rate should be used for a stub period. They are
 all included in the fix or floating leg above, either in the inital or in the final stub period. In
 short, it depends on the content of
-:ref:`StubCalculationPeriodAmount <type-daml-finance-interface-instrument-swap-fpml-fpmltypes-stubcalculationperiodamount-23577>`:
+:ref:`StubCalculationPeriodAmount <type-daml-finance-interface-instrument-swap-v1-fpml-fpmltypes-stubcalculationperiodamount-90721>`:
 
 #. *None*: No special stub rate is provided. Instead, use the same rate as was specified in the
    corresponding
-   :ref:`Calculation <type-daml-finance-interface-instrument-swap-fpml-fpmltypes-calculation-37694>`.
+   :ref:`Calculation <type-daml-finance-interface-instrument-swap-v1-fpml-fpmltypes-calculation-72470>`.
 #. Specific *stubRate*: Use this specific fix rate.
 #. Specific *floatingRate*: Use this specific floating rate (if one rate is provided). If two rates
    are provided: use linear interpolation between the two rates.

--- a/docs/3.1/docs/daml-finance/instruments/token.rst
+++ b/docs/3.1/docs/daml-finance/instruments/token.rst
@@ -37,7 +37,7 @@ How to lifecycle a Token Instrument
 ***********************************
 
 Generic corporate actions, such as
-:ref:`Distribution events <module-daml-finance-lifecycle-event-distribution-17302>`, can be
+:ref:`Distribution events <module-daml-finance-lifecycle-v4-event-distribution-38493>`, can be
 applied to Token Instruments.
 The :doc:`Lifecycling <../tutorials/getting-started/lifecycling>`
 section of the Getting Started tutorial shows how this is done in detail.

--- a/docs/3.1/docs/daml-finance/overview/architecture.rst
+++ b/docs/3.1/docs/daml-finance/overview/architecture.rst
@@ -46,10 +46,10 @@ Implementation Layer
 The implementation layer contains concrete template definitions implementing the interfaces defined
 in the interface layer. These represent the contracts that are ultimately stored on the ledger.
 
-For instance, ``Daml.Finance.Holding`` contains a concrete implementation of a
-:ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>` and
-:ref:`Fungible <module-daml-finance-interface-holding-fungible-63712>` holding. These
-interfaces are defined in ``Daml.Finance.Interface.Holding``.
+For instance, ``Daml.Finance.Holding.V4`` contains a concrete implementation of a
+:ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>` and
+:ref:`Fungible <module-daml-finance-interface-holding-v4-fungible-55495>` holding. These
+interfaces are defined in ``Daml.Finance.Interface.Holding.V4``.
 
 The implementation layer consists of the following packages:
 

--- a/docs/3.1/docs/daml-finance/overview/architecture.rst
+++ b/docs/3.1/docs/daml-finance/overview/architecture.rst
@@ -23,21 +23,21 @@ These packages can in principle be used independently of each other.
 
 The interface layer consists of the following packages:
 
-- ``Daml.Finance.Interface.Holding`` defines interfaces for holdings and related properties such
+- ``Daml.Finance.Interface.Holding.V4`` defines interfaces for holdings and related properties such
   as :ref:`transferability <transferability>` or :ref:`fungibility <fungibility>`.
-- ``Daml.Finance.Interface.Account`` defines interfaces for accounts
-- ``Daml.Finance.Interface.Settlement`` defines interfaces for settlement route providers,
+- ``Daml.Finance.Interface.Account.V4`` defines interfaces for accounts
+- ``Daml.Finance.Interface.Settlement.V4`` defines interfaces for settlement route providers,
   settlement instructions, and batched settlements
-- ``Daml.Finance.Interface.Lifecycle`` defines interfaces used for instrument lifecycling
+- ``Daml.Finance.Interface.Lifecycle.V4`` defines interfaces used for instrument lifecycling
 - ``Daml.Finance.Interface.Instrument.*`` contains interfaces used for different instrument types
-- ``Daml.Finance.Interface.Claims`` contains interfaces used for
+- ``Daml.Finance.Interface.Claims.V4`` contains interfaces used for
   :doc:`Contingent Claims <../instruments/generic/contingent-claims>` based instrument types
-- ``Daml.Finance.Interface.Data`` defines interfaces related to reference data
-- ``Daml.Finance.Interface.Types.Common`` provides common types
-- ``Daml.Finance.Interface.Types.Date`` provides types related to dates
-- ``Daml.Finance.Interface.Util`` defines utilities and interfaces used by other interface
+- ``Daml.Finance.Interface.Data.V4`` defines interfaces related to reference data
+- ``Daml.Finance.Interface.Types.Common.V3`` provides common types
+- ``Daml.Finance.Interface.Types.Date.V3`` provides types related to dates
+- ``Daml.Finance.Interface.Util.V3`` defines utilities and interfaces used by other interface
   packages.
-- ``ContingentClaims.Core`` contains types for representing
+- ``ContingentClaims.Core.V3`` contains types for representing
   :doc:`Contingent Claims <../instruments/generic/contingent-claims>` tree structures.
 
 Implementation Layer
@@ -53,21 +53,21 @@ interfaces are defined in ``Daml.Finance.Interface.Holding``.
 
 The implementation layer consists of the following packages:
 
-- ``Daml.Finance.Holding`` defines default implementations for holdings
-- ``Daml.Finance.Account`` defines default implementations for accounts
-- ``Daml.Finance.Settlement`` defines templates for settlement route providers, settlement
+- ``Daml.Finance.Holding.V4`` defines default implementations for holdings
+- ``Daml.Finance.Account.V4`` defines default implementations for accounts
+- ``Daml.Finance.Settlement.V4`` defines templates for settlement route providers, settlement
   instructions, and batched settlements
-- ``Daml.Finance.Lifecycle`` defines an implementation of lifecycle effects and a rule template to
+- ``Daml.Finance.Lifecycle.V4`` defines an implementation of lifecycle effects and a rule template to
   facilitate their settlement
 - ``Daml.Finance.Instrument.*`` contains implementations for various instrument types
-- ``Daml.Finance.Data`` includes templates used to store reference data on the ledger
-- ``Daml.Finance.Claims`` contains utility functions relating to
+- ``Daml.Finance.Data.V4`` includes templates used to store reference data on the ledger
+- ``Daml.Finance.Claims.V3`` contains utility functions relating to
   :doc:`Contingent Claims <../instruments/generic/contingent-claims>` based instruments and
   lifecycling
-- ``Daml.Finance.Util`` provides a set of pure utility functions mainly for date manipulation
-- ``ContingentClaims.Lifecycle`` provides lifecycle utility functions for
+- ``Daml.Finance.Util.V4`` provides a set of pure utility functions mainly for date manipulation
+- ``ContingentClaims.Lifecycle.V3`` provides lifecycle utility functions for
   :doc:`Contingent Claims <../instruments/generic/contingent-claims>` based instruments
-- ``ContingentClaims.Valuation`` contains experimental functions to transform
+- ``ContingentClaims.Valuation.V1`` contains experimental functions to transform
   :doc:`Contingent Claims <../instruments/generic/contingent-claims>` instrument trees into a
   mathematical representation suitable for integration with pricing and risk frameworks
 

--- a/docs/3.1/docs/daml-finance/overview/extending-daml-finance.rst
+++ b/docs/3.1/docs/daml-finance/overview/extending-daml-finance.rst
@@ -23,16 +23,16 @@ Daml Finance provides default holding implementations for the following holding 
 4. neither fungible nor transferable (i.e., the `BaseHolding` holding standard)
 
 The transferability of transferable holdings can be flexibly controlled through the
-:ref:`controllers <type-daml-finance-interface-account-account-controllers-36430>`
-property on an :ref:`Account <module-daml-finance-account-account-19369>`.
+:ref:`controllers <type-daml-finance-interface-account-v4-account-controllers-59817>`
+property on an :ref:`Account <module-daml-finance-account-v4-account-5834>`.
 Some use cases, however, might require additional functionality on holding contracts:
 
 - *Restricted transferability*: a custom implementation of the
-  :ref:`Transferable interface <module-daml-finance-interface-holding-transferable-88121>`
+  :ref:`Transferable interface <module-daml-finance-interface-holding-v4-transferable-93054>`
   can enforce additional conditions (e.g. the presence of some contract) required to transfer a
   holding.
 - *Fixed divisibility*: a custom implementation of the
-  :ref:`Fungible interface <module-daml-finance-interface-holding-fungible-63712>` can enforce
+  :ref:`Fungible interface <module-daml-finance-interface-holding-v4-fungible-55495>` can enforce
   specific requirements regarding the divisibility of a holding.
 - *Additional information*: a custom implementation of a holding can provide additional information,
   for example, the timestamp of when the holding was obtained. This can be used to implement
@@ -42,7 +42,7 @@ Some use cases, however, might require additional functionality on holding contr
 Note that any custom holding implementation will still allow you to leverage other parts of the
 library (e.g. lifecycling or settlement) as those are implemented against the respective interfaces.
 You will need to provide an implementation of the
-:ref:`Holding Factory <module-daml-finance-interface-holding-factory-6211>` interface for
+:ref:`Holding Factory <module-daml-finance-interface-holding-v4-factory-49942>` interface for
 your implementation to be usable throughout the library.
 
 Custom Account Implementations
@@ -50,19 +50,19 @@ Custom Account Implementations
 
 The default account implementation in Daml Finance allows you to define authorization requirements
 for incoming and outgoing transfers through the
-:ref:`controllers <type-daml-finance-interface-account-account-controllers-36430>` property.
+:ref:`controllers <type-daml-finance-interface-account-v4-account-controllers-59817>` property.
 For some cases, however, a custom account implementation may be warranted:
 
 - Restricted credit and debit: a custom implementation of the ``Credit`` and / or
   ``Debit`` choices on the
-  :ref:`Account interface <module-daml-finance-interface-account-account-92922>` can place
+  :ref:`Account interface <module-daml-finance-interface-account-v4-account-30007>` can place
   additional restrictions on those actions that can depend, for example, on the presence of a
   separate know-your-customer (KYC) contract.
 - Additional information: a custom account implementation can serve to represent different concepts
   of accounts. For example, a shelf in a vault for gold bars or a specific location within a
   warehouse can be represented by providing additional information on an account implementation.
 - Account Freezing: an account can optionally implement
-  the :ref:`Lockable <module-daml-finance-interface-util-lockable-80915>` interface, allowing it to
+  the :ref:`Lockable <module-daml-finance-interface-util-v3-lockable-20339>` interface, allowing it to
   be frozen, i.e., temporarily disabling credits and debits.
 
 Custom Instrument Implementations
@@ -74,7 +74,7 @@ entirely new instrument types. The following are typical examples of when a cust
 implementation is required:
 
 - Additional information: a custom instrument implementation might, for example, build upon the
-  :ref:`Equity interface <module-daml-finance-interface-instrument-equity-instrument-13224>` to
+  :ref:`Equity interface <module-daml-finance-interface-instrument-equity-v1-instrument-10480>` to
   provide additional information pertinent to private equity (like share class, or liquidation
   preference).
 - New instrument types: if Daml Finance does not provide an implementation for a given instrument
@@ -83,20 +83,20 @@ implementation is required:
   described in
   :doc:`this tutorial <../tutorials/advanced-topics/instrument-modeling/contingent-claims-instrument>`,
   or be implemented through standard interfaces, as seen in the implementation of the
-  :ref:`Equity instrument <module-daml-finance-instrument-equity-instrument-69265>`.
+  :ref:`Equity instrument <module-daml-finance-instrument-equity-v1-instrument-56047>`.
 
 Custom Lifecycle Implementations
 ********************************
 
 Daml Finance provides a default set of lifecycle rules that can be used to evolve instruments.
 Examples are the implementation of
-:ref:`Distributions <module-daml-finance-lifecycle-rule-distribution-35531>`,
-:ref:`Replacements <module-daml-finance-lifecycle-rule-replacement-6984>`, or the
-:ref:`time-based evolution <module-daml-finance-interface-lifecycle-event-time-4252>`
+:ref:`Distributions <module-daml-finance-lifecycle-v4-rule-distribution-2662>`,
+:ref:`Replacements <module-daml-finance-lifecycle-v4-rule-replacement-25183>`, or the
+:ref:`time-based evolution <module-daml-finance-interface-lifecycle-v4-event-time-69757>`
 of contingent-claims based instruments. There are many more lifecycle events and rules
 that can be implemented using the provided interfaces. Typically, implementations of the
-:ref:`Event <module-daml-finance-interface-lifecycle-event-43586>` and
-:ref:`Rule <module-daml-finance-interface-lifecycle-rule-lifecycle-50431>` interface are required to
+:ref:`Event <module-daml-finance-interface-lifecycle-v4-event-91777>` and
+:ref:`Rule <module-daml-finance-interface-lifecycle-v4-rule-lifecycle-8270>` interface are required to
 handle new lifecycle events. Examples of events where a library extension might be warranted
 include:
 

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/contingent-claims-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/contingent-claims-lifecycle.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Lifecycle - Changelog
-######################################
+ContingentClaims.Lifecycle.V3 - Changelog
+#########################################
 
 Version 2.0.1
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/contingent-claims-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/contingent-claims-lifecycle.rst
@@ -10,7 +10,7 @@ ContingentClaims.Lifecycle.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 - Bumps `daml-ctl` to `2.4.1`.
 

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/contingent-claims-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/contingent-claims-lifecycle.rst
@@ -1,8 +1,21 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Lifecycle.V3 - Changelog
-#########################################
+Changelog
+#########
+
+ContingentClaims.Lifecycle.V3
+=============================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+- Bumps `daml-ctl` to `2.4.1`.
+
+ContingentClaims.Lifecycle
+==========================
 
 Version 2.0.1
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/contingent-claims-valuation.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/contingent-claims-valuation.rst
@@ -1,8 +1,21 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Valuation.V1 - Changelog
-#########################################
+Changelog
+#########
+
+ContingentClaims.Valuation.V1
+=============================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+- Bumps `daml-ctl` to `2.4.1`.
+
+ContingentClaims.Valuation
+==========================
 
 Version 0.2.2
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/contingent-claims-valuation.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/contingent-claims-valuation.rst
@@ -10,7 +10,7 @@ ContingentClaims.Valuation.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 - Bumps `daml-ctl` to `2.4.1`.
 

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/contingent-claims-valuation.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/contingent-claims-valuation.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Valuation - Changelog
-######################################
+ContingentClaims.Valuation.V1 - Changelog
+#########################################
 
 Version 0.2.2
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-account.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-account.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Account - Changelog
-################################
+Daml.Finance.Account.V4 - Changelog
+###################################
 
 Version 3.0.0
 *************
@@ -10,7 +10,7 @@ Version 3.0.0
 - Update of SDK version and dependencies.
 
 - The Account now uses a key (specifically, a `HoldingFactoryKey`)
-  to reference its `Daml.Finance.Interface.Holding.Factory`, rather than a `ContractId`.
+  to reference its `Daml.Finance.Interface.Holding.V4.Factory`, rather than a `ContractId`.
 
 - The `Remove` implementation was removed from the `Factory` (it is newly part of the `Account`
   interface).

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-account.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-account.rst
@@ -10,7 +10,7 @@ Daml.Finance.Account.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Account
 ====================

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-account.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-account.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Account.V4 - Changelog
-###################################
+Changelog
+#########
+
+Daml.Finance.Account.V4
+=======================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Account
+====================
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-claims.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-claims.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Claims.V3 - Changelog
-##################################
+Changelog
+#########
+
+Daml.Finance.Claims.V3
+======================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Claims
+===================
 
 Version 2.1.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-claims.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-claims.rst
@@ -10,7 +10,7 @@ Daml.Finance.Claims.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Claims
 ===================

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-claims.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-claims.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Claims - Changelog
-###############################
+Daml.Finance.Claims.V3 - Changelog
+##################################
 
 Version 2.1.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-data.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-data.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Data.V4 - Changelog
-################################
+Changelog
+#########
+
+Daml.Finance.Data.V4
+====================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Data
+=================
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-data.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-data.rst
@@ -10,7 +10,7 @@ Daml.Finance.Data.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Data
 =================

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-data.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-data.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Data - Changelog
-#############################
+Daml.Finance.Data.V4 - Changelog
+################################
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-holding.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-holding.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Holding.V4 - Changelog
-###################################
+Changelog
+#########
+
+Daml.Finance.Holding.V4
+=======================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Holding
+====================
 
 Version 3.0.1
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-holding.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-holding.rst
@@ -10,7 +10,7 @@ Daml.Finance.Holding.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Holding
 ====================

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-holding.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-holding.rst
@@ -1,14 +1,14 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Holding - Changelog
-################################
+Daml.Finance.Holding.V4 - Changelog
+###################################
 
 Version 3.0.1
 *************
 
-- Resolved an issue in the `Daml.Finance.Holding` package affecting the `Disclosure.I`
-  implementation of the `Factory` template within the `Daml.Finance.Holding.Factory` module. This
+- Resolved an issue in the `Daml.Finance.Holding.V4` package affecting the `Disclosure.I`
+  implementation of the `Factory` template within the `Daml.Finance.Holding.V4.Factory` module. This
   patch ensures that observers are now correctly updated for the associated `Reference` template.
 
 Version 3.0.0
@@ -32,8 +32,8 @@ Version 3.0.0
 - The holding implementations newly `ensure` that the desired `HoldingStandard` is met.
 
 - The locking logic was factored out to a separate `Lockable` interface (within the
-  `Daml.Finance.Interface.Util` package), and the `acquireImpl` and `releaseImpl` utility functions
-  moved to the `Lockable` module in the `Daml.Finance.Util` implementation package.
+  `Daml.Finance.Interface.Util.V3` package), and the `acquireImpl` and `releaseImpl` utility functions
+  moved to the `Lockable` module in the `Daml.Finance.Util.V4` implementation package.
 
 - The `Transfer`, `Split`, `Merge`, and `Debit` actions on holdings are prohibited in a locked
   state, requiring them to be unlocked first. Notably, the type signatures for `splitImpl` and

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-bond.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-bond.rst
@@ -10,7 +10,7 @@ Daml.Finance.Instrument.Bond.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Instrument.Bond
 ============================

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-bond.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-bond.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Bond.V3 - Changelog
-###########################################
+Changelog
+#########
+
+Daml.Finance.Instrument.Bond.V3
+===============================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Instrument.Bond
+============================
 
 Version 2.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-bond.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-bond.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Bond - Changelog
-########################################
+Daml.Finance.Instrument.Bond.V3 - Changelog
+###########################################
 
 Version 2.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-equity.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-equity.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Equity.V1 - Changelog
-#############################################
+Changelog
+#########
+
+Daml.Finance.Instrument.Equity.V1
+=================================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Instrument.Equity
+==============================
 
 Version 0.4.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-equity.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-equity.rst
@@ -10,7 +10,7 @@ Daml.Finance.Instrument.Equity.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Instrument.Equity
 ==============================

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-equity.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-equity.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Equity - Changelog
-##########################################
+Daml.Finance.Instrument.Equity.V1 - Changelog
+#############################################
 
 Version 0.4.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-generic.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-generic.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Generic.V4 - Changelog
-##############################################
+Changelog
+#########
+
+Daml.Finance.Instrument.Generic.V4
+==================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Instrument.Generic
+===============================
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-generic.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-generic.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Generic - Changelog
-###########################################
+Daml.Finance.Instrument.Generic.V4 - Changelog
+##############################################
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-generic.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-generic.rst
@@ -10,7 +10,7 @@ Daml.Finance.Instrument.Generic.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Instrument.Generic
 ===============================

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-option.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-option.rst
@@ -10,7 +10,7 @@ Daml.Finance.Instrument.Option.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Instrument.Option
 ==============================

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-option.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-option.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Option - Changelog
-##########################################
+Daml.Finance.Instrument.Option.V1 - Changelog
+#############################################
 
 Version 0.3.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-option.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-option.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Option.V1 - Changelog
-#############################################
+Changelog
+#########
+
+Daml.Finance.Instrument.Option.V1
+=================================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Instrument.Option
+==============================
 
 Version 0.3.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-structuredproduct.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-structuredproduct.rst
@@ -10,9 +10,9 @@ Daml.Finance.Instrument.StructuredProduct.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
-- Add new AutoCallable instrument.
+- New AutoCallable instrument.
 
 Daml.Finance.Instrument.StructuredProduct
 =========================================

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-structuredproduct.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-structuredproduct.rst
@@ -1,8 +1,21 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.StructuredProduct.V1 - Changelog
-########################################################
+Changelog
+#########
+
+Daml.Finance.Instrument.StructuredProduct.V1
+============================================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+- Add new AutoCallable instrument.
+
+Daml.Finance.Instrument.StructuredProduct
+=========================================
 
 Version 0.1.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-structuredproduct.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-structuredproduct.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.StructuredProduct - Changelog
-#####################################################
+Daml.Finance.Instrument.StructuredProduct.V1 - Changelog
+########################################################
 
 Version 0.1.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-swap.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-swap.rst
@@ -10,7 +10,7 @@ Daml.Finance.Instrument.Swap.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Instrument.Swap
 ============================

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-swap.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-swap.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Swap - Changelog
-########################################
+Daml.Finance.Instrument.Swap.V1 - Changelog
+###########################################
 
 Version 0.4.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-swap.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-swap.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Swap.V1 - Changelog
-###########################################
+Changelog
+#########
+
+Daml.Finance.Instrument.Swap.V1
+===============================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Instrument.Swap
+============================
 
 Version 0.4.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-token.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-token.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Token.V4 - Changelog
-############################################
+Changelog
+#########
+
+Daml.Finance.Instrument.Token.V4
+================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Instrument.Token
+=============================
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-token.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-token.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Token - Changelog
-#########################################
+Daml.Finance.Instrument.Token.V4 - Changelog
+############################################
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-token.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-instrument-token.rst
@@ -10,7 +10,7 @@ Daml.Finance.Instrument.Token.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Instrument.Token
 =============================

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-lifecycle.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Lifecycle.V4 - Changelog
-#####################################
+Changelog
+#########
+
+Daml.Finance.Lifecycle.V4
+=========================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Lifecycle
+======================
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-lifecycle.rst
@@ -10,7 +10,7 @@ Daml.Finance.Lifecycle.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Lifecycle
 ======================

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-lifecycle.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Lifecycle - Changelog
-##################################
+Daml.Finance.Lifecycle.V4 - Changelog
+#####################################
 
 Version 3.0.0
 *************
@@ -11,7 +11,7 @@ Version 3.0.0
 
 - The `Calculate` choice of the `Effect` and `ElectionEffect` now takes a quantity as argument
   to reflect the change in the `Effect.I` interface. The implementation of the `ClaimEffect` choice
-  body of `Daml.Finance.Lifecycle.Rule.Claim` also changed accordingly.
+  body of `Daml.Finance.Lifecycle.V4.Rule.Claim` also changed accordingly.
 
 - Replaced `lookupByKey` by an `exerciseByKey` in the `Distribution` and `Replacement` rule.
 

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-settlement.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-settlement.rst
@@ -10,7 +10,7 @@ Daml.Finance.Settlement.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Settlement
 =======================

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-settlement.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-settlement.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Settlement.V4 - Changelog
-######################################
+Changelog
+#########
+
+Daml.Finance.Settlement.V4
+==========================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Settlement
+=======================
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-settlement.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-settlement.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Settlement - Changelog
-###################################
+Daml.Finance.Settlement.V4 - Changelog
+######################################
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-util.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-util.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Util - Changelog
-#############################
+Daml.Finance.Util.V4 - Changelog
+################################
 
 Version 3.1.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-util.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-util.rst
@@ -10,9 +10,9 @@ Daml.Finance.Util.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
-- Only release a Semaphore lock if the provided context is recognized (patch).
+- Only release a Semaphore lock if the provided context is recognized.
 
 Daml.Finance.Util
 =================

--- a/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-util.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/changelogs/daml-finance-util.rst
@@ -1,8 +1,21 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Util.V4 - Changelog
-################################
+Changelog
+#########
+
+Daml.Finance.Util.V4
+====================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+- Only release a Semaphore lock if the provided context is recognized (patch).
+
+Daml.Finance.Util
+=================
 
 Version 3.1.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/implementations/contingent-claims-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/contingent-claims-lifecycle.rst
@@ -2,7 +2,7 @@
 .. SPDX-License-Identifier: Apache-2.0
 
 ContingentClaims.Lifecycle.V3
-##########################
+#############################
 
 This package contains the *implementation* of utility functions to lifecycle a
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` tree. The following modules

--- a/docs/3.1/docs/daml-finance/packages/implementations/contingent-claims-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/contingent-claims-lifecycle.rst
@@ -8,10 +8,10 @@ This package contains the *implementation* of utility functions to lifecycle a
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` tree. The following modules
 are included:
 
-- :ref:`Lifecycle <module-contingentclaims-lifecycle-lifecycle-72039>`:
+- :ref:`Lifecycle <module-contingentclaims-lifecycle-v3-lifecycle-61551>`:
   Functions to lifecycle a :doc:`Contingent Claims <../../instruments/generic/contingent-claims>`
   tree
-- :ref:`Util <module-contingentclaims-lifecycle-util-90074>`:
+- :ref:`Util <module-contingentclaims-lifecycle-v3-util-47746>`:
   Utility functions to query a
   :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` tree for certain properties
 

--- a/docs/3.1/docs/daml-finance/packages/implementations/contingent-claims-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/contingent-claims-lifecycle.rst
@@ -1,7 +1,7 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Lifecycle
+ContingentClaims.Lifecycle.V3
 ##########################
 
 This package contains the *implementation* of utility functions to lifecycle a

--- a/docs/3.1/docs/daml-finance/packages/implementations/contingent-claims-valuation.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/contingent-claims-valuation.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Valuation
-##########################
+ContingentClaims.Valuation.V1
+#############################
 
 This package contains the *implementation* of utility functions to map a
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` tree into a mathematical

--- a/docs/3.1/docs/daml-finance/packages/implementations/contingent-claims-valuation.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/contingent-claims-valuation.rst
@@ -9,10 +9,10 @@ This package contains the *implementation* of utility functions to map a
 representation to facilitate integration with pricing and risk frameworks. The following modules are
 included:
 
-- :ref:`Stochastic <module-contingentclaims-valuation-stochastic-37844>`: Utilities to map a
+- :ref:`Stochastic <module-contingentclaims-valuation-v1-stochastic-86240>`: Utilities to map a
   :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` tree to a stochastic
   process representation
-- :ref:`MathML <module-contingentclaims-valuation-mathml-30102>`: Typeclass definition to map an
+- :ref:`MathML <module-contingentclaims-valuation-v1-mathml-73874>`: Typeclass definition to map an
   expression in the MathML presentation format
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-account.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-account.rst
@@ -6,7 +6,7 @@ Daml.Finance.Account.V4
 
 This package contains the *implementation* of accounts. It has the following module:
 
-- :ref:`Account <module-daml-finance-account-account-19369>`: Implementation of an account, i.e., a
+- :ref:`Account <module-daml-finance-account-v4-account-5834>`: Implementation of an account, i.e., a
   relationship between a custodian and an asset owner, referenced by holdings. It also provides an
   implementation of a factory from which you can create and remove accounts. Upon creation of an
   account, it allows you to specify controlling parties for incoming / outgoing transfers.

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-account.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-account.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Account
-####################
+Daml.Finance.Account.V4
+#######################
 
 This package contains the *implementation* of accounts. It has the following module:
 

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-claims.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-claims.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Claims
-###################
+Daml.Finance.Claims.V3
+######################
 
 This package contains utility functions that facilitate building and working with
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` based instruments. It includes the

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-claims.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-claims.rst
@@ -8,18 +8,18 @@ This package contains utility functions that facilitate building and working wit
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` based instruments. It includes the
 following modules:
 
-- :ref:`Lifecycle.Rule <module-daml-finance-claims-lifecycle-rule-53980>`:
+- :ref:`Lifecycle.Rule <module-daml-finance-claims-v3-lifecycle-rule-196>`:
   Rule to process a lifecycle event for instruments that build a
   :doc:`Contingent Claims tree dynamically <../../tutorials/advanced-topics/instrument-modeling/contingent-claims-instrument>`.
-- :ref:`Util <module-daml-finance-claims-util-5254>`:
+- :ref:`Util <module-daml-finance-claims-v3-util-10150>`:
   Contains utility functions for claims, e.g., checking the content of a claim and converting the
   claim time
-- :ref:`Util.Lifecycle <module-daml-finance-claims-util-lifecycle-9534>`:
+- :ref:`Util.Lifecycle <module-daml-finance-claims-v3-util-lifecycle-43238>`:
   Defines different types of events and how to lifecycle them
-- :ref:`Util.Builders <module-daml-finance-claims-util-builders-48637>`:
+- :ref:`Util.Builders <module-daml-finance-claims-v3-util-builders-30825>`:
   Utility functions related to creating :doc:`Contingent Claims <../../instruments/generic/contingent-claims>`,
   e.g. for bonds/swaps
-- :ref:`Util.Date <module-daml-finance-claims-util-date-40505>`:
+- :ref:`Util.Date <module-daml-finance-claims-v3-util-date-8229>`:
   Utility functions related to dates and schedule periods, which are used to define claims.
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-data.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-data.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Data
-#################
+Daml.Finance.Data.V4
+####################
 
 This package implements templates containing reference data. It includes the following modules:
 

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-data.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-data.rst
@@ -6,22 +6,22 @@ Daml.Finance.Data.V4
 
 This package implements templates containing reference data. It includes the following modules:
 
-- :ref:`Numeric.Observation <module-daml-finance-data-numeric-observation-78761>`:
+- :ref:`Numeric.Observation <module-daml-finance-data-v4-numeric-observation-19522>`:
   An implementation of an observation that explicitly stores time-dependent numerical values on the
   ledger. It can be used to, e.g., store equity or rate fixings.
-- :ref:`Reference.HolidayCalendar <module-daml-finance-data-reference-holidaycalendar-10773>`:
+- :ref:`Reference.HolidayCalendar <module-daml-finance-data-v4-reference-holidaycalendar-15110>`:
   A holiday calendar of an entity (typically an exchange or a currency)
-- :ref:`Time.DateClock.Types <module-daml-finance-data-time-dateclock-types-48777>`:
+- :ref:`Time.DateClock.Types <module-daml-finance-data-v4-time-dateclock-types-32520>`:
   A date type which can be converted to time, and time-related utility functions
-- :ref:`Time.DateClock <module-daml-finance-data-time-dateclock-65212>`:
+- :ref:`Time.DateClock <module-daml-finance-data-v4-time-dateclock-1389>`:
   A contract specifying what is the current local date. It is used to inject date information in
   lifecycle processing rules
-- :ref:`Time.DateClockUpdate <module-daml-finance-data-time-dateclockupdate-48859>`:
+- :ref:`Time.DateClockUpdate <module-daml-finance-data-v4-time-dateclockupdate-59678>`:
   A contract representing passing of (market) time that can be used to trigger contractual,
   time-based `effects <#lifecycling-effect>`__, like interest payments on a bond. It is, for
   example, used to drive the evolution and lifecycling of
   :doc:`Contingent Claims <../../instruments/generic/contingent-claims>`-based instruments.
-- :ref:`Time.LedgerTime <module-daml-finance-data-time-ledgertime-84639>`:
+- :ref:`Time.LedgerTime <module-daml-finance-data-v4-time-ledgertime-80144>`:
   A time observable which uses ledger time
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-holding.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-holding.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Holding
-####################
+Daml.Finance.Holding.V4
+#######################
 
 This package contains the *implementation* of holdings, including utility functions. It has the
 following modules:

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-holding.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-holding.rst
@@ -7,15 +7,15 @@ Daml.Finance.Holding.V4
 This package contains the *implementation* of holdings, including utility functions. It has the
 following modules:
 
-- :ref:`Fungible <module-daml-finance-holding-fungible-7201>`: Implementation of a holding which is
+- :ref:`Fungible <module-daml-finance-holding-v4-fungible-60188>`: Implementation of a holding which is
   fungible only, i.e., include split and merge functionality
-- :ref:`Transferable <module-daml-finance-holding-transferable-43388>`: Implementation of a holding
+- :ref:`Transferable <module-daml-finance-holding-v4-transferable-38649>`: Implementation of a holding
   which is transferable only
-- :ref:`TransferableFungible <module-daml-finance-holding-transferablefungible-77726>`:
+- :ref:`TransferableFungible <module-daml-finance-holding-v4-transferablefungible-66907>`:
   Implementation of a holding which is both transferable and fungible
-- :ref:`BaseHolding <module-daml-finance-holding-baseholding-57062>`: Implementation of
+- :ref:`BaseHolding <module-daml-finance-holding-v4-baseholding-28133>`: Implementation of
   a holding which is neither transferable nor fungible
-- :ref:`Util <module-daml-finance-holding-util-87323>`: Utility functions related to holdings, e.g.,
+- :ref:`Util <module-daml-finance-holding-v4-util-71966>`: Utility functions related to holdings, e.g.,
   to transfer or split/merge a holding
 
 The :doc:`Asset Model <../../concepts/asset-model>` page explains the relationship between

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-bond.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-bond.rst
@@ -7,27 +7,27 @@ Daml.Finance.Instrument.Bond.V3
 This package contains the *implementation* of different bond types, defined in the following
 modules:
 
-- :ref:`Callable.Instrument <module-daml-finance-instrument-bond-callable-instrument-83330>`:
+- :ref:`Callable.Instrument <module-daml-finance-instrument-bond-v3-callable-instrument-35206>`:
   Instrument implementation for callable bonds
-- :ref:`Callable.Factory <module-daml-finance-instrument-bond-callable-factory-52054>`:
+- :ref:`Callable.Factory <module-daml-finance-instrument-bond-v3-callable-factory-64026>`:
   Factory implementation to instantiate callable bonds
-- :ref:`FixedRate.Instrument <module-daml-finance-instrument-bond-fixedrate-instrument-67993>`:
+- :ref:`FixedRate.Instrument <module-daml-finance-instrument-bond-v3-fixedrate-instrument-89221>`:
   Instrument implementation for fixed-rate bonds
-- :ref:`FixedRate.Factory <module-daml-finance-instrument-bond-fixedrate-factory-46203>`:
+- :ref:`FixedRate.Factory <module-daml-finance-instrument-bond-v3-fixedrate-factory-55391>`:
   Factory implementation to instantiate fixed-rate bonds
-- :ref:`FloatingRate.Instrument <module-daml-finance-instrument-bond-floatingrate-instrument-98586>`:
+- :ref:`FloatingRate.Instrument <module-daml-finance-instrument-bond-v3-floatingrate-instrument-82370>`:
   Instrument implementation for floating-rate bonds
-- :ref:`FloatingRate.Factory <module-daml-finance-instrument-bond-floatingrate-factory-64782>`:
+- :ref:`FloatingRate.Factory <module-daml-finance-instrument-bond-v3-floatingrate-factory-96062>`:
   Factory implementation to instantiate floating-rate bonds
-- :ref:`InflationLinked.Instrument <module-daml-finance-instrument-bond-inflationlinked-instrument-30250>`:
+- :ref:`InflationLinked.Instrument <module-daml-finance-instrument-bond-v3-inflationlinked-instrument-99606>`:
   Instrument implementation for inflation-linked bonds
-- :ref:`InflationLinked.Factory <module-daml-finance-instrument-bond-inflationlinked-factory-70614>`:
+- :ref:`InflationLinked.Factory <module-daml-finance-instrument-bond-v3-inflationlinked-factory-84934>`:
   Factory implementation to instantiate inflation-linked bonds
-- :ref:`ZeroCoupon.Instrument <module-daml-finance-instrument-bond-zerocoupon-instrument-52804>`:
+- :ref:`ZeroCoupon.Instrument <module-daml-finance-instrument-bond-v3-zerocoupon-instrument-96672>`:
   Instrument implementation for zero-coupon bonds
-- :ref:`ZeroCoupon.Factory <module-daml-finance-instrument-bond-zerocoupon-factory-51640>`:
+- :ref:`ZeroCoupon.Factory <module-daml-finance-instrument-bond-v3-zerocoupon-factory-47672>`:
   Factory implementation to instantiate zero-coupon bonds
-- :ref:`Util <module-daml-finance-instrument-bond-util-70458>`:
+- :ref:`Util <module-daml-finance-instrument-bond-v3-util-25042>`:
   Bond-specific utility functions
 
 Check out the page on

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-bond.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-bond.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Bond
-############################
+Daml.Finance.Instrument.Bond.V3
+###############################
 
 This package contains the *implementation* of different bond types, defined in the following
 modules:

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-equity.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-equity.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Equity
-##############################
+Daml.Finance.Instrument.Equity.V1
+#################################
 
 This package contains the *implementation* of equity instruments, defined in the following modules:
 

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-equity.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-equity.rst
@@ -6,9 +6,9 @@ Daml.Finance.Instrument.Equity.V1
 
 This package contains the *implementation* of equity instruments, defined in the following modules:
 
-- :ref:`Instrument <module-daml-finance-instrument-equity-instrument-69265>`:
+- :ref:`Instrument <module-daml-finance-instrument-equity-v1-instrument-56047>`:
   Instrument implementation for equities
-- :ref:`Factory <module-daml-finance-instrument-equity-factory-96899>`:
+- :ref:`Factory <module-daml-finance-instrument-equity-v1-factory-43861>`:
   Factory implementation to instantiate equities
 
 For a detailed explanation of this package, check out the page on

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-generic.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-generic.rst
@@ -8,11 +8,11 @@ This package contains the *implementation* of generic,
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` based instruments, defined
 in the following modules:
 
-- :ref:`Instrument <module-daml-finance-instrument-generic-instrument-67364>`:
+- :ref:`Instrument <module-daml-finance-instrument-generic-v4-instrument-39541>`:
   Instrument implementation for generic instruments
-- :ref:`Factory <module-daml-finance-instrument-generic-factory-42712>`:
+- :ref:`Factory <module-daml-finance-instrument-generic-v4-factory-26927>`:
   Factory implementation to instantiate generic instruments
-- :ref:`Lifecycle.Rule <module-daml-finance-instrument-generic-lifecycle-rule-68537>`:
+- :ref:`Lifecycle.Rule <module-daml-finance-instrument-generic-v4-lifecycle-rule-7812>`:
   Rule to process a lifecycle event for generic instruments
 
 Check out the page on :doc:`How to use the Generic Instrument packages <../../instruments/generic>`

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-generic.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-generic.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Generic
-###############################
+Daml.Finance.Instrument.Generic.V4
+##################################
 
 This package contains the *implementation* of generic,
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` based instruments, defined

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-option.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-option.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Option
-##############################
+Daml.Finance.Instrument.Option.V1
+#################################
 
 This package contains the *implementation* of different option types, defined in the
 following modules:

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-option.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-option.rst
@@ -7,23 +7,23 @@ Daml.Finance.Instrument.Option.V1
 This package contains the *implementation* of different option types, defined in the
 following modules:
 
-- :ref:`BarrierEuropeanCash.Instrument <module-daml-finance-instrument-option-barriereuropeancash-instrument-15498>`:
+- :ref:`BarrierEuropeanCash.Instrument <module-daml-finance-instrument-option-v1-barriereuropeancash-instrument-70992>`:
   Instrument implementation for barrier options
-- :ref:`BarrierEuropeanCash.Factory <module-daml-finance-instrument-option-barriereuropeancash-factory-43938>`:
+- :ref:`BarrierEuropeanCash.Factory <module-daml-finance-instrument-option-v1-barriereuropeancash-factory-25456>`:
   Factory implementation to instantiate barrier options
-- :ref:`Dividend.Instrument <module-daml-finance-instrument-option-dividend-instrument-7333>`:
+- :ref:`Dividend.Instrument <module-daml-finance-instrument-option-v1-dividend-instrument-35111>`:
   Instrument implementation for dividend options
-- :ref:`Dividend.Factory <module-daml-finance-instrument-option-dividend-factory-82807>`:
+- :ref:`Dividend.Factory <module-daml-finance-instrument-option-v1-dividend-factory-65033>`:
   Factory implementation to instantiate dividend options
-- :ref:`Dividend.Election <module-daml-finance-instrument-option-dividend-election-79353>`:
+- :ref:`Dividend.Election <module-daml-finance-instrument-option-v1-dividend-election-77267>`:
   Factory implementation to create an Election for dividend options
-- :ref:`EuropeanCash.Instrument <module-daml-finance-instrument-option-europeancash-instrument-22074>`:
+- :ref:`EuropeanCash.Instrument <module-daml-finance-instrument-option-v1-europeancash-instrument-97900>`:
   Instrument implementation for cash-settled European options
-- :ref:`EuropeanCash.Factory <module-daml-finance-instrument-option-europeancash-factory-75778>`:
+- :ref:`EuropeanCash.Factory <module-daml-finance-instrument-option-v1-europeancash-factory-80316>`:
   Factory implementation to instantiate cash-settled European options
-- :ref:`EuropeanPhysical.Instrument <module-daml-finance-instrument-option-europeanphysical-instrument-71708>`:
+- :ref:`EuropeanPhysical.Instrument <module-daml-finance-instrument-option-v1-europeanphysical-instrument-98774>`:
   Instrument implementation for physically settled European options
-- :ref:`EuropeanPhysical.Factory <module-daml-finance-instrument-option-europeanphysical-factory-58032>`:
+- :ref:`EuropeanPhysical.Factory <module-daml-finance-instrument-option-v1-europeanphysical-factory-99630>`:
   Factory implementation to instantiate physically settled European options
 
 Check out the page on :doc:`How to use the Option Instrument packages <../../instruments/option>`

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-structuredproduct.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-structuredproduct.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.StructuredProduct
-#########################################
+Daml.Finance.Instrument.StructuredProduct.V1
+############################################
 
 This package contains the *implementation* of different structured product types, defined in the
 following modules:

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-structuredproduct.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-structuredproduct.rst
@@ -7,9 +7,9 @@ Daml.Finance.Instrument.StructuredProduct.V1
 This package contains the *implementation* of different structured product types, defined in the
 following modules:
 
-- :ref:`BarrierReverseConvertible.Instrument <module-daml-finance-instrument-structuredproduct-barrierreverseconvertible-instrument-95793>`:
+- :ref:`BarrierReverseConvertible.Instrument <module-daml-finance-instrument-structuredproduct-v1-barrierreverseconvertible-instrument-16231>`:
   Instrument implementation for Barrier Reverse Convertibles
-- :ref:`BarrierReverseConvertible.Factory <module-daml-finance-instrument-structuredproduct-barrierreverseconvertible-factory-6075>`:
+- :ref:`BarrierReverseConvertible.Factory <module-daml-finance-instrument-structuredproduct-v1-barrierreverseconvertible-factory-25753>`:
   Factory implementation to instantiate Barrier Reverse Convertibles
 
 Check out the page on

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-structuredproduct.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-structuredproduct.rst
@@ -7,6 +7,10 @@ Daml.Finance.Instrument.StructuredProduct.V1
 This package contains the *implementation* of different structured product types, defined in the
 following modules:
 
+- :ref:`AutoCallable.Instrument <module-daml-finance-instrument-structuredproduct-v1-autocallable-instrument-89951>`:
+  Instrument implementation for Auto Callables
+- :ref:`AutoCallable.Factory <module-daml-finance-instrument-structuredproduct-v1-autocallable-factory-58405>`:
+  Factory implementation to instantiate Auto Callables
 - :ref:`BarrierReverseConvertible.Instrument <module-daml-finance-instrument-structuredproduct-v1-barrierreverseconvertible-instrument-16231>`:
   Instrument implementation for Barrier Reverse Convertibles
 - :ref:`BarrierReverseConvertible.Factory <module-daml-finance-instrument-structuredproduct-v1-barrierreverseconvertible-factory-25753>`:

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-swap.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-swap.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Swap
-############################
+Daml.Finance.Instrument.Swap.V1
+###############################
 
 This package contains the *implementation* of different swap types, defined in the following
 modules:

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-swap.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-swap.rst
@@ -7,31 +7,31 @@ Daml.Finance.Instrument.Swap.V1
 This package contains the *implementation* of different swap types, defined in the following
 modules:
 
-- :ref:`Asset.Instrument <module-daml-finance-instrument-swap-asset-instrument-28127>`:
+- :ref:`Asset.Instrument <module-daml-finance-instrument-swap-v1-asset-instrument-35945>`:
   Instrument implementation for asset swaps
-- :ref:`Asset.Factory <module-daml-finance-instrument-swap-asset-factory-18993>`:
+- :ref:`Asset.Factory <module-daml-finance-instrument-swap-v1-asset-factory-5803>`:
   Factory implementation to instantiate asset swaps
-- :ref:`CreditDefault.Instrument <module-daml-finance-instrument-swap-creditdefault-instrument-88725>`:
+- :ref:`CreditDefault.Instrument <module-daml-finance-instrument-swap-v1-creditdefault-instrument-52131>`:
   Instrument implementation for credit default swaps
-- :ref:`CreditDefault.Factory <module-daml-finance-instrument-swap-creditdefault-factory-17039>`:
+- :ref:`CreditDefault.Factory <module-daml-finance-instrument-swap-v1-creditdefault-factory-79921>`:
   Factory implementation to instantiate credit default swaps
-- :ref:`Currency.Instrument <module-daml-finance-instrument-swap-currency-instrument-67721>`:
+- :ref:`Currency.Instrument <module-daml-finance-instrument-swap-v1-currency-instrument-73211>`:
   Instrument implementation for currency swaps
-- :ref:`Currency.Factory <module-daml-finance-instrument-swap-currency-factory-52907>`:
+- :ref:`Currency.Factory <module-daml-finance-instrument-swap-v1-currency-factory-69701>`:
   Factory implementation to instantiate currency swaps
-- :ref:`ForeignExchange.Instrument <module-daml-finance-instrument-swap-foreignexchange-instrument-43394>`:
+- :ref:`ForeignExchange.Instrument <module-daml-finance-instrument-swap-v1-foreignexchange-instrument-82256>`:
   Instrument implementation for foreign exchange swaps
-- :ref:`ForeignExchange.Factory <module-daml-finance-instrument-swap-foreignexchange-factory-31070>`:
+- :ref:`ForeignExchange.Factory <module-daml-finance-instrument-swap-v1-foreignexchange-factory-56532>`:
   Factory implementation to instantiate foreign exchange swaps
-- :ref:`Fpml.Instrument <module-daml-finance-instrument-swap-fpml-instrument-17241>`:
+- :ref:`Fpml.Instrument <module-daml-finance-instrument-swap-v1-fpml-instrument-78235>`:
   Instrument implementation for FpML swaps (`FpML swap schema <https://www.fpml.org/spec/fpml-5-11-3-lcwd-1/html/confirmation/schemaDocumentation/schemas/fpml-ird-5-11_xsd/complexTypes/Swap.html>`_)
-- :ref:`Fpml.Factory <module-daml-finance-instrument-swap-fpml-factory-80739>`:
+- :ref:`Fpml.Factory <module-daml-finance-instrument-swap-v1-fpml-factory-41381>`:
   Factory implementation to instantiate FpML swaps
-- :ref:`Fpml.Util <module-daml-finance-instrument-swap-fpml-util-24838>`:
+- :ref:`Fpml.Util <module-daml-finance-instrument-swap-v1-fpml-util-68548>`:
   Utility functions to support FpML swaps
-- :ref:`InterestRate.Instrument <module-daml-finance-instrument-swap-interestrate-instrument-86260>`:
+- :ref:`InterestRate.Instrument <module-daml-finance-instrument-swap-v1-interestrate-instrument-25554>`:
   Instrument implementation for interest rate swaps
-- :ref:`InterestRate.Factory <module-daml-finance-instrument-swap-interestrate-factory-62092>`:
+- :ref:`InterestRate.Factory <module-daml-finance-instrument-swap-v1-interestrate-factory-6094>`:
   Factory implementation to instantiate interest rate swaps
 
 Check out the page on :doc:`How to use the Swap Instrument packages <../../instruments/swap>` for a

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-token.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-token.rst
@@ -7,9 +7,9 @@ Daml.Finance.Instrument.Token.V4
 This package contains the *implementation* of simple token instruments which do not define any
 lifecycling logic. It contains the following modules:
 
-- :ref:`Instrument <module-daml-finance-instrument-token-instrument-10682>`:
+- :ref:`Instrument <module-daml-finance-instrument-token-v4-instrument-53415>`:
   Instrument implementation for simple tokens
-- :ref:`Factory <module-daml-finance-instrument-token-factory-62942>`:
+- :ref:`Factory <module-daml-finance-instrument-token-v4-factory-92377>`:
   Factory implementation to instantiate simple tokens
 
 Check out the :doc:`Transfer tutorial <../../tutorials/getting-started/transfer>` for an example on

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-token.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-instrument-token.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Instrument.Token
-#############################
+Daml.Finance.Instrument.Token.V4
+################################
 
 This package contains the *implementation* of simple token instruments which do not define any
 lifecycling logic. It contains the following modules:

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-lifecycle.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Lifecycle
-######################
+Daml.Finance.Lifecycle.V4
+#########################
 
 This package contains the *implementation* of lifecycle related processes. It contains the following
 modules:

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-lifecycle.rst
@@ -7,38 +7,38 @@ Daml.Finance.Lifecycle.V4
 This package contains the *implementation* of lifecycle related processes. It contains the following
 modules:
 
-- :ref:`Effect <module-daml-finance-lifecycle-effect-1975>`:
+- :ref:`Effect <module-daml-finance-lifecycle-v4-effect-31424>`:
   A contract encoding the *consequences of a lifecycle event* for one unit of the target
   instrument
-- :ref:`Election <module-daml-finance-lifecycle-election-53183>`:
+- :ref:`Election <module-daml-finance-lifecycle-v4-election-2732>`:
   Implementation of elections (e.g. the exercise of an option) for claim based instruments
-- :ref:`ElectionEffect <module-daml-finance-lifecycle-electioneffect-99924>`:
+- :ref:`ElectionEffect <module-daml-finance-lifecycle-v4-electioneffect-83755>`:
   A contract encoding the *consequences of an election* for one unit of the target instrument
-- :ref:`Rule.Claim <module-daml-finance-lifecycle-rule-claim-99318>`:
+- :ref:`Rule.Claim <module-daml-finance-lifecycle-v4-rule-claim-11721>`:
   Rule contract that allows an actor to process/claim effects, returning settlement instructions
-- :ref:`Rule.Distribution <module-daml-finance-lifecycle-rule-distribution-35531>`:
+- :ref:`Rule.Distribution <module-daml-finance-lifecycle-v4-rule-distribution-2662>`:
   Rule contract that defines the distribution of units of an instrument for each unit of a
   target instrument (e.g. share or cash dividends)
-- :ref:`Rule.Replacement <module-daml-finance-lifecycle-rule-replacement-6984>`:
+- :ref:`Rule.Replacement <module-daml-finance-lifecycle-v4-rule-replacement-25183>`:
   Rule contract that defines the replacement of units of an instrument with a basket of other
   instruments (e.g. stock merger)
-- :ref:`Rule.Util <module-daml-finance-lifecycle-rule-util-40465>`:
+- :ref:`Rule.Util <module-daml-finance-lifecycle-v4-rule-util-70932>`:
   Utility functions to net, split and merge pending payments
-- :ref:`Event.Distribution <module-daml-finance-lifecycle-event-distribution-17302>`:
+- :ref:`Event.Distribution <module-daml-finance-lifecycle-v4-event-distribution-38493>`:
   Event contract for the distribution of units of an instrument for each unit of a target
   instrument (e.g. share or cash dividends)
-- :ref:`Event.Replacement <module-daml-finance-lifecycle-event-replacement-51859>`:
+- :ref:`Event.Replacement <module-daml-finance-lifecycle-v4-event-replacement-94706>`:
   Event contract for the replacement of units of an instrument with a basket of other
   instruments (e.g. stock merger)
 
 Check out the :doc:`Lifecycling tutorial <../../tutorials/getting-started/lifecycling>` for a
 description on how lifecycling works in practice, including how to
-:ref:`Claim <module-daml-finance-interface-lifecycle-rule-claim-6739>` an
-:ref:`Effect <module-daml-finance-interface-lifecycle-effect-16050>`.
+:ref:`Claim <module-daml-finance-interface-lifecycle-v4-rule-claim-89954>` an
+:ref:`Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>`.
 There is also the tutorial
 :doc:`How to implement a Contingent Claims-based instrument <../../tutorials/advanced-topics/instrument-modeling/contingent-claims-instrument>`,
 which describes how to create an
-:ref:`Effect <module-daml-finance-interface-lifecycle-effect-16050>`.
+:ref:`Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>`.
 For a description of ``Distribution`` and ``Replacement``, check out the
 `Instrument/Equity/Test <https://github.com/digital-asset/daml-finance/blob/main/src/test/daml/Daml/Finance/Instrument/Equity/Test>`_
 folder. It demonstrates how to create and lifecycle a cash dividend, and how to handle corporate

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-settlement.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-settlement.rst
@@ -7,17 +7,17 @@ Daml.Finance.Settlement.V4
 This package contains the *implementation* of the components used for settlement. It has the
 following modules:
 
-- :ref:`RouteProvider.SingleCustodian <module-daml-finance-settlement-routeprovider-singlecustodian-83455>`:
+- :ref:`RouteProvider.SingleCustodian <module-daml-finance-settlement-v4-routeprovider-singlecustodian-88974>`:
   Used to generate a single `RoutedStep` from a `Step` using a single custodian
-- :ref:`RouteProvider.IntermediatedStatic <module-daml-finance-settlement-routeprovider-intermediatedstatic-17490>`:
+- :ref:`RouteProvider.IntermediatedStatic <module-daml-finance-settlement-v4-routeprovider-intermediatedstatic-92315>`:
   Used to generate a route, i.e., `RoutedStep`\s, for each settlement `Step`
-- :ref:`Instruction <module-daml-finance-settlement-instruction-87187>`: Used to settle a single
+- :ref:`Instruction <module-daml-finance-settlement-v4-instruction-73130>`: Used to settle a single
   `RoutedStep`, i.e., a `Step` at a custodian.
-- :ref:`Batch <module-daml-finance-settlement-batch-95573>`: Allows you to atomically settle a
+- :ref:`Batch <module-daml-finance-settlement-v4-batch-88124>`: Allows you to atomically settle a
   set of settlement `Instruction`\s
-- :ref:`Factory <module-daml-finance-settlement-factory-257>`: Used to create a set of
+- :ref:`Factory <module-daml-finance-settlement-v4-factory-65040>`: Used to create a set of
   settlement `Instruction`\s, and a `Batch` to atomically settle them
-- :ref:`Hierarchy <module-daml-finance-settlement-hierarchy-15826>`: Data type that describes a
+- :ref:`Hierarchy <module-daml-finance-settlement-v4-hierarchy-83331>`: Data type that describes a
   hierarchical account structure between multiple parties
 
 The :doc:`Settlement <../../concepts/settlement>` page contains an overview of the settlement

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-settlement.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-settlement.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Settlement
-#######################
+Daml.Finance.Settlement.V4
+##########################
 
 This package contains the *implementation* of the components used for settlement. It has the
 following modules:

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-util.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-util.rst
@@ -8,19 +8,19 @@ This package primarily contains utility functions related to dates (see the
 :doc:`interface docs <../interfaces/daml-finance-interface-types-date>` for an introduction), lists,
 maps, and disclosure. They are defined in the following modules:
 
-- :ref:`Date.Calendar <module-daml-finance-util-date-calendar-17588>`:
+- :ref:`Date.Calendar <module-daml-finance-util-v4-date-calendar-71711>`:
   Functions regarding dates and holiday calendars (business vs non-business days)
-- :ref:`Date.DayCount <module-daml-finance-util-date-daycount-38239>`:
+- :ref:`Date.DayCount <module-daml-finance-util-v4-date-daycount-38488>`:
   Functions to calculate day count fractions according to different conventions
-- :ref:`Date.RollConvention <module-daml-finance-util-date-rollconvention-88672>`:
+- :ref:`Date.RollConvention <module-daml-finance-util-v4-date-rollconvention-61455>`:
   Functions to calculate date periods including rolling dates
-- :ref:`Date.Schedule <module-daml-finance-util-date-schedule-32303>`:
+- :ref:`Date.Schedule <module-daml-finance-util-v4-date-schedule-63724>`:
   Functions to calculate a periodic schedule, including both adjusted and unadjusted dates
-- :ref:`Common <module-daml-finance-util-common-41560>`:
+- :ref:`Common <module-daml-finance-util-v4-common-85309>`:
   Various functions related to lists and maps, which are used in several packages
-- :ref:`Disclosure <module-daml-finance-util-disclosure-73352>`:
+- :ref:`Disclosure <module-daml-finance-util-v4-disclosure-31001>`:
   Utility functions related to disclosure, e.g., to add or remove observers
-- :ref:`Lockable <module-daml-finance-util-lockable-3360>`:
+- :ref:`Lockable <module-daml-finance-util-v4-lockable-69357>`:
   Default implementation for the locking of holdings (acquire, release and validation check).
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-util.rst
+++ b/docs/3.1/docs/daml-finance/packages/implementations/daml-finance-util.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Util
-#################
+Daml.Finance.Util.V4
+####################
 
 This package primarily contains utility functions related to dates (see the
 :doc:`interface docs <../interfaces/daml-finance-interface-types-date>` for an introduction), lists,

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/contingent-claims-core.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/contingent-claims-core.rst
@@ -1,8 +1,21 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Core.V3 - Changelog
-####################################
+Changelog
+#########
+
+ContingentClaims.Core.V3
+========================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+- Bumps `daml-ctl` to `2.4.1`.
+
+ContingentClaims.Core
+=====================
 
 Version 2.0.1
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/contingent-claims-core.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/contingent-claims-core.rst
@@ -10,7 +10,7 @@ ContingentClaims.Core.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 - Bumps `daml-ctl` to `2.4.1`.
 

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/contingent-claims-core.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/contingent-claims-core.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Core - Changelog
-#################################
+ContingentClaims.Core.V3 - Changelog
+####################################
 
 Version 2.0.1
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-account.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-account.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Account.V4 - Changelog
-#############################################
+Changelog
+#########
+
+Daml.Finance.Interface.Account.V4
+=================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Account
+==============================
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-account.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-account.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Account - Changelog
-##########################################
+Daml.Finance.Interface.Account.V4 - Changelog
+#############################################
 
 Version 3.0.0
 *************
@@ -15,7 +15,7 @@ Version 3.0.0
   the `Account`.
 
 - The `Create` choice of the account's `Factory` has been adapted; it now takes a
-  `HoldingFactoryKey` instead of the `ContractId Daml.Finance.Interface.Holding.Factory` as input
+  `HoldingFactoryKey` instead of the `ContractId Daml.Finance.Interface.Holding.V4.Factory` as input
 
 - Renamed the `F` type synonym to `I` .
 

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-account.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-account.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Account.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Account
 ==============================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-claims.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-claims.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Claims.V4 - Changelog
-############################################
+Changelog
+#########
+
+Daml.Finance.Interface.Claims.V4
+================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Claims
+=============================
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-claims.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-claims.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Claims - Changelog
-#########################################
+Daml.Finance.Interface.Claims.V4 - Changelog
+############################################
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-claims.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-claims.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Claims.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Claims
 =============================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
@@ -1,12 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Data.V4 - Changelog
-##########################################
+Changelog
+#########
 
-- Update of SDK version and dependencies.
+Daml.Finance.Interface.Data.V4
+==============================
 
-- Added new day-count conventions: Act365NL, Basis30365, and Basis30E2360.
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Data
+===========================
 
 Version 3.1.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Data.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Data
 ===========================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-data.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Data - Changelog
-#######################################
+Daml.Finance.Interface.Data.V4 - Changelog
+##########################################
 
 - Update of SDK version and dependencies.
 

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-holding.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-holding.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Holding.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Holding
 ==============================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-holding.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-holding.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Holding.V4 - Changelog
-#############################################
+Changelog
+#########
+
+Daml.Finance.Interface.Holding.V4
+=================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Holding
+==============================
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-holding.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-holding.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Holding - Changelog
-##########################################
+Daml.Finance.Interface.Holding.V4 - Changelog
+#############################################
 
 Version 3.0.0
 *************
@@ -10,9 +10,9 @@ Version 3.0.0
 - Update of SDK version and dependencies.
 
 - Factored out the locking logic from the base `Holding` interface to a separate interface called
-  `Lockable` of the `Daml.Finance.Interface.Util` package.
+  `Lockable` of the `Daml.Finance.Interface.Util.V3` package.
 
-- Updated the `Daml.Finance.Interface.Holding.Factory` to use a key, employing a `Reference`
+- Updated the `Daml.Finance.Interface.Holding.V4.Factory` to use a key, employing a `Reference`
   template and the `HoldingFactoryKey` data type. Additionally, It also requires the `Disclosure.I`
   and has a `getKey` method and `Remove` choice.
 

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-base.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-base.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Base.V4 - Changelog
-#####################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Base.V4
+=========================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Base
+======================================
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-base.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-base.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Base.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Base
 ======================================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-base.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-base.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Base - Changelog
-##################################################
+Daml.Finance.Interface.Instrument.Base.V4 - Changelog
+#####################################################
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-bond.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-bond.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Bond - Changelog
-##################################################
+Daml.Finance.Interface.Instrument.Bond.V3 - Changelog
+#####################################################
 
 Version 2.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-bond.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-bond.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Bond.V3 - Changelog
-#####################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Bond.V3
+=========================================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Bond
+======================================
 
 Version 2.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-bond.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-bond.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Bond.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Bond
 ======================================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-equity.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-equity.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Equity.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Equity
 ========================================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-equity.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-equity.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Equity - Changelog
-####################################################
+Daml.Finance.Interface.Instrument.Equity.V1 - Changelog
+#######################################################
 
 Version 0.4.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-equity.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-equity.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Equity.V1 - Changelog
-#######################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Equity.V1
+===========================================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Equity
+========================================
 
 Version 0.4.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-generic.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-generic.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Generic.V4 - Changelog
-########################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Generic.V4
+============================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Generic.V4
+============================================
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-generic.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-generic.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Generic - Changelog
-#####################################################
+Daml.Finance.Interface.Instrument.Generic.V4 - Changelog
+########################################################
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-generic.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-generic.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Generic.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Generic.V4
 ============================================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-option.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-option.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Option.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Option.V1
 ===========================================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-option.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-option.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Option - Changelog
-####################################################
+Daml.Finance.Interface.Instrument.Option.V1 - Changelog
+#######################################################
 
 Version 0.3.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-option.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-option.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Option.V1 - Changelog
-#######################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Option.V1
+===========================================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Option.V1
+===========================================
 
 Version 0.3.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-structuredproduct.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-structuredproduct.rst
@@ -1,8 +1,21 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.StructuredProduct.V1 - Changelog
-##################################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.StructuredProduct.V1
+======================================================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+- Add new AutoCallable instrument.
+
+Daml.Finance.Interface.Instrument.StructuredProduct
+===================================================
 
 Version 0.1.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-structuredproduct.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-structuredproduct.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.StructuredProduct - Changelog
-###############################################################
+Daml.Finance.Interface.Instrument.StructuredProduct.V1 - Changelog
+##################################################################
 
 Version 0.1.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-structuredproduct.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-structuredproduct.rst
@@ -10,9 +10,9 @@ Daml.Finance.Interface.Instrument.StructuredProduct.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
-- Add new AutoCallable instrument.
+- New AutoCallable instrument.
 
 Daml.Finance.Interface.Instrument.StructuredProduct
 ===================================================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-swap.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-swap.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Swap.V1
 Version 1.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Swap
 ======================================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-swap.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-swap.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Swap - Changelog
-##################################################
+Daml.Finance.Interface.Instrument.Swap.V1 - Changelog
+#####################################################
 
 Version 0.4.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-swap.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-swap.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Swap.V1 - Changelog
-#####################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Swap.V1
+=========================================
+
+Version 1.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Swap
+======================================
 
 Version 0.4.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-token.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-token.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Token - Changelog
-###################################################
+Daml.Finance.Interface.Instrument.Token.V4 - Changelog
+######################################################
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-token.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-token.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Token.V4 - Changelog
-######################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Token.V4
+==========================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Token
+=======================================
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-token.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-token.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Token.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Token
 =======================================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-types.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-types.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Types.V2 - Changelog
-######################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Instrument.Types.V2
+==========================================
+
+Version 2.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Instrument.Types
+=======================================
 
 Version 1.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-types.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-types.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Instrument.Types.V2
 Version 2.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Instrument.Types
 =======================================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-types.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-instrument-types.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Types - Changelog
-###################################################
+Daml.Finance.Interface.Instrument.Types.V2 - Changelog
+######################################################
 
 Version 1.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-lifecycle.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Lifecycle - Changelog
-############################################
+Daml.Finance.Interface.Lifecycle.V4 - Changelog
+###############################################
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-lifecycle.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Lifecycle.V4 - Changelog
-###############################################
+Changelog
+#########
+
+Daml.Finance.Interface.Lifecycle.V4
+===================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Lifecycle
+================================
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-lifecycle.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Lifecycle.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Lifecycle
 ================================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-settlement.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-settlement.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Settlement - Changelog
-#############################################
+Daml.Finance.Interface.Settlement.V4 - Changelog
+################################################
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-settlement.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-settlement.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Settlement.V4 - Changelog
-################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Settlement.V4
+====================================
+
+Version 4.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Settlement
+=================================
 
 Version 3.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-settlement.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-settlement.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Settlement.V4
 Version 4.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Settlement
 =================================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-common.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-common.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Types.Common - Changelog
-###############################################
+Daml.Finance.Interface.Types.Common.V3 - Changelog
+##################################################
 
 Version 2.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-common.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-common.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Types.Common.V3 - Changelog
-##################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Types.Common.V3
+======================================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Types.Common
+===================================
 
 Version 2.0.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-common.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-common.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Types.Common.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Types.Common
 ===================================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-date.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-date.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Types.Date - Changelog
-#############################################
+Daml.Finance.Interface.Types.Date.V3 - Changelog
+################################################
 
 Version 2.1.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-date.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-date.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Types.Date.V3 - Changelog
-################################################
+Changelog
+#########
+
+Daml.Finance.Interface.Types.Date.V3
+====================================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Types.Date
+=================================
 
 Version 2.1.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-date.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-types-date.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Types.Date.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Types.Date
 =================================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-util.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-util.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Util - Changelog
-#######################################
+Daml.Finance.Interface.Util.V3 - Changelog
+##########################################
 
 Version 2.1.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-util.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-util.rst
@@ -1,8 +1,19 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Util.V3 - Changelog
-##########################################
+Changelog
+#########
+
+Daml.Finance.Interface.Util.V3
+==============================
+
+Version 3.0.0
+*************
+
+- Update of SDK version and dependencies. LF protocol update.
+
+Daml.Finance.Interface.Util
+===========================
 
 Version 2.1.0
 *************

--- a/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-util.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/changelogs/daml-finance-interface-util.rst
@@ -10,7 +10,7 @@ Daml.Finance.Interface.Util.V3
 Version 3.0.0
 *************
 
-- Update of SDK version and dependencies. LF protocol update.
+- Update of SDK version and dependencies. LF protocol update to support SCU.
 
 Daml.Finance.Interface.Util
 ===========================

--- a/docs/3.1/docs/daml-finance/packages/interfaces/contingent-claims-core.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/contingent-claims-core.rst
@@ -9,15 +9,15 @@ This package contains the *interface* to represent
 and utility functions to process such trees. It also contains builder functions to facilitate the
 creation of trees using composition. The following modules are included:
 
-- :ref:`Builders <module-contingentclaims-core-builders-15004>`: Builder functions to compose trees
+- :ref:`Builders <module-contingentclaims-core-v3-builders-35188>`: Builder functions to compose trees
   from smaller building blocks
-- :ref:`Internal.Claim <module-contingentclaims-core-internal-claim-23633>`: Internal data types to
+- :ref:`Internal.Claim <module-contingentclaims-core-v3-internal-claim-26517>`: Internal data types to
   represent tree nodes
-- :ref:`Claim <module-contingentclaims-core-claim-90861>`: Smart constructors for the types defined
-  in :ref:`Internal.Claim <module-contingentclaims-core-internal-claim-23633>`
-- :ref:`Observation <module-contingentclaims-core-observation-86605>`: Data types to represent
+- :ref:`Claim <module-contingentclaims-core-v3-claim-98141>`: Smart constructors for the types defined
+  in :ref:`Internal.Claim <module-contingentclaims-core-v3-internal-claim-26517>`
+- :ref:`Observation <module-contingentclaims-core-v3-observation-36021>`: Data types to represent
   observations in trees
-- :ref:`Util.Recursion <module-contingentclaims-core-util-recursion-31812>`: Utility functions to
+- :ref:`Util.Recursion <module-contingentclaims-core-v3-util-recursion-82116>`: Utility functions to
   facilitate recursive traversal of trees
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/interfaces/contingent-claims-core.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/contingent-claims-core.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-ContingentClaims.Core
-#####################
+ContingentClaims.Core.V3
+########################
 
 This package contains the *interface* to represent
 :doc:`Contingent Claims <../../instruments/generic/contingent-claims>` trees. It contains data types

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-account.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-account.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Account
-##############################
+Daml.Finance.Interface.Account.V4
+#################################
 
 This package contains the *interface* and utility functions for accounts. It has the following
 modules:

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-account.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-account.rst
@@ -7,13 +7,13 @@ Daml.Finance.Interface.Account.V4
 This package contains the *interface* and utility functions for accounts. It has the following
 modules:
 
-- :ref:`Factory <module-daml-finance-interface-account-factory-11691>`:
+- :ref:`Factory <module-daml-finance-interface-account-v4-factory-69358>`:
   Interface that allows implementing templates to create and remove accounts
-- :ref:`Account <module-daml-finance-interface-account-account-92922>`:
+- :ref:`Account <module-daml-finance-interface-account-v4-account-30007>`:
   Interface which represents an established relationship between a custodian and an owner. It
   specifies parties controlling incoming and outgoing transfers, and allows for crediting and
   debiting holdings
-- :ref:`Util <module-daml-finance-interface-account-util-56106>`:
+- :ref:`Util <module-daml-finance-interface-account-v4-util-78761>`:
   Utility functions related to accounts, e.g., getting the custodian or the owner of an account
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-claims.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-claims.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Claims
-#############################
+Daml.Finance.Interface.Claims.V4
+################################
 
 This package contains the *interface* for Contingent Claims based instruments. It contains the
 following modules:

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-claims.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-claims.rst
@@ -7,12 +7,12 @@ Daml.Finance.Interface.Claims.V4
 This package contains the *interface* for Contingent Claims based instruments. It contains the
 following modules:
 
-- :ref:`Claim <module-daml-finance-interface-claims-claim-82866>`:
+- :ref:`Claim <module-daml-finance-interface-claims-v4-claim-38573>`:
   Interface implemented by templates that can be represented as a set of contingent claims
-- :ref:`Dynamic.Instrument <module-daml-finance-interface-claims-dynamic-instrument-83951>`:
+- :ref:`Dynamic.Instrument <module-daml-finance-interface-claims-v4-dynamic-instrument-86702>`:
   Interface implemented by instruments that create Contingent Claims trees on-the-fly (i.e. the
   tree is not stored on disk as part of a contract, but created and processed in-memory)
-- :ref:`Types <module-daml-finance-interface-claims-types-95967>`:
+- :ref:`Types <module-daml-finance-interface-claims-v4-types-7840>`:
   Types related to claims and what is required to represent claims (e.g. Deliverable and
   Observable)
 

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-data.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-data.rst
@@ -7,16 +7,16 @@ Daml.Finance.Interface.Data.V4
 This package contains the *interface* for inspecting and working with observables, which are used
 in the context of lifecycling. It contains the following modules:
 
-- :ref:`Numeric.Observation.Factory <module-daml-finance-interface-data-numeric-observation-factory-57560>`:
+- :ref:`Numeric.Observation.Factory <module-daml-finance-interface-data-v4-numeric-observation-factory-95641>`:
   Interface for a factory used to create, remove and view a ``Numeric.Observation``
-- :ref:`Numeric.Observation <module-daml-finance-interface-data-numeric-observation-99152>`:
+- :ref:`Numeric.Observation <module-daml-finance-interface-data-v4-numeric-observation-41921>`:
   Interface for a time-dependent ``Numeric.Observation``, where the values are explicitly stored
   on-ledger
-- :ref:`Reference.HolidayCalendar.Factory <module-daml-finance-interface-data-reference-holidaycalendar-factory-22148>`:
+- :ref:`Reference.HolidayCalendar.Factory <module-daml-finance-interface-data-v4-reference-holidaycalendar-factory-36485>`:
   Interface for a factory used to create, remove and view a ``HolidayCalendar``
-- :ref:`Reference.HolidayCalendar <module-daml-finance-interface-data-reference-holidaycalendar-19648>`:
+- :ref:`Reference.HolidayCalendar <module-daml-finance-interface-data-v4-reference-holidaycalendar-24201>`:
   Interface for contracts storing holiday calendar data on the ledger
-- :ref:`Reference.Time <module-daml-finance-interface-data-reference-time-54882>`:
+- :ref:`Reference.Time <module-daml-finance-interface-data-v4-reference-time-12465>`:
   Interface for contracts that control business time, providing choices to advance or rewind time
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-data.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-data.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Data
-###########################
+Daml.Finance.Interface.Data.V4
+##############################
 
 This package contains the *interface* for inspecting and working with observables, which are used
 in the context of lifecycling. It contains the following modules:

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-holding.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-holding.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Holding
-##############################
+Daml.Finance.Interface.Holding.V4
+#################################
 
 This package contains the *interface* and utility functions for holdings. It has the following
 modules:

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-holding.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-holding.rst
@@ -7,15 +7,15 @@ Daml.Finance.Interface.Holding.V4
 This package contains the *interface* and utility functions for holdings. It has the following
 modules:
 
-- :ref:`Factory <module-daml-finance-interface-holding-factory-6211>`:
+- :ref:`Factory <module-daml-finance-interface-holding-v4-factory-49942>`:
   Interface for a holding factory used to create (credit) and archive (debit) holdings
-- :ref:`Holding <module-daml-finance-interface-holding-holding-64126>`:
+- :ref:`Holding <module-daml-finance-interface-holding-v4-holding-20535>`:
   Interface for a base holding which includes locking capabilities
-- :ref:`Fungible <module-daml-finance-interface-holding-fungible-63712>`:
+- :ref:`Fungible <module-daml-finance-interface-holding-v4-fungible-55495>`:
   Interface for a fungible holding which allows splitting and merging
-- :ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`:
+- :ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`:
   Interface for a transferable holding, i.e., where ownership can be transferred to other parties
-- :ref:`Util <module-daml-finance-interface-holding-util-81618>`:
+- :ref:`Util <module-daml-finance-interface-holding-v4-util-74545>`:
   Utility functions related to holdings, e.g., getting the amount or the instrument of a holding
 
 The :doc:`Asset Model <../../concepts/asset-model>` page explains the relationship between

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-base.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-base.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Base
-######################################
+Daml.Finance.Interface.Instrument.Base.V4
+#########################################
 
 This package contains the *root interface* for all instruments. It contains the following modules:
 

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-base.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-base.rst
@@ -6,7 +6,7 @@ Daml.Finance.Interface.Instrument.Base.V4
 
 This package contains the *root interface* for all instruments. It contains the following modules:
 
-- :ref:`Instrument <module-daml-finance-interface-instrument-base-instrument-57320>`:
+- :ref:`Instrument <module-daml-finance-interface-instrument-base-v4-instrument-47185>`:
   Root instrument abstraction containing basic properties that every instrument exhibits
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-bond.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-bond.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Bond
-######################################
+Daml.Finance.Interface.Instrument.Bond.V3
+#########################################
 
 This package contains the *interface* definitions for bond instruments. It contains the following
 modules:

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-bond.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-bond.rst
@@ -7,35 +7,35 @@ Daml.Finance.Interface.Instrument.Bond.V3
 This package contains the *interface* definitions for bond instruments. It contains the following
 modules:
 
-- :ref:`Callable.Instrument <module-daml-finance-interface-instrument-bond-callable-instrument-70617>`:
+- :ref:`Callable.Instrument <module-daml-finance-interface-instrument-bond-v3-callable-instrument-14719>`:
   Instrument interface for callable bonds
-- :ref:`Callable.Factory <module-daml-finance-interface-instrument-bond-callable-factory-92299>`:
+- :ref:`Callable.Factory <module-daml-finance-interface-instrument-bond-v3-callable-factory-33809>`:
   Factory interface to instantiate callable bond instruments
-- :ref:`Callable.Types <module-daml-finance-interface-instrument-bond-callable-types-46430>`:
+- :ref:`Callable.Types <module-daml-finance-interface-instrument-bond-v3-callable-types-79940>`:
   Type definitions to support callable bond instruments
-- :ref:`FixedRate.Instrument <module-daml-finance-interface-instrument-bond-fixedrate-instrument-43896>`:
+- :ref:`FixedRate.Instrument <module-daml-finance-interface-instrument-bond-v3-fixedrate-instrument-6918>`:
   Instrument interface for fixed-rate bonds
-- :ref:`FixedRate.Factory <module-daml-finance-interface-instrument-bond-fixedrate-factory-42532>`:
+- :ref:`FixedRate.Factory <module-daml-finance-interface-instrument-bond-v3-fixedrate-factory-45278>`:
   Factory interface to instantiate fixed-rate bond instruments
-- :ref:`FixedRate.Types <module-daml-finance-interface-instrument-bond-fixedrate-types-40221>`:
+- :ref:`FixedRate.Types <module-daml-finance-interface-instrument-bond-v3-fixedrate-types-11835>`:
   Type definitions to support fixed-rate bond instruments
-- :ref:`FloatingRate.Instrument <module-daml-finance-interface-instrument-bond-floatingrate-instrument-46777>`:
+- :ref:`FloatingRate.Instrument <module-daml-finance-interface-instrument-bond-v3-floatingrate-instrument-18047>`:
   Instrument interface for floating-rate bonds
-- :ref:`FloatingRate.Factory <module-daml-finance-interface-instrument-bond-floatingrate-factory-53843>`:
+- :ref:`FloatingRate.Factory <module-daml-finance-interface-instrument-bond-v3-floatingrate-factory-1777>`:
   Factory interface to instantiate floating-rate bond instruments
-- :ref:`FloatingRate.Types <module-daml-finance-interface-instrument-bond-floatingrate-types-45430>`:
+- :ref:`FloatingRate.Types <module-daml-finance-interface-instrument-bond-v3-floatingrate-types-56004>`:
   Type definitions to support floating-rate bond instruments
-- :ref:`InflationLinked.Instrument <module-daml-finance-interface-instrument-bond-inflationlinked-instrument-38495>`:
+- :ref:`InflationLinked.Instrument <module-daml-finance-interface-instrument-bond-v3-inflationlinked-instrument-29769>`:
   Instrument interface for inflation-linked bonds
-- :ref:`InflationLinked.Factory <module-daml-finance-interface-instrument-bond-inflationlinked-factory-57553>`:
+- :ref:`InflationLinked.Factory <module-daml-finance-interface-instrument-bond-v3-inflationlinked-factory-90803>`:
   Factory interface to instantiate inflation-linked bond instruments
-- :ref:`InflationLinked.Types <module-daml-finance-interface-instrument-bond-inflationlinked-types-71908>`:
+- :ref:`InflationLinked.Types <module-daml-finance-interface-instrument-bond-v3-inflationlinked-types-43490>`:
   Type definitions to support inflation-linked bond instruments
-- :ref:`ZeroCoupon.Instrument <module-daml-finance-interface-instrument-bond-zerocoupon-instrument-59755>`:
+- :ref:`ZeroCoupon.Instrument <module-daml-finance-interface-instrument-bond-v3-zerocoupon-instrument-34777>`:
   Instrument interface for zero-coupon bonds
-- :ref:`ZeroCoupon.Factory <module-daml-finance-interface-instrument-bond-zerocoupon-factory-70433>`:
+- :ref:`ZeroCoupon.Factory <module-daml-finance-interface-instrument-bond-v3-zerocoupon-factory-22139>`:
   Factory interface to instantiate zero-coupon bond instruments
-- :ref:`ZeroCoupon.Types <module-daml-finance-interface-instrument-bond-zerocoupon-types-74248>`:
+- :ref:`ZeroCoupon.Types <module-daml-finance-interface-instrument-bond-v3-zerocoupon-types-44506>`:
   Type definitions to support zero-coupon bond instruments
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-equity.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-equity.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Equity
-########################################
+Daml.Finance.Interface.Instrument.Equity.V1
+###########################################
 
 This package contains the *interface* definitions for equity instruments. It contains the following
 modules:

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-equity.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-equity.rst
@@ -7,10 +7,10 @@ Daml.Finance.Interface.Instrument.Equity.V1
 This package contains the *interface* definitions for equity instruments. It contains the following
 modules:
 
-- :ref:`Instrument <module-daml-finance-interface-instrument-equity-instrument-13224>`:
+- :ref:`Instrument <module-daml-finance-interface-instrument-equity-v1-instrument-10480>`:
   Instrument interface for equities. It supports lifecycling events through the
   ``DeclareDistribution``, ``DeclareReplacement`` and ``DeclareStockSplit`` choices.
-- :ref:`Factory <module-daml-finance-interface-instrument-equity-factory-97140>`:
+- :ref:`Factory <module-daml-finance-interface-instrument-equity-v1-factory-86676>`:
   Factory interface to instantiate equities
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-generic.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-generic.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Generic
-#########################################
+Daml.Finance.Interface.Instrument.Generic.V4
+############################################
 
 This package contains the *interface* definitions for generic, contingent-claims-based instruments.
 It contains the following modules:

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-generic.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-generic.rst
@@ -7,9 +7,9 @@ Daml.Finance.Interface.Instrument.Generic.V4
 This package contains the *interface* definitions for generic, contingent-claims-based instruments.
 It contains the following modules:
 
-- :ref:`Instrument <module-daml-finance-interface-instrument-generic-instrument-53275>`:
+- :ref:`Instrument <module-daml-finance-interface-instrument-generic-v4-instrument-7928>`:
   Instrument interface for generic instruments
-- :ref:`Factory <module-daml-finance-interface-instrument-generic-factory-11761>`:
+- :ref:`Factory <module-daml-finance-interface-instrument-generic-v4-factory-73556>`:
   Factory interface to instantiate generic instruments
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-option.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-option.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Option
-########################################
+Daml.Finance.Interface.Instrument.Option.V1
+###########################################
 
 This package contains the *interface* definitions for various option instruments. It contains the
 following modules:

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-option.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-option.rst
@@ -7,33 +7,33 @@ Daml.Finance.Interface.Instrument.Option.V1
 This package contains the *interface* definitions for various option instruments. It contains the
 following modules:
 
-- :ref:`BarrierEuropeanCash.Instrument <module-daml-finance-interface-instrument-option-barriereuropeancash-instrument-61159>`:
+- :ref:`BarrierEuropeanCash.Instrument <module-daml-finance-interface-instrument-option-v1-barriereuropeancash-instrument-53071>`:
   Instrument interface for barrier options
-- :ref:`BarrierEuropeanCash.Factory <module-daml-finance-interface-instrument-option-barriereuropeancash-factory-6809>`:
+- :ref:`BarrierEuropeanCash.Factory <module-daml-finance-interface-instrument-option-v1-barriereuropeancash-factory-7901>`:
   Factory interface to instantiate barrier options
-- :ref:`BarrierEuropeanCash.Types <module-daml-finance-interface-instrument-option-barriereuropeancash-types-4296>`:
+- :ref:`BarrierEuropeanCash.Types <module-daml-finance-interface-instrument-option-v1-barriereuropeancash-types-88688>`:
   Type definitions to support barrier options
-- :ref:`Dividend.Instrument <module-daml-finance-interface-instrument-option-dividend-instrument-3166>`:
+- :ref:`Dividend.Instrument <module-daml-finance-interface-instrument-option-v1-dividend-instrument-62914>`:
   Instrument interface for dividend options
-- :ref:`Dividend.Factory <module-daml-finance-interface-instrument-option-dividend-factory-77394>`:
+- :ref:`Dividend.Factory <module-daml-finance-interface-instrument-option-v1-dividend-factory-13790>`:
   Factory interface to instantiate dividend options
-- :ref:`Dividend.Types <module-daml-finance-interface-instrument-option-dividend-types-84299>`:
+- :ref:`Dividend.Types <module-daml-finance-interface-instrument-option-v1-dividend-types-94199>`:
   Type definitions to support dividend options
-- :ref:`Dividend.Election.Factory <module-daml-finance-interface-instrument-option-dividend-election-factory-158>`:
+- :ref:`Dividend.Election.Factory <module-daml-finance-interface-instrument-option-v1-dividend-election-factory-48110>`:
   Factory interface to instantiate elections for dividend options
-- :ref:`EuropeanCash.Instrument <module-daml-finance-interface-instrument-option-europeancash-instrument-96357>`:
+- :ref:`EuropeanCash.Instrument <module-daml-finance-interface-instrument-option-v1-europeancash-instrument-57397>`:
   Instrument interface for cash-settled European options
-- :ref:`EuropeanCash.Factory <module-daml-finance-interface-instrument-option-europeancash-factory-18215>`:
+- :ref:`EuropeanCash.Factory <module-daml-finance-interface-instrument-option-v1-europeancash-factory-30359>`:
   Factory interface to instantiate cash-settled European options
-- :ref:`EuropeanCash.Types <module-daml-finance-interface-instrument-option-europeancash-types-42062>`:
+- :ref:`EuropeanCash.Types <module-daml-finance-interface-instrument-option-v1-europeancash-types-26382>`:
   Type definitions to support cash-settled European options
-- :ref:`EuropeanPhysical.Instrument <module-daml-finance-interface-instrument-option-europeanphysical-instrument-46335>`:
+- :ref:`EuropeanPhysical.Instrument <module-daml-finance-interface-instrument-option-v1-europeanphysical-instrument-41255>`:
   Instrument interface for physically settled European options
-- :ref:`EuropeanPhysical.Factory <module-daml-finance-interface-instrument-option-europeanphysical-factory-8645>`:
+- :ref:`EuropeanPhysical.Factory <module-daml-finance-interface-instrument-option-v1-europeanphysical-factory-44217>`:
   Factory interface to instantiate physically settled European options
-- :ref:`EuropeanPhysical.Types <module-daml-finance-interface-instrument-option-europeanphysical-types-48412>`:
+- :ref:`EuropeanPhysical.Types <module-daml-finance-interface-instrument-option-v1-europeanphysical-types-4904>`:
   Type definitions to support physically settled European options
-- :ref:`Types <module-daml-finance-interface-instrument-option-types-52343>`:
+- :ref:`Types <module-daml-finance-interface-instrument-option-v1-types-50595>`:
   Type definitions common to several instruments in this package
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-structuredproduct.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-structuredproduct.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.StructuredProduct
-###################################################
+Daml.Finance.Interface.Instrument.StructuredProduct.V1
+######################################################
 
 This package contains the *interface* definitions for various structured product instruments. It
 contains the following modules:

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-structuredproduct.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-structuredproduct.rst
@@ -7,6 +7,12 @@ Daml.Finance.Interface.Instrument.StructuredProduct.V1
 This package contains the *interface* definitions for various structured product instruments. It
 contains the following modules:
 
+- :ref:`AutoCallable.Instrument <module-daml-finance-interface-instrument-structuredproduct-v1-autocallable-instrument-15420>`:
+  Instrument interface for Barrier Reverse Convertibles
+- :ref:`AutoCallable.Factory <module-daml-finance-interface-instrument-structuredproduct-v1-autocallable-factory-27792>`:
+  Factory interface to instantiate Barrier Reverse Convertibles
+- :ref:`AutoCallable.Types <module-daml-finance-interface-instrument-structuredproduct-v1-autocallable-types-17541>`:
+  Type definitions to support Auto Callable
 - :ref:`BarrierReverseConvertible.Instrument <module-daml-finance-interface-instrument-structuredproduct-v1-barrierreverseconvertible-instrument-63394>`:
   Instrument interface for Barrier Reverse Convertibles
 - :ref:`BarrierReverseConvertible.Factory <module-daml-finance-interface-instrument-structuredproduct-v1-barrierreverseconvertible-factory-71934>`:

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-structuredproduct.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-structuredproduct.rst
@@ -7,13 +7,13 @@ Daml.Finance.Interface.Instrument.StructuredProduct.V1
 This package contains the *interface* definitions for various structured product instruments. It
 contains the following modules:
 
-- :ref:`BarrierReverseConvertible.Instrument <module-daml-finance-interface-instrument-structuredproduct-barrierreverseconvertible-instrument-73562>`:
+- :ref:`BarrierReverseConvertible.Instrument <module-daml-finance-interface-instrument-structuredproduct-v1-barrierreverseconvertible-instrument-63394>`:
   Instrument interface for Barrier Reverse Convertibles
-- :ref:`BarrierReverseConvertible.Factory <module-daml-finance-interface-instrument-structuredproduct-barrierreverseconvertible-factory-31742>`:
+- :ref:`BarrierReverseConvertible.Factory <module-daml-finance-interface-instrument-structuredproduct-v1-barrierreverseconvertible-factory-71934>`:
   Factory interface to instantiate Barrier Reverse Convertibles
-- :ref:`BarrierReverseConvertible.Types <module-daml-finance-interface-instrument-structuredproduct-barrierreverseconvertible-types-21839>`:
+- :ref:`BarrierReverseConvertible.Types <module-daml-finance-interface-instrument-structuredproduct-v1-barrierreverseconvertible-types-37471>`:
   Type definitions to support Barrier Reverse Convertibles
-- :ref:`Types <module-daml-finance-interface-instrument-structuredproduct-types-79453>`:
+- :ref:`Types <module-daml-finance-interface-instrument-structuredproduct-v1-types-27765>`:
   Type definitions common to instruments in this package
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-swap.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-swap.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Swap
-######################################
+Daml.Finance.Interface.Instrument.Swap.V1
+#########################################
 
 This package contains the *interface* definitions for various swap instruments. It contains the
 following modules:

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-swap.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-swap.rst
@@ -7,43 +7,43 @@ Daml.Finance.Interface.Instrument.Swap.V1
 This package contains the *interface* definitions for various swap instruments. It contains the
 following modules:
 
-- :ref:`Asset.Instrument <module-daml-finance-interface-instrument-swap-asset-instrument-37258>`:
+- :ref:`Asset.Instrument <module-daml-finance-interface-instrument-swap-v1-asset-instrument-20594>`:
   Instrument interface for asset swaps
-- :ref:`Asset.Factory <module-daml-finance-interface-instrument-swap-asset-factory-39510>`:
+- :ref:`Asset.Factory <module-daml-finance-interface-instrument-swap-v1-asset-factory-94466>`:
   Factory interface to instantiate asset swaps
-- :ref:`Asset.Types <module-daml-finance-interface-instrument-swap-asset-types-80415>`:
+- :ref:`Asset.Types <module-daml-finance-interface-instrument-swap-v1-asset-types-74535>`:
   Type definitions to support asset swaps
-- :ref:`CreditDefault.Instrument <module-daml-finance-interface-instrument-swap-creditdefault-instrument-27480>`:
+- :ref:`CreditDefault.Instrument <module-daml-finance-interface-instrument-swap-v1-creditdefault-instrument-73888>`:
   Instrument interface for credit default swaps
-- :ref:`CreditDefault.Factory <module-daml-finance-interface-instrument-swap-creditdefault-factory-3156>`:
+- :ref:`CreditDefault.Factory <module-daml-finance-interface-instrument-swap-v1-creditdefault-factory-54420>`:
   Factory interface to instantiate credit default swaps
-- :ref:`CreditDefault.Types <module-daml-finance-interface-instrument-swap-creditdefault-types-77045>`:
+- :ref:`CreditDefault.Types <module-daml-finance-interface-instrument-swap-v1-creditdefault-types-7361>`:
   Type definitions to support credit default swaps
-- :ref:`Currency.Instrument <module-daml-finance-interface-instrument-swap-currency-instrument-11782>`:
+- :ref:`Currency.Instrument <module-daml-finance-interface-instrument-swap-v1-currency-instrument-56842>`:
   Instrument interface for currency swaps
-- :ref:`Currency.Factory <module-daml-finance-interface-instrument-swap-currency-factory-24950>`:
+- :ref:`Currency.Factory <module-daml-finance-interface-instrument-swap-v1-currency-factory-88578>`:
   Factory interface to instantiate currency swaps
-- :ref:`Currency.Types <module-daml-finance-interface-instrument-swap-currency-types-6291>`:
+- :ref:`Currency.Types <module-daml-finance-interface-instrument-swap-v1-currency-types-57191>`:
   Type definitions to support currency swaps
-- :ref:`ForeignExchange.Instrument <module-daml-finance-interface-instrument-swap-foreignexchange-instrument-90743>`:
+- :ref:`ForeignExchange.Instrument <module-daml-finance-interface-instrument-swap-v1-foreignexchange-instrument-1927>`:
   Instrument interface for foreign exchange swaps
-- :ref:`ForeignExchange.Factory <module-daml-finance-interface-instrument-swap-foreignexchange-factory-12809>`:
+- :ref:`ForeignExchange.Factory <module-daml-finance-interface-instrument-swap-v1-foreignexchange-factory-73309>`:
   Factory interface to instantiate foreign exchange swaps
-- :ref:`ForeignExchange.Types <module-daml-finance-interface-instrument-swap-foreignexchange-types-73964>`:
+- :ref:`ForeignExchange.Types <module-daml-finance-interface-instrument-swap-v1-foreignexchange-types-23348>`:
   Type definitions to support foreign exchange swaps
-- :ref:`Fpml.Instrument <module-daml-finance-interface-instrument-swap-fpml-instrument-38654>`:
+- :ref:`Fpml.Instrument <module-daml-finance-interface-instrument-swap-v1-fpml-instrument-33450>`:
   Instrument interface for FpML swaps
-- :ref:`Fpml.Factory <module-daml-finance-interface-instrument-swap-fpml-factory-59622>`:
+- :ref:`Fpml.Factory <module-daml-finance-interface-instrument-swap-v1-fpml-factory-48474>`:
   Factory interface to instantiate FpML swaps
-- :ref:`Fpml.FpmlTypes <module-daml-finance-interface-instrument-swap-fpml-fpmltypes-35062>`:
+- :ref:`Fpml.FpmlTypes <module-daml-finance-interface-instrument-swap-v1-fpml-fpmltypes-21994>`:
   Specific FpML types used to support FpML swaps
-- :ref:`Fpml.Types <module-daml-finance-interface-instrument-swap-fpml-types-21219>`:
+- :ref:`Fpml.Types <module-daml-finance-interface-instrument-swap-v1-fpml-types-78959>`:
   Type definitions to support FpML swaps
-- :ref:`InterestRate.Instrument <module-daml-finance-interface-instrument-swap-interestrate-instrument-49463>`:
+- :ref:`InterestRate.Instrument <module-daml-finance-interface-instrument-swap-v1-interestrate-instrument-49411>`:
   Instrument interface for interest rate swaps
-- :ref:`InterestRate.Factory <module-daml-finance-interface-instrument-swap-interestrate-factory-76077>`:
+- :ref:`InterestRate.Factory <module-daml-finance-interface-instrument-swap-v1-interestrate-factory-67829>`:
   Factory interface to instantiate interest rate swaps
-- :ref:`InterestRate.Types <module-daml-finance-interface-instrument-swap-interestrate-types-72064>`:
+- :ref:`InterestRate.Types <module-daml-finance-interface-instrument-swap-v1-interestrate-types-3648>`:
   Type definitions to support interest rate swaps
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-token.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-token.rst
@@ -7,11 +7,11 @@ Daml.Finance.Interface.Instrument.Token.V4
 This package contains the *interface* definitions for simple token instruments which do not define
 any lifecycling logic. It contains the following modules:
 
-- :ref:`Instrument <module-daml-finance-interface-instrument-token-instrument-24425>`:
+- :ref:`Instrument <module-daml-finance-interface-instrument-token-v4-instrument-40238>`:
   Instrument interface for simple tokens
-- :ref:`Factory <module-daml-finance-interface-instrument-token-factory-34763>`:
+- :ref:`Factory <module-daml-finance-interface-instrument-token-v4-factory-1398>`:
   Factory interface to instantiate simple tokens
-- :ref:`Types <module-daml-finance-interface-instrument-token-types-26222>`:
+- :ref:`Types <module-daml-finance-interface-instrument-token-v4-types-62835>`:
   Type definitions to support simple tokens
 
 Check out the :doc:`Transfer tutorial <../../tutorials/getting-started/transfer>` for an example on

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-token.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-token.rst
@@ -2,7 +2,7 @@
 .. SPDX-License-Identifier: Apache-2.0
 
 Daml.Finance.Interface.Instrument.Token.V4
-#######################################
+##########################################
 
 This package contains the *interface* definitions for simple token instruments which do not define
 any lifecycling logic. It contains the following modules:

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-token.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-token.rst
@@ -1,7 +1,7 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Token
+Daml.Finance.Interface.Instrument.Token.V4
 #######################################
 
 This package contains the *interface* definitions for simple token instruments which do not define

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-types.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-types.rst
@@ -6,7 +6,7 @@ Daml.Finance.Interface.Instrument.Types.V2
 
 This package contains types shared by several instruments. It contains the following modules:
 
-- :ref:`FloatingRate <module-daml-finance-interface-instrument-types-floatingrate-35782>`:
+- :ref:`FloatingRate <module-daml-finance-interface-instrument-types-v2-floatingrate-85519>`:
   Types used to specify different kinds of floating reference rates.
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-types.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-instrument-types.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Instrument.Types
-#######################################
+Daml.Finance.Interface.Instrument.Types.V2
+##########################################
 
 This package contains types shared by several instruments. It contains the following modules:
 

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-lifecycle.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Lifecycle
-################################
+Daml.Finance.Interface.Lifecycle.V4
+###################################
 
 This package contains the *interface* for lifecycle related processes. It contains the following
 modules:

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-lifecycle.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-lifecycle.rst
@@ -7,33 +7,33 @@ Daml.Finance.Interface.Lifecycle.V4
 This package contains the *interface* for lifecycle related processes. It contains the following
 modules:
 
-- :ref:`Effect <module-daml-finance-interface-lifecycle-effect-16050>`:
+- :ref:`Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>`:
   Interface for contracts exposing effects of lifecycling processes, e.g., the payment resulting
   from a bond coupon
-- :ref:`Election <module-daml-finance-interface-lifecycle-election-24570>`:
+- :ref:`Election <module-daml-finance-interface-lifecycle-v4-election-15483>`:
   Interface to allow for elections to be made on claim based instruments
-- :ref:`Election.Factory <module-daml-finance-interface-lifecycle-election-factory-66610>`:
+- :ref:`Election.Factory <module-daml-finance-interface-lifecycle-v4-election-factory-21763>`:
   Factory interface to instantiate elections on claim based instruments
-- :ref:`Event <module-daml-finance-interface-lifecycle-event-43586>`:
+- :ref:`Event <module-daml-finance-interface-lifecycle-v4-event-91777>`:
   Interface for a lifecycle event. An event is any contract that triggers the processing of a
   lifecycle rule. Events can be, e.g., dividend announcements or simply the passing of time.
-- :ref:`Event.Distribution <module-daml-finance-interface-lifecycle-event-distribution-91943>`:
+- :ref:`Event.Distribution <module-daml-finance-interface-lifecycle-v4-event-distribution-56030>`:
   Event interface for the distribution of units of an instrument for each unit of a target
   instrument (e\.g\. share or cash dividends)
-- :ref:`Event.Replacement <module-daml-finance-interface-lifecycle-event-replacement-2440>`:
+- :ref:`Event.Replacement <module-daml-finance-interface-lifecycle-v4-event-replacement-41051>`:
   Event interface for the replacement of units of an instrument with a basket of other
   instruments (e\.g\. stock merger)
-- :ref:`Event.Time <module-daml-finance-interface-lifecycle-event-time-4252>`:
+- :ref:`Event.Time <module-daml-finance-interface-lifecycle-v4-event-time-69757>`:
   Event interface for events that signal the passing of (business) time
-- :ref:`Rule.Lifecycle <module-daml-finance-interface-lifecycle-rule-lifecycle-50431>`:
+- :ref:`Rule.Lifecycle <module-daml-finance-interface-lifecycle-v4-rule-lifecycle-8270>`:
   Interface implemented by rules that lifecycle and evolve instruments
-- :ref:`Rule.Claim <module-daml-finance-interface-lifecycle-rule-claim-6739>`:
+- :ref:`Rule.Claim <module-daml-finance-interface-lifecycle-v4-rule-claim-89954>`:
   Interface for contracts that allow holders to claim an ``Effect`` and generate settlement
   instructions
-- :ref:`Observable.NumericObservable <module-daml-finance-interface-lifecycle-observable-numericobservable-67288>`:
+- :ref:`Observable.NumericObservable <module-daml-finance-interface-lifecycle-v4-observable-numericobservable-50817>`:
   Interface to observe time-dependent numerical values (e.g. a stock price or an interest rate
   fixing)
-- :ref:`Observable.TimeObservable <module-daml-finance-interface-lifecycle-observable-timeobservable-45971>`:
+- :ref:`Observable.TimeObservable <module-daml-finance-interface-lifecycle-v4-observable-timeobservable-64296>`:
   Interface implemented by templates exposing time information
 
 The :doc:`Lifecycling <../../concepts/lifecycling>` page contains an overview of the lifecycle

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-settlement.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-settlement.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Settlement
-#################################
+Daml.Finance.Interface.Settlement.V4
+####################################
 
 This package contains the *interface* for settlement. It has the following modules:
 

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-settlement.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-settlement.rst
@@ -6,15 +6,15 @@ Daml.Finance.Interface.Settlement.V4
 
 This package contains the *interface* for settlement. It has the following modules:
 
-- :ref:`RouteProvider <module-daml-finance-interface-settlement-routeprovider-15164>`:
+- :ref:`RouteProvider <module-daml-finance-interface-settlement-v4-routeprovider-63>`:
   Interface for providing a discovery mechanism for settlement routes
-- :ref:`Instruction <module-daml-finance-interface-settlement-instruction-10970>`:
+- :ref:`Instruction <module-daml-finance-interface-settlement-v4-instruction-71097>`:
   Interface for providing a single instruction to transfer an asset at a custodian
-- :ref:`Batch <module-daml-finance-interface-settlement-batch-39188>`:
+- :ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>`:
   Interface for atomically executing instructions, i.e., settling `Transferable`\s
-- :ref:`Factory <module-daml-finance-interface-settlement-factory-75196>`:
+- :ref:`Factory <module-daml-finance-interface-settlement-v4-factory-85379>`:
   Interface used to generate a batch and associated instructions
-- :ref:`Types <module-daml-finance-interface-settlement-types-44085>`:
+- :ref:`Types <module-daml-finance-interface-settlement-v4-types-65938>`:
   Types required in the settlement process, e.g., `Step`, `RoutedStep`, `Allocation`, and
   `Approval`
 

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-types-common.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-types-common.rst
@@ -6,7 +6,7 @@ Daml.Finance.Interface.Types.Common.V3
 
 This package contains common type definitions. They are defined in the following modules:
 
-- :ref:`Types <module-daml-finance-interface-types-common-types-55444>`:
+- :ref:`Types <module-daml-finance-interface-types-common-v3-types-97540>`:
   Various types related to keys, observers, parties, identifiers and quantities, which are
   commonly used in several packages
 

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-types-common.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-types-common.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Types.Common
-###################################
+Daml.Finance.Interface.Types.Common.V3
+######################################
 
 This package contains common type definitions. They are defined in the following modules:
 

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-types-date.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-types-date.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Types.Date
-#################################
+Daml.Finance.Interface.Types.Date.V3
+####################################
 
 Financial instruments, especially those related to interest rates, often depend on periodic
 schedules. For example, consider a fixed rate bond with a coupon that should be paid every three

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-types-date.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-types-date.rst
@@ -14,19 +14,19 @@ This package contains types related to dates, in particular how to define regula
 dates should be adjusted when they fall on non-business days. They are defined in the following
 modules:
 
-- :ref:`Calendar <module-daml-finance-interface-types-date-calendar-23555>`:
+- :ref:`Calendar <module-daml-finance-interface-types-date-v3-calendar-20021>`:
   Types for holiday calendar data and how to adjust non-business days
-- :ref:`Classes <module-daml-finance-interface-types-date-classes-73544>`:
+- :ref:`Classes <module-daml-finance-interface-types-date-v3-classes-49826>`:
   Type class that specifies what can be converted to UTC time
-- :ref:`DateOffset <module-daml-finance-interface-types-date-dateoffset-40136>`:
+- :ref:`DateOffset <module-daml-finance-interface-types-date-v3-dateoffset-17578>`:
   Types for date offsets that can be used e.g. to specify a rate fixing date relative to the reset
   date in terms of a business days offset and an associated set of financial business centers.
-- :ref:`DayCount <module-daml-finance-interface-types-date-daycount-90980>`:
+- :ref:`DayCount <module-daml-finance-interface-types-date-v3-daycount-5046>`:
   Type to specify the conventions used to calculate day count fractions. These are used to define
   the interest accrued during each schedule period, for example for a bond or a swap.
-- :ref:`RollConvention <module-daml-finance-interface-types-date-rollconvention-76363>`:
+- :ref:`RollConvention <module-daml-finance-interface-types-date-v3-rollconvention-38965>`:
   Types to define date periods and how to roll dates
-- :ref:`Schedule <module-daml-finance-interface-types-date-schedule-61944>`:
+- :ref:`Schedule <module-daml-finance-interface-types-date-v3-schedule-94670>`:
   Types to define date schedules
 
 Check out the :ref:`Fixed rate bond documentation <fixed-rate-bond-tutorial-section>`

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-util.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-util.rst
@@ -7,13 +7,13 @@ Daml.Finance.Interface.Util.V3
 This package contains the *interface* for the disclosure of contracts and some commonly used
 utility functions. They are defined in these modules:
 
-- :ref:`Disclosure <module-daml-finance-interface-util-disclosure-87755>`:
+- :ref:`Disclosure <module-daml-finance-interface-util-v3-disclosure-50779>`:
   An interface for managing the visibility of contracts for non-authorizing parties
-- :ref:`Lockable <module-daml-finance-interface-util-lockable-80915>`:
+- :ref:`Lockable <module-daml-finance-interface-util-v3-lockable-20339>`:
   An interface for locking contracts, e.g., a holding or account
-- :ref:`InterfaceKeys <module-daml-finance-interface-util-interfacekey-52230>`:
+- :ref:`InterfaceKeys <module-daml-finance-interface-util-v3-interfacekey-20882>`:
   An interface with utility functions for keying interfaces
-- :ref:`Common <module-daml-finance-interface-util-common-43703>`:
+- :ref:`Common <module-daml-finance-interface-util-v3-common-32871>`:
   Different utility functions related to interfaces and assertions
 
 Changelog

--- a/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-util.rst
+++ b/docs/3.1/docs/daml-finance/packages/interfaces/daml-finance-interface-util.rst
@@ -1,8 +1,8 @@
 .. Copyright (c) 2023 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Daml.Finance.Interface.Util
-###########################
+Daml.Finance.Interface.Util.V3
+##############################
 
 This package contains the *interface* for the disclosure of contracts and some commonly used
 utility functions. They are defined in these modules:

--- a/docs/3.1/docs/daml-finance/reference/patterns.rst
+++ b/docs/3.1/docs/daml-finance/reference/patterns.rst
@@ -17,7 +17,7 @@ has to do with application decoupling / upgradeability of your application.
 
 For example, suppose that you are writing Daml code to issue equity instruments. Your workflow
 references the version ``0.2.1`` of the
-:ref:`Equity implementation package <module-daml-finance-instrument-equity-instrument-69265>`
+:ref:`Equity implementation package <module-daml-finance-instrument-equity-v1-instrument-56047>`
 and at some point creates an instrument as follows.
 
 .. code-block:: daml
@@ -33,15 +33,15 @@ Daml code in order to use the new feature and will have to deal with upgrading m
 on the ledger.
 
 A safer approach is for your Daml code to only reference the
-:ref:`Equity interface package <module-daml-finance-interface-instrument-equity-instrument-13224>`,
+:ref:`Equity interface package <module-daml-finance-interface-instrument-equity-v1-instrument-10480>`,
 which contains interface definitions and is updated less frequently.
 
 However, you would now need a way to create equity instruments without referencing
 ``Daml.Finance.Instrument.Equity.V1`` in your main Daml workflow. To do this, you can setup a Script
 to run during ledger initialisation that will create a
-:ref:`factory contract <module-daml-finance-instrument-equity-factory-96899>`
+:ref:`factory contract <module-daml-finance-instrument-equity-v1-factory-43861>`
 and cast it to the corresponding
-:ref:`interface <module-daml-finance-interface-instrument-equity-factory-97140>`.
+:ref:`interface <module-daml-finance-interface-instrument-equity-v1-factory-86676>`.
 You can then use the factory in your main workflow code to create the instruments.
 
 When an upgraded instrument comes along, you would need to write code to archive the old factory and
@@ -61,7 +61,7 @@ when working with interfaces. This is required as there is currently no built-in
 language level for interface keys.
 
 We want for instance to use an
-:ref:`InstrumentKey <constr-daml-finance-interface-types-common-types-instrumentkey-32970>` to
+:ref:`InstrumentKey <constr-daml-finance-interface-types-common-v3-types-instrumentkey-49116>` to
 identify instruments across a number of implementing templates.
 
 To do that, we define a `Reference` template that
@@ -96,14 +96,14 @@ There are different ways to access the data of a contract, for example the terms
    submitting party to be a stakeholder of the contract). It is then possible to use the ``view``
    built-in method to get the interface view.
 #. ``GetView``: by calling this choice on the interface, for example on a
-   :ref:`callable bond <module-daml-finance-interface-instrument-bond-callable-instrument-70617>`,
+   :ref:`callable bond <module-daml-finance-interface-instrument-bond-v3-callable-instrument-14719>`,
    a party can get the view of a contract, without necessarily being a stakeholder of the contract.
    This can be useful in situations where someone needs access to reference data, but should not be
    a stakeholder of the contract. Specifically, if *publicParty* is an observer of an instrumentCid,
    a party would only require readAs rights of *publicParty* in order to exercise ``GetView``. In
    the Daml Finance library, this choice has been implemented not only for instruments but also for
    other types of contracts, e.g.
-   :ref:`Holdings <module-daml-finance-interface-holding-fungible-63712>` and lifecycle related
+   :ref:`Holdings <module-daml-finance-interface-holding-v4-fungible-55495>` and lifecycle related
    contracts like
-   :ref:`Rule <module-daml-finance-interface-lifecycle-rule-lifecycle-50431>` and
-   :ref:`Effect <module-daml-finance-interface-lifecycle-effect-16050>`.
+   :ref:`Rule <module-daml-finance-interface-lifecycle-v4-rule-lifecycle-8270>` and
+   :ref:`Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>`.

--- a/docs/3.1/docs/daml-finance/reference/patterns.rst
+++ b/docs/3.1/docs/daml-finance/reference/patterns.rst
@@ -37,7 +37,7 @@ A safer approach is for your Daml code to only reference the
 which contains interface definitions and is updated less frequently.
 
 However, you would now need a way to create equity instruments without referencing
-``Daml.Finance.Instrument.Equity`` in your main Daml workflow. To do this, you can setup a Script
+``Daml.Finance.Instrument.Equity.V1`` in your main Daml workflow. To do this, you can setup a Script
 to run during ledger initialisation that will create a
 :ref:`factory contract <module-daml-finance-instrument-equity-factory-96899>`
 and cast it to the corresponding

--- a/docs/3.1/docs/daml-finance/tutorials/advanced-topics/instrument-modeling/contingent-claims-instrument.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/advanced-topics/instrument-modeling/contingent-claims-instrument.rst
@@ -32,7 +32,7 @@ Template Definition
 We start by defining a new template for the instrument. Here are the fields used for the fixed
 rate instrument:
 
-.. literalinclude:: ../../../src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
+.. literalinclude:: ../../../src/main/daml/Daml/Finance/Instrument/Bond/V3/FixedRate/Instrument.daml
   :language: daml
   :start-after: -- FIXED_RATE_BOND_TEMPLATE_BEGIN
   :end-before: -- FIXED_RATE_BOND_TEMPLATE_END
@@ -57,7 +57,7 @@ economic terms.
 Here is a high level implementation of the
 :ref:`Claims interface <module-daml-finance-interface-claims-claim-82866>`:
 
-.. literalinclude:: ../../../src/main/daml/Daml/Finance/Instrument/Bond/FixedRate/Instrument.daml
+.. literalinclude:: ../../../src/main/daml/Daml/Finance/Instrument/Bond/V3/FixedRate/Instrument.daml
   :language: daml
   :start-after: -- FIXED_RATE_BOND_CLAIMS_BEGIN
   :end-before: -- FIXED_RATE_BOND_CLAIMS_END
@@ -78,7 +78,7 @@ How to define the redemption claim
 
 The redemption claim depends on the currency and the maturity date of the bond.
 
-.. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/Util/Builders.daml
+.. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Util/Builders.daml
   :language: daml
   :start-after: -- FIXED_RATE_BOND_REDEMPTION_CLAIM_BEGIN
   :end-before: -- FIXED_RATE_BOND_REDEMPTION_CLAIM_END
@@ -102,7 +102,7 @@ How to define the coupon claims
 The coupon claims are a bit more complicated to define.
 We need to take a schedule of adjusted coupon dates and the day count convention into account.
 
-.. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/Util/Builders.daml
+.. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Util/Builders.daml
   :language: daml
   :start-after: -- FIXED_RATE_BOND_COUPON_CLAIMS_BEGIN
   :end-before: -- FIXED_RATE_BOND_COUPON_CLAIMS_END
@@ -122,7 +122,7 @@ payment.
 Evolution of the instrument over time (and calculation of the corresponding lifecycle effects) can
 be performed using the :ref:`Lifecycle.Rule <module-daml-finance-claims-lifecycle-rule-53980>`
 template provided in the
-:doc:`Daml.Finance.Claims <../../../packages/implementations/daml-finance-claims>` package. This
+:doc:`Daml.Finance.Claims.V3 <../../../packages/implementations/daml-finance-claims>` package. This
 rule is very generic and can be used for all instruments that implement the
 :ref:`Claims interface <module-daml-finance-interface-claims-claim-82866>`.
 
@@ -131,7 +131,7 @@ Let us break its implementation apart to describe what happens in more detail:
 * First, we retrieve the claim tree corresponding to the initial state of the instrument. We do so
   by fetching the ``Claims`` interface we defined for the template.
 
-  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/Lifecycle/Rule.daml
+  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Lifecycle/Rule.daml
     :language: daml
     :start-after: -- BOND_PROCESS_CLOCK_UPDATE_INITAL_CLAIMS_BEGIN
     :end-before: -- BOND_PROCESS_CLOCK_UPDATE_INITAL_CLAIMS_END
@@ -139,7 +139,7 @@ Let us break its implementation apart to describe what happens in more detail:
 * By using the ``lastEventTimestamp`` (in our case: the last time a coupon was paid), we can now
   "fast forward" the claim tree to the current instrument state.
 
-  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/Lifecycle/Rule.daml
+  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Lifecycle/Rule.daml
     :language: daml
     :start-after: -- BOND_PROCESS_CLOCK_UPDATE_LIFECYCLE_FASTFORWARD_BEGIN
     :end-before: -- BOND_PROCESS_CLOCK_UPDATE_LIFECYCLE_FASTFORWARD_END
@@ -149,7 +149,7 @@ Let us break its implementation apart to describe what happens in more detail:
   due), we create a :ref:`Lifecycle Effect <module-daml-finance-lifecycle-effect-1975>` for it,
   which can then be claimed and settled.
 
-  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/Lifecycle/Rule.daml
+  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Lifecycle/Rule.daml
     :language: daml
     :start-after: -- BOND_PROCESS_CLOCK_UPDATE_LIFECYCLE_BEGIN
     :end-before: -- BOND_PROCESS_CLOCK_UPDATE_LIFECYCLE_END
@@ -164,7 +164,7 @@ done by exercising the
 choice of the
 :ref:`Dynamic.Instrument interface <module-daml-finance-interface-claims-claim-82866>`:
 
-  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/Lifecycle/Rule.daml
+  .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Lifecycle/Rule.daml
     :language: daml
     :start-after: -- CREATE_NEW_DYNAMIC_INSTRUMENT_VERSION_BEGIN
     :end-before: -- CREATE_NEW_DYNAMIC_INSTRUMENT_VERSION_END
@@ -186,7 +186,7 @@ define the coupon based on a future observation of the reference rate.
 
 In the instrument definition, we need an identifier for the reference rate:
 
-.. literalinclude:: ../../../src/main/daml/Daml/Finance/Instrument/Bond/FloatingRate/Instrument.daml
+.. literalinclude:: ../../../src/main/daml/Daml/Finance/Instrument/Bond/V3/FloatingRate/Instrument.daml
   :language: daml
   :start-after: -- FLOATING_RATE_BOND_TEMPLATE_UNTIL_REFRATE_BEGIN
   :end-before: -- FLOATING_RATE_BOND_TEMPLATE_UNTIL_REFRATE_END
@@ -195,7 +195,7 @@ When we create the claims for the coupon payments, we can then use
 :ref:`ObserveAt <constr-contingentclaims-core-observation-observeat-8418>` to refer to the value of
 the reference rate:
 
-.. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/Util/Builders.daml
+.. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Util/Builders.daml
   :language: daml
   :start-after: -- FLOATING_RATE_BOND_COUPON_CLAIMS_BEGIN
   :end-before: -- FLOATING_RATE_BOND_COUPON_CLAIMS_END

--- a/docs/3.1/docs/daml-finance/tutorials/advanced-topics/instrument-modeling/contingent-claims-instrument.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/advanced-topics/instrument-modeling/contingent-claims-instrument.rst
@@ -13,7 +13,7 @@ implementations. The :doc:`Bond <../../../instruments/bond>` and
 behind the scenes to calculate pending coupon payments.
 
 Let us explore in detail how the
-:ref:`fixed rate bond instrument <module-daml-finance-instrument-bond-fixedrate-instrument-67993>`
+:ref:`fixed rate bond instrument <module-daml-finance-instrument-bond-v3-fixedrate-instrument-89221>`
 is implemented in Daml Finance. The goal is for you to learn how to implement and lifecycle your own
 instrument template, should you need an instrument type that is not already implemented in the
 library.
@@ -21,7 +21,7 @@ library.
 To follow the code snippets used in this tutorial in Daml Studio, you can clone the
 `Daml Finance repository <https://github.com/digital-asset/daml-finance>`_ and take a look at how
 the
-:ref:`Bond Instrument template <module-daml-finance-instrument-bond-fixedrate-instrument-67993>`
+:ref:`Bond Instrument template <module-daml-finance-instrument-bond-v3-fixedrate-instrument-89221>`
 is implemented. In order to see how lifecycling is performed, you can run the script in the
 `Instrument/Bond/Test/FixedRate.daml <https://github.com/digital-asset/daml-finance/blob/main/src/test/daml/Daml/Finance/Instrument/Bond/Test/FixedRate.daml>`_
 file.
@@ -49,13 +49,13 @@ Note that the Contingent Claims tree is not a part of the template above, instea
 dynamically upon request.
 
 In order do that, we implement the
-:ref:`Claims interface <module-daml-finance-interface-claims-claim-82866>`.
+:ref:`Claims interface <module-daml-finance-interface-claims-v4-claim-38573>`.
 This interface provides access to a generic mechanism to process coupon payments and redemptions.
 It will work in a similar way for the majority of instrument types, regardless of their specific
 economic terms.
 
 Here is a high level implementation of the
-:ref:`Claims interface <module-daml-finance-interface-claims-claim-82866>`:
+:ref:`Claims interface <module-daml-finance-interface-claims-v4-claim-38573>`:
 
 .. literalinclude:: ../../../src/main/daml/Daml/Finance/Instrument/Bond/V3/FixedRate/Instrument.daml
   :language: daml
@@ -84,13 +84,13 @@ The redemption claim depends on the currency and the maturity date of the bond.
   :end-before: -- FIXED_RATE_BOND_REDEMPTION_CLAIM_END
 
 Keywords like
-:ref:`when <function-contingentclaims-core-claim-when-17123>`,
-:ref:`scale <function-contingentclaims-core-claim-scale-79608>`,
-:ref:`one <function-contingentclaims-core-claim-one-13168>` and
-:ref:`give <function-contingentclaims-core-claim-give-6964>` should be familiar from the
+:ref:`when <function-contingentclaims-core-v3-claim-when-40851>`,
+:ref:`scale <function-contingentclaims-core-v3-claim-scale-39304>`,
+:ref:`one <function-contingentclaims-core-v3-claim-one-90688>` and
+:ref:`give <function-contingentclaims-core-v3-claim-give-33092>` should be familiar from the
 :doc:`Payoff Modeling tutorial <../../payoff-modeling/intro>`.
-:ref:`TimeGte <constr-contingentclaims-core-internal-claim-timegte-91610>` is just a synonym for
-:ref:`at <function-contingentclaims-core-claim-at-6466>`.
+:ref:`TimeGte <constr-contingentclaims-core-v3-internal-claim-timegte-43192>` is just a synonym for
+:ref:`at <function-contingentclaims-core-v3-claim-at-41106>`.
 
 The ``ownerReceives`` flag is used to indicate whether the owner of a holding on the bond is meant
 to receive the redemption payment. When this is set to ``false``, the holding custodian will be
@@ -120,11 +120,11 @@ The ``lastEventTimestamp`` field in our template is used to keep track of the la
 payment.
 
 Evolution of the instrument over time (and calculation of the corresponding lifecycle effects) can
-be performed using the :ref:`Lifecycle.Rule <module-daml-finance-claims-lifecycle-rule-53980>`
+be performed using the :ref:`Lifecycle.Rule <module-daml-finance-claims-v3-lifecycle-rule-196>`
 template provided in the
 :doc:`Daml.Finance.Claims.V3 <../../../packages/implementations/daml-finance-claims>` package. This
 rule is very generic and can be used for all instruments that implement the
-:ref:`Claims interface <module-daml-finance-interface-claims-claim-82866>`.
+:ref:`Claims interface <module-daml-finance-interface-claims-v4-claim-38573>`.
 
 Let us break its implementation apart to describe what happens in more detail:
 
@@ -146,7 +146,7 @@ Let us break its implementation apart to describe what happens in more detail:
 
 * Finally, we lifecycle the current instrument state to calculate pending
   `effects <#lifecycling-effect>`__. If there are such effects (for example when a coupon payment is
-  due), we create a :ref:`Lifecycle Effect <module-daml-finance-lifecycle-effect-1975>` for it,
+  due), we create a :ref:`Lifecycle Effect <module-daml-finance-lifecycle-v4-effect-31424>` for it,
   which can then be claimed and settled.
 
   .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Lifecycle/Rule.daml
@@ -160,9 +160,9 @@ The ``Dynamic.Instrument`` Interface
 In the ``tryCreateNewInstrument`` part above, we create a new version of the instrument containing
 the updated ``lastEventTimestamp`` (and also including all previous events up until now). This is
 done by exercising the
-:ref:`CreateNewVersion <type-daml-finance-interface-claims-dynamic-instrument-createnewversion-36931>`
+:ref:`CreateNewVersion <type-daml-finance-interface-claims-v4-dynamic-instrument-createnewversion-58950>`
 choice of the
-:ref:`Dynamic.Instrument interface <module-daml-finance-interface-claims-claim-82866>`:
+:ref:`Dynamic.Instrument interface <module-daml-finance-interface-claims-v4-claim-38573>`:
 
   .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Lifecycle/Rule.daml
     :language: daml
@@ -192,7 +192,7 @@ In the instrument definition, we need an identifier for the reference rate:
   :end-before: -- FLOATING_RATE_BOND_TEMPLATE_UNTIL_REFRATE_END
 
 When we create the claims for the coupon payments, we can then use
-:ref:`ObserveAt <constr-contingentclaims-core-observation-observeat-8418>` to refer to the value of
+:ref:`ObserveAt <constr-contingentclaims-core-v3-observation-observeat-93788>` to refer to the value of
 the reference rate:
 
 .. literalinclude:: ../../../src/main/daml/Daml/Finance/Claims/V3/Util/Builders.daml

--- a/docs/3.1/docs/daml-finance/tutorials/advanced-topics/instrument-modeling/date-utilities.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/advanced-topics/instrument-modeling/date-utilities.rst
@@ -20,10 +20,10 @@ your own custom use cases. For example, you can use these functions to:
 Calendar
 ========
 
-The :ref:`Calendar <module-daml-finance-util-date-calendar-17588>` module contains various utility
+The :ref:`Calendar <module-daml-finance-util-v4-date-calendar-71711>` module contains various utility
 functions related to business days and date adjustments.
 
-To distinguish business days and non-business days, set a holiday calendar. The :ref:`HolidayCalendarData <type-daml-finance-interface-types-date-calendar-holidaycalendardata-60004>`
+To distinguish business days and non-business days, set a holiday calendar. The :ref:`HolidayCalendarData <type-daml-finance-interface-types-date-v3-calendar-holidaycalendardata-87370>`
 type defines the set of non-business days by specifying the days of the week that belong to the
 weekend, as well as the dates of designated holidays. The following example sets Saturday and Sunday
 as weekend days and specifies some additional holidays:
@@ -76,14 +76,14 @@ You can adjust a date according to a business day convention:
   :end-before: -- TEST_ADJUST_DATE_END
 
 For the full list of available conventions, see the
-:ref:`BusinessDayConventionEnum <type-daml-finance-interface-types-date-calendar-businessdayconventionenum-88986>`
+:ref:`BusinessDayConventionEnum <type-daml-finance-interface-types-date-v3-calendar-businessdayconventionenum-14112>`
 reference. Use them to specify how non-business days are adjusted, including when the next or
 previous business day is around the end of the month.
 
 RollConvention
 ==============
 
-The :ref:`RollConvention <module-daml-finance-util-date-rollconvention-88672>` module provides
+The :ref:`RollConvention <module-daml-finance-util-v4-date-rollconvention-61455>` module provides
 utility functions to add a period to a given date.
 
 For example, you can add a day, week, month, or year to a date:
@@ -110,7 +110,7 @@ To *subtract* a period of time, use a negative offset:
 
 You might need to find the start date of the next period according to a specific market
 convention, as described in the
-:ref:`RollConventionEnum <type-daml-finance-interface-types-date-rollconvention-rollconventionenum-73360>`
+:ref:`RollConventionEnum <type-daml-finance-interface-types-date-v3-rollconvention-rollconventionenum-89490>`
 reference.
 The *Roll convention* specifies when the date is rolled.
 
@@ -149,14 +149,14 @@ The following example shows you how to roll to the *previous* period:
   :start-after: -- TEST_PREVIOUS_DOM_FROM_EOFEB_BEGIN
   :end-before: -- TEST_PREVIOUS_DOM_FROM_EOFEB_END
 
-The :ref:`RollConvention <module-daml-finance-util-date-rollconvention-88672>` functions
+The :ref:`RollConvention <module-daml-finance-util-v4-date-rollconvention-61455>` functions
 are often used in the context of rolling out a schedule, as
 explained in the next section.
 
 Schedule
 ========
 
-The :ref:`Schedule <module-daml-finance-util-date-schedule-32303>` module contains functions for
+The :ref:`Schedule <module-daml-finance-util-v4-date-schedule-63724>` module contains functions for
 creating a series of time periods.
 A schedule can be used to represent different aspects of a financial instrument, for example:
 
@@ -181,7 +181,7 @@ correspond to four periods of 3M each:
 Note the distinction between adjusted and unadjusted dates. The unadjusted date is the result of
 adding a specified time period to the start date of the previous schedule period. This date might
 fall on a non-business day. Apply a
-:ref:`BusinessDayAdjustment <type-daml-finance-interface-types-date-calendar-businessdayadjustment-93933>`,
+:ref:`BusinessDayAdjustment <type-daml-finance-interface-types-date-v3-calendar-businessdayadjustment-71551>`,
 to get an adjusted date that falls on a business day.
 
 Now you can roll out the schedule to get the specific start and end date for each period, and
@@ -214,7 +214,7 @@ schedule:
   :end-before: -- CREATE_EXPECTED_SCHEDULE_RESULT_WITH_STUB_END
 
 To configure different stub types, use the
-:ref:`StubPeriodTypeEnum <type-daml-finance-interface-types-date-schedule-stubperiodtypeenum-69372>`
+:ref:`StubPeriodTypeEnum <type-daml-finance-interface-types-date-v3-schedule-stubperiodtypeenum-99734>`
 data type. You can configure whether the stub period should be at the beginning or end of the
 schedule, as well as whether the stub period should be longer or shorter than a regular period.
 
@@ -231,7 +231,7 @@ DayCount
 
 Many instruments that pay interest (often expressed as an annualized rate) require an exact
 definition of how many days of interest belong to each payment period. The
-:ref:`DayCount <module-daml-finance-util-date-daycount-38239>` module provides functions  to support
+:ref:`DayCount <module-daml-finance-util-v4-date-daycount-38488>` module provides functions  to support
 such requirements.
 In particular, you can calculate a *day count fraction* (*dcf*) between two dates. This indicates
 the fraction of a full year between the dates.
@@ -241,7 +241,7 @@ like the one described in the previous section.
 
 This bond does not have the same number of days in each period, which normally results in different
 coupon amounts for each period. Various market conventions address this and are provided in the
-:ref:`DayCountConventionEnum <type-daml-finance-interface-types-date-daycount-daycountconventionenum-67281>`.
+:ref:`DayCountConventionEnum <type-daml-finance-interface-types-date-v3-daycount-daycountconventionenum-31>`.
 
 Consider the schedule with a short initial stub in the previous section. The following example uses
 the ``Act360`` day count convention:
@@ -268,14 +268,14 @@ correspond to 3M instead of 2M. Note that they differ slightly: they do not cont
 exact same number of days.
 
 In addition to ``Act360``, the
-:ref:`DayCountConventionEnum <type-daml-finance-interface-types-date-daycount-daycountconventionenum-67281>`
+:ref:`DayCountConventionEnum <type-daml-finance-interface-types-date-v3-daycount-daycountconventionenum-31>`
 supports several other day count conventions. You can compute some of them with
-:ref:`calcDcf <function-daml-finance-util-date-daycount-calcdcf-20432>`, using only a start and an
+:ref:`calcDcf <function-daml-finance-util-v4-date-daycount-calcdcf-53229>`, using only a start and an
 end date as an input as shown above.
 Others, such as ``ActActISDA``, are a bit more complicated because they require additional
 information.
 You can calculate them using the
-:ref:`calcPeriodDcf <function-daml-finance-util-date-daycount-calcperioddcf-63067>` function
+:ref:`calcPeriodDcf <function-daml-finance-util-v4-date-daycount-calcperioddcf-52338>` function
 instead. This function takes a schedule period (containing stub information) as input, as well as
 the schedule end date and the payment frequency:
 

--- a/docs/3.1/docs/daml-finance/tutorials/advanced-topics/lifecycling/intermediated-lifecycling.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/advanced-topics/lifecycling/intermediated-lifecycling.rst
@@ -69,7 +69,7 @@ has been reached:
 Lifecycle the Bond Instrument
 *****************************
 
-Using the :ref:`Lifecycle <module-daml-finance-interface-lifecycle-rule-lifecycle-50431>` interface,
+Using the :ref:`Lifecycle <module-daml-finance-interface-lifecycle-v4-rule-lifecycle-8270>` interface,
 the CSD creates a lifecycle rule contract:
 
 .. literalinclude:: ../../../src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -85,12 +85,12 @@ exercising the ``Evolve`` choice on the coupon date:
   :start-after: -- LIFECYCLE_BOND_BEGIN
   :end-before: -- LIFECYCLE_BOND_END
 
-This internally uses the :ref:`Event <module-daml-finance-interface-lifecycle-event-43586>`
+This internally uses the :ref:`Event <module-daml-finance-interface-lifecycle-v4-event-91777>`
 interface. In our case, the event is a clock update event, since the coupon payment is triggered by
 the passage of time.
 
 The return type of ``effectCid`` is an
-:ref:`Effect <module-daml-finance-interface-lifecycle-effect-16050>` interface.
+:ref:`Effect <module-daml-finance-interface-lifecycle-v4-effect-48507>` interface.
 It will contain the effect(s) of the lifecycling, in this case a coupon payment. If
 there is nothing to lifecycle, for example because there is no coupon to be paid today,
 this would be empty.
@@ -119,7 +119,7 @@ factory:
   :end-before: -- LIFECYCLE_BOND_SETTLEMENT_FACTORY_END
 
 Settlement instructions are created
-by using the :ref:`Claim <module-daml-finance-interface-lifecycle-rule-claim-6739>` interface and
+by using the :ref:`Claim <module-daml-finance-interface-lifecycle-v4-rule-claim-89954>` interface and
 exercising the ``ClaimEffect`` choice:
 
 .. literalinclude:: ../../../src/test/daml/Daml/Finance/Instrument/Generic/Test/Intermediated/BondCoupon.daml
@@ -175,10 +175,10 @@ What if one party wants to cancel the settlement?
 =================================================
 
 The parties who sign the
-:ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` contract (the instructor
+:ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` contract (the instructor
 and consenters) can exercise the ``Cancel`` choice of the
-:ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` to cancel all associated
-:ref:`Instructions <module-daml-finance-interface-settlement-instruction-10970>`
+:ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` to cancel all associated
+:ref:`Instructions <module-daml-finance-interface-settlement-v4-instruction-71097>`
 atomically.
 
 Settlement can also be obstructed if the responsible parties do not fully allocate

--- a/docs/3.1/docs/daml-finance/tutorials/getting-started/holdings.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/getting-started/holdings.rst
@@ -136,7 +136,7 @@ You might be wondering why we use account factories and holding factories instea
 :ref:`Account <module-daml-finance-account-account-19369>` or
 :ref:`Holding <module-daml-finance-holding-transferablefungible-77726>` directly.
 
-This is done to avoid having to reference the ``Daml.Finance.Holding`` package directly in the
+This is done to avoid having to reference the ``Daml.Finance.Holding.V4`` package directly in the
 user workflows (and hence simplify upgrading procedures).
 
 This pattern is described in detail in the :ref:`Daml Finance Patterns <factory-pattern>` page and

--- a/docs/3.1/docs/daml-finance/tutorials/getting-started/holdings.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/getting-started/holdings.rst
@@ -38,7 +38,7 @@ because our workflows, such as ``CreateAccount``, do not have any knowledge of c
 implementations.
 
 Similarly, we instantiate a
-:ref:`holding factory <module-daml-finance-holding-factory-11188>`, which is used within an
+:ref:`holding factory <module-daml-finance-holding-v4-factory-50391>`, which is used within an
 account to create (``Credit``) holdings for any instrument.
 
 .. literalinclude:: ../../quickstart-finance/daml/Scripts/Holding.daml
@@ -47,7 +47,7 @@ account to create (``Credit``) holdings for any instrument.
   :end-before: -- CREATE_HOLDING_FACTORY_END
 
 Finally, we create a factory template which is used to instantiate :ref:`token instruments
-<module-daml-finance-instrument-token-instrument-10682>`.
+<module-daml-finance-instrument-token-v4-instrument-53415>`.
 
 .. literalinclude:: ../../quickstart-finance/daml/Scripts/Holding.daml
   :language: daml
@@ -77,7 +77,7 @@ Create the Cash Instrument
 In order to credit Alice’s account with some cash, we first create a cash instrument. An instrument
 is a representation of what it is that we are holding against the Bank. It can be as simple as just
 a textual label (like the
-:ref:`Token Instrument <module-daml-finance-interface-instrument-token-instrument-24425>`
+:ref:`Token Instrument <module-daml-finance-interface-instrument-token-v4-instrument-40238>`
 used in this case) or it can include complex on-ledger lifecycling logic.
 
 .. literalinclude:: ../../quickstart-finance/daml/Scripts/Holding.daml
@@ -93,7 +93,7 @@ Deposit Cash in Alice’s Account
 
 We can now deposit cash in Alice’s account, using the ``CreditAccount`` workflow.
 Alice creates a request to deposit ``USD 1000`` at the Bank, the Bank then accepts the request and
-a corresponding :ref:`Holding <module-daml-finance-interface-holding-holding-64126>` is created.
+a corresponding :ref:`Holding <module-daml-finance-interface-holding-v4-holding-20535>` is created.
 
 .. literalinclude:: ../../quickstart-finance/daml/Scripts/Holding.daml
   :language: daml
@@ -133,8 +133,8 @@ Why do we need factories?
 =========================
 
 You might be wondering why we use account factories and holding factories instead of creating an
-:ref:`Account <module-daml-finance-account-account-19369>` or
-:ref:`Holding <module-daml-finance-holding-transferablefungible-77726>` directly.
+:ref:`Account <module-daml-finance-account-v4-account-5834>` or
+:ref:`Holding <module-daml-finance-holding-v4-transferablefungible-66907>` directly.
 
 This is done to avoid having to reference the ``Daml.Finance.Holding.V4`` package directly in the
 user workflows (and hence simplify upgrading procedures).

--- a/docs/3.1/docs/daml-finance/tutorials/getting-started/intro.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/getting-started/intro.rst
@@ -80,6 +80,6 @@ logic in the ``Workflows`` will not need to be modified nor re-compiled to work 
 upgraded (ie., newer versions of) *implementation* packages.
 
 On the other hand, modules in the ``Scripts`` folder depend on both the *interface* packages and
-the *implementation* packages (in this case, ``Daml.Finance.Account``, ``Daml.Finance.Holding``,
-and ``Daml.Finance.Instrument.Token``). This is not problematic as scripts are meant to be run only
+the *implementation* packages (in this case, ``Daml.Finance.Account.V4``, ``Daml.Finance.Holding.V4``,
+and ``Daml.Finance.Instrument.Token.V4``). This is not problematic as scripts are meant to be run only
 once when the application is initialized.

--- a/docs/3.1/docs/daml-finance/tutorials/getting-started/lifecycling.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/getting-started/lifecycling.rst
@@ -71,10 +71,10 @@ Next, we create two lifecycle rules:
   :start-after: -- LIFECYCLE_RULES_BEGIN
   :end-before: -- LIFECYCLE_RULES_END
 
-* The :ref:`Distribution Rule <module-daml-finance-lifecycle-rule-distribution-35531>` defines the
+* The :ref:`Distribution Rule <module-daml-finance-lifecycle-v4-rule-distribution-2662>` defines the
   business logic to calculate the resulting lifecycle effect from a given distribution event. It is
   signed by the `Bank` as a provider.
-* The :ref:`Claim Rule <module-daml-finance-lifecycle-rule-claim-99318>` allows a holder of the
+* The :ref:`Claim Rule <module-daml-finance-lifecycle-v4-rule-claim-11721>` allows a holder of the
   target instrument to claim the effect resulting from the distribution event. By presenting their
   holding they can instruct the settlement of the holding transfers described in the effect.
 

--- a/docs/3.1/docs/daml-finance/tutorials/getting-started/settlement.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/getting-started/settlement.rst
@@ -10,7 +10,7 @@ purpose is to demonstrate how multiple holding transfers can be executed atomica
 We are going to:
 
 #. create a new ``TOKEN``
-   :ref:`instrument <module-daml-finance-interface-instrument-token-instrument-24425>`
+   :ref:`instrument <module-daml-finance-interface-instrument-token-v4-instrument-40238>`
 #. credit a ``TOKEN`` holding to Alice’s account
 #. setup a delivery-vs-payment (DvP) transaction to give Alice's ``TOKEN`` holding to Bob in
    exchange for a ``USD`` holding
@@ -24,45 +24,45 @@ Overview of the Process
 
 We first give a quick outline of the settlement process:
 
-+--------------------+-----------------------------------------------------------------------------+
-| 1. Define steps to | Two (or more) parties need to first agree on a set of                       |
-|    be settled      | :ref:`steps <type-daml-finance-interface-settlement-types-step-78661>`      |
-|                    | to be settled.                                                              |
-|                    |                                                                             |
-+--------------------+-----------------------------------------------------------------------------+
-| 2. Generate        | :ref:`Instructions                                                          |
-|    settlement      | <module-daml-finance-interface-settlement-instruction-10970>`               |
-|    instructions    | are generated for each step.                                                |
-|                    |                                                                             |
-|                    | An instruction is a contract where the sender can specify its               |
-|                    | :ref:`Allocation                                                            |
-|                    | <type-daml-finance-interface-settlement-types-allocation-46483>`            |
-|                    | preference for the instruction (e.g., the matching holding they wish to     |
-|                    | send). The receiver can specify its :ref:`Approval                          |
-|                    | <type-daml-finance-interface-settlement-types-approval-84286>`              |
-|                    | preference for the instruction (e.g., the account they wish to receive      |
-|                    | the holding to).                                                            |
-|                    |                                                                             |
-|                    | The creation of Instructions is done by first using a :ref:`Route Provider  |
-|                    | <type-daml-finance-interface-settlement-routeprovider-routeprovider-53805>` |
-|                    | and then applying a :ref:`Settlement Factory                                |
-|                    | <module-daml-finance-interface-settlement-factory-75196>`.                  |
-|                    |                                                                             |
-+--------------------+-----------------------------------------------------------------------------+
-| 3. Allocate and    | For every instruction, the sender and the receiver specify their allocation |
-|    approve         | and approval preferences, respectively.                                     |
-|    instructions    |                                                                             |
-|                    |                                                                             |
-+--------------------+-----------------------------------------------------------------------------+
-| 4. Settle the      | A :ref:`Batch <module-daml-finance-interface-settlement-batch-39188>`       |
-|    batch           | contract is used to settle all instructions atomically according to the     |
-|                    | specified preferences (e.g. by transferring all allocated holdings to the   |
-|                    | corresponding receiving accounts).                                          |
-|                    |                                                                             |
-|                    | This batch contract is created in step 2, together with the settlement      |
-|                    | instructions.                                                               |
-|                    |                                                                             |
-+--------------------+-----------------------------------------------------------------------------+
++------------------+-------------------------------------------------------------------------------+
+| 1. Define steps  | Two (or more) parties need to first agree on a set of                         |
+|    to be settled | :ref:`steps <type-daml-finance-interface-settlement-v4-types-step-16302>`     |
+|                  | to be settled.                                                                |
+|                  |                                                                               |
++------------------+-------------------------------------------------------------------------------+
+| 2. Generate      | :ref:`Instructions                                                            |
+|    settlement    | <module-daml-finance-interface-settlement-v4-instruction-71097>`              |
+|    instructions  | are generated for each step.                                                  |
+|                  |                                                                               |
+|                  | An instruction is a contract where the sender can specify its                 |
+|                  | :ref:`Allocation                                                              |
+|                  | <type-daml-finance-interface-settlement-v4-types-allocation-41200>`           |
+|                  | preference for the instruction (e.g., the matching holding they wish to       |
+|                  | send). The receiver can specify its :ref:`Approval                            |
+|                  | <type-daml-finance-interface-settlement-v4-types-approval-77821>`             |
+|                  | preference for the instruction (e.g., the account they wish to receive        |
+|                  | the holding to).                                                              |
+|                  |                                                                               |
+|                  | The creation of Instructions is done by first using a :ref:`Route Provider    |
+|                  | <type-daml-finance-interface-settlement-v4-routeprovider-routeprovider-29628>`|
+|                  | and then applying a :ref:`Settlement Factory                                  |
+|                  | <module-daml-finance-interface-settlement-v4-factory-85379>`.                 |
+|                  |                                                                               |
++------------------+-------------------------------------------------------------------------------+
+| 3. Allocate and  | For every instruction, the sender and the receiver specify their allocation   |
+|    approve       | and approval preferences, respectively.                                       |
+|    instructions  |                                                                               |
+|                  |                                                                               |
++------------------+-------------------------------------------------------------------------------+
+| 4. Settle the    | A :ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>`      |
+|    batch         | contract is used to settle all instructions atomically according to the       |
+|                  | specified preferences (e.g. by transferring all allocated holdings to the     |
+|                  | corresponding receiving accounts).                                            |
+|                  |                                                                               |
+|                  | This batch contract is created in step 2, together with the settlement        |
+|                  | instructions.                                                                 |
+|                  |                                                                               |
++------------------+-------------------------------------------------------------------------------+
 
 Run the Script
 **************
@@ -72,13 +72,13 @@ The code for this tutorial can be executed via the ``runSettlement`` function in
 
 The first part executes the script from the previous :doc:`Transfer <transfer>` tutorial to arrive
 at the initial state for this scenario. We then create an additional ``TOKEN``
-:ref:`instrument <module-daml-finance-interface-instrument-token-instrument-24425>`
+:ref:`instrument <module-daml-finance-interface-instrument-token-v4-instrument-40238>`
 and credit Alice's account with it.
 
 The interesting part begins once Bob proposes the DvP trade to Alice. Before creating the DvP
 proposal, we need to instantiate two contracts:
 
-1. :ref:`Route Provider <type-daml-finance-interface-settlement-routeprovider-routeprovider-53805>`
+1. :ref:`Route Provider <type-daml-finance-interface-settlement-v4-routeprovider-routeprovider-29628>`
 
    .. literalinclude:: ../../quickstart-finance/daml/Scripts/Settlement.daml
      :language: daml
@@ -86,12 +86,12 @@ proposal, we need to instantiate two contracts:
      :end-before: -- ROUTE_PROVIDER_END
 
    This is used to discover a settlement route, i.e.,
-   :ref:`routed steps <type-daml-finance-interface-settlement-types-routedstep-10086>`, for each
-   settlement :ref:`step <type-daml-finance-interface-settlement-types-step-78661>`. In this
+   :ref:`routed steps <type-daml-finance-interface-settlement-v4-types-routedstep-26293>`, for each
+   settlement :ref:`step <type-daml-finance-interface-settlement-v4-types-step-16302>`. In this
    example, the route provider simply converts each step to a routed step using a single custodian
    (the bank).
 
-2. :ref:`Settlement Factory <module-daml-finance-interface-settlement-factory-75196>`
+2. :ref:`Settlement Factory <module-daml-finance-interface-settlement-v4-factory-85379>`
 
    .. literalinclude:: ../../quickstart-finance/daml/Scripts/Settlement.daml
      :language: daml
@@ -99,7 +99,7 @@ proposal, we need to instantiate two contracts:
      :end-before: -- SETTLEMENT_FACTORY_END
 
    This is used to generate the settlement batch and instructions from the
-   :ref:`routed steps <type-daml-finance-interface-settlement-types-routedstep-10086>`.
+   :ref:`routed steps <type-daml-finance-interface-settlement-v4-types-routedstep-26293>`.
 
 Bob creates a ``Dvp.Proposal`` template to propose the exchange of the ``TOKEN`` against ``USD``.
 
@@ -163,11 +163,11 @@ following happens:
   bank)
 - ``USD 100`` are credited to Alice's account at her bank
 
-A single settlement :ref:`Step <type-daml-finance-interface-settlement-types-step-78661>` requires
-three :ref:`RoutedStep <type-daml-finance-interface-settlement-types-routedstep-10086>`\s to settle.
+A single settlement :ref:`Step <type-daml-finance-interface-settlement-v4-types-step-16302>` requires
+three :ref:`RoutedStep <type-daml-finance-interface-settlement-v4-types-routedstep-26293>`\s to settle.
 
 The same dynamics can be reproduced in Daml with a :ref:`Route Provider
-<type-daml-finance-interface-settlement-routeprovider-routeprovider-53805>` implementation, allowing
+<type-daml-finance-interface-settlement-v4-routeprovider-routeprovider-29628>` implementation, allowing
 for on-ledger intermediated settlement. For example, see the
 :doc:`Intermediated Lifecycling <../advanced-topics/lifecycling/intermediated-lifecycling>`
 tutorial.
@@ -176,21 +176,21 @@ Why do we need a settlement factory?
 ====================================
 
 A settlement factory contract is used to generate settlement
-:ref:`Instructions <module-daml-finance-interface-settlement-instruction-10970>` from
-:ref:`RoutedStep <type-daml-finance-interface-settlement-types-routedstep-10086>`\s.
-It also generates a :ref:`Batch <module-daml-finance-interface-settlement-batch-39188>`
+:ref:`Instructions <module-daml-finance-interface-settlement-v4-instruction-71097>` from
+:ref:`RoutedStep <type-daml-finance-interface-settlement-v4-types-routedstep-26293>`\s.
+It also generates a :ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>`
 contract, which is used to settle instructions atomically.
 
 The reason why the factory is needed has already been introduced in the previous tutorial: it
 provides an interface abstraction, so that your workflow does not need to depend on concrete
-implementations of :ref:`Batch <module-daml-finance-interface-settlement-batch-39188>`
-or :ref:`Instructions <module-daml-finance-interface-settlement-instruction-10970>`.
+implementations of :ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>`
+or :ref:`Instructions <module-daml-finance-interface-settlement-v4-instruction-71097>`.
 
 Can we use a different settler?
 ===============================
 
 In our example, Bob triggers the final settlement of the transaction (by exercising the ``Settle``
-choice on the :ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` contract).
+choice on the :ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` contract).
 
 In principle, a different settler could be chosen. The choice of a settler is usually quite
 delicate, as this party acquires visibility on the entire transaction and hence needs to be trusted.
@@ -199,10 +199,10 @@ What if one party wants to cancel the settlement?
 =================================================
 
 The parties who sign the
-:ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` contract (the instructor and
+:ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` contract (the instructor and
 consenters) can exercise the ``Cancel`` choice of the
-:ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` to cancel all associated
-:ref:`Instructions <module-daml-finance-interface-settlement-instruction-10970>`
+:ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` to cancel all associated
+:ref:`Instructions <module-daml-finance-interface-settlement-v4-instruction-71097>`
 atomically.
 
 Summary

--- a/docs/3.1/docs/daml-finance/tutorials/getting-started/transfer.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/getting-started/transfer.rst
@@ -45,16 +45,16 @@ If you look at the implementation of the ``Transfer`` workflow, you will notice 
   :end-before: -- DO_TRANSFER_END
 
 The first line converts the holding contract id (of type
-:ref:`ContractId Holding.I <module-daml-finance-interface-holding-holding-64126>`) to the
-:ref:`Transferable.I <module-daml-finance-interface-holding-transferable-88121>`
+:ref:`ContractId Holding.I <module-daml-finance-interface-holding-v4-holding-20535>`) to the
+:ref:`Transferable.I <module-daml-finance-interface-holding-v4-transferable-93054>`
 interface using ``coerceInterfaceContractId``.
 
 Then, the ``Transfer`` choice, defined as part of the
-:ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`
+:ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`
 interface, is exercised.
 
 Finally, the new holding is converted back to a
-:ref:`Holding.I <module-daml-finance-interface-holding-holding-64126>`
+:ref:`Holding.I <module-daml-finance-interface-holding-v4-holding-20535>`
 before it is returned. This is done using ``toInterfaceContractId``.
 
 In order to fully understand these instructions, we need to keep in mind the interface hierarchy
@@ -67,17 +67,17 @@ used by our holding implementation.
         "requires".
 
 We use ``coerceInterfaceContractId`` to convert the
-:ref:`Holding.I <module-daml-finance-interface-holding-holding-64126>`
-to a :ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`.
+:ref:`Holding.I <module-daml-finance-interface-holding-v4-holding-20535>`
+to a :ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`.
 The success of this operation is not guaranteed and will result in a run-time error if the holding
 implementation at hand does not implement
-:ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`.
+:ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`.
 
 We use ``toInterfaceContractId`` to convert back to a
-:ref:`Holding <module-daml-finance-interface-holding-holding-64126>`.
+:ref:`Holding <module-daml-finance-interface-holding-v4-holding-20535>`.
 This is because all
-:ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`\ s
-implement the :ref:`Holding.I <module-daml-finance-interface-holding-holding-64126>`
+:ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`\ s
+implement the :ref:`Holding.I <module-daml-finance-interface-holding-v4-holding-20535>`
 interface, so the validity of this operation is guaranteed at compile-time.
 
 Why is Alice an observer on Bob’s account?
@@ -106,18 +106,18 @@ right amount, because the transfer would otherwise fail. We want the transfer to
 if Alice allocates a holding for a larger amount e.g., ``USD 1500``.
 
 We can leverage the fact that the holding implements the
-:ref:`Fungible <module-daml-finance-interface-holding-fungible-63712>`
+:ref:`Fungible <module-daml-finance-interface-holding-v4-fungible-55495>`
 interface, which makes it possible to ``Split`` it into a holding of ``USD 1000`` and one of
 ``USD 500``. In the implementation of the ``CashTransferRequest_Accept`` choice:
 
 - cast the allocated holding to the :ref:`Fungible
-  <module-daml-finance-interface-holding-fungible-63712>` interface
+  <module-daml-finance-interface-holding-v4-fungible-55495>` interface
 - use the ``Split`` choice to split the larger holding into two holdings
 - execute the transfer, allocating the holding with the correct amount
 
 In the last step, you will need to cast the
-:ref:`Fungible <module-daml-finance-interface-holding-fungible-63712>` to a
-:ref:`Transferable <module-daml-finance-interface-holding-transferable-88121>`
+:ref:`Fungible <module-daml-finance-interface-holding-v4-fungible-55495>` to a
+:ref:`Transferable <module-daml-finance-interface-holding-v4-transferable-93054>`
 using ``toInterfaceContractId``.
 
 Temporary Account Disclosure
@@ -132,13 +132,13 @@ Modify the original code, such that:
 - When the Transfer is executed, Alice removes herself from the account observers
 
 In order to do that, you can leverage the fact that
-:ref:`Account <module-daml-finance-account-account-19369>`
+:ref:`Account <module-daml-finance-account-v4-account-5834>`
 implements the
-:ref:`Disclosure <module-daml-finance-interface-util-disclosure-87755>`
+:ref:`Disclosure <module-daml-finance-interface-util-v3-disclosure-50779>`
 interface. This interface exposes the ``AddObservers`` and ``RemoveObservers`` choices, which can be
 used to disclose / undisclose Bob's account contract to Alice. In order to exercise these choices,
 you can use the :ref:`Account.exerciseInterfaceByKey
-<function-daml-finance-interface-account-account-exerciseinterfacebykey-13671>` utility function.
+<function-daml-finance-interface-account-v4-account-exerciseinterfacebykey-87310>` utility function.
 
 Summary
 *******

--- a/docs/3.1/docs/daml-finance/tutorials/lifecycling/callable-bond.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/lifecycling/callable-bond.rst
@@ -32,9 +32,9 @@ Instrument and Holding
 ======================
 
 In order to demonstrate the
-:ref:`Election <module-daml-finance-interface-lifecycle-election-24570>` concept, we need a suitable
+:ref:`Election <module-daml-finance-interface-lifecycle-v4-election-15483>` concept, we need a suitable
 sample instrument.
-:ref:`Callable bonds <module-daml-finance-instrument-bond-callable-instrument-83330>` pay coupons as
+:ref:`Callable bonds <module-daml-finance-instrument-bond-v3-callable-instrument-35206>` pay coupons as
 long as the bond has not been called by the issuer.
 The :doc:`Bond Instrument packages <../../instruments/bond>` page describes this
 instrument in more detail. Here, we briefly show how to create the bond instrument using a factory:
@@ -67,7 +67,7 @@ We start by creating an Election factory, which can be used to create elections:
   :start-after: -- CREATE_ELECTION_FACTORY_BEGIN
   :end-before: -- CREATE_ELECTION_FACTORY_END
 
-An :ref:`Election <module-daml-finance-interface-lifecycle-election-24570>` contains three main
+An :ref:`Election <module-daml-finance-interface-lifecycle-v4-election-15483>` contains three main
 pieces of information:
 
 - the election tag (e.g. "CALLED")
@@ -101,7 +101,7 @@ In order to lifecycle the coupon payment above, we need a lifecycle rule that de
 all election events. The lifecycle rule from the previous tutorial can be reused for this, if we
 first convert it to an ``Election.Exercisable``, as described above.
 
-A :ref:`Claim Rule <module-daml-finance-lifecycle-rule-claim-99318>` allows the elector to claim the
+A :ref:`Claim Rule <module-daml-finance-lifecycle-v4-rule-claim-11721>` allows the elector to claim the
 effect resulting from the election event:
 
 .. literalinclude:: ../../finance-lifecycling/daml/Scripts/CallableBond.daml

--- a/docs/3.1/docs/daml-finance/tutorials/lifecycling/callable-bond.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/lifecycling/callable-bond.rst
@@ -67,7 +67,6 @@ We start by creating an Election factory, which can be used to create elections:
   :start-after: -- CREATE_ELECTION_FACTORY_BEGIN
   :end-before: -- CREATE_ELECTION_FACTORY_END
 
-
 An :ref:`Election <module-daml-finance-interface-lifecycle-election-24570>` contains three main
 pieces of information:
 

--- a/docs/3.1/docs/daml-finance/tutorials/lifecycling/fixed-rate-bond.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/lifecycling/fixed-rate-bond.rst
@@ -43,7 +43,7 @@ Instrument and Holding
 ======================
 
 For the purpose of showcasing time-based lifecycling, we need a suitable sample instrument.
-:ref:`Fixed rate bonds <module-daml-finance-instrument-bond-fixedrate-instrument-67993>`
+:ref:`Fixed rate bonds <module-daml-finance-instrument-bond-v3-fixedrate-instrument-89221>`
 pay a constant coupon rate at the end of each coupon period. The
 :doc:`Bond Instrument packages <../../instruments/bond>` page describes this instrument
 in more detail. Here, we briefly show how to create the bond instrument using a factory:
@@ -87,9 +87,9 @@ first coupon:
   :end-before: -- CREATE_CLOCK_UPDATE_EVENT_END
 
 Note that it is the bank that actively creates a
-:ref:`DateClockUpdateEvent <module-daml-finance-data-time-dateclockupdate-48859>`.
+:ref:`DateClockUpdateEvent <module-daml-finance-data-v4-time-dateclockupdate-59678>`.
 This results in more control when to actually process the coupon payment. One could also use
-:ref:`LedgerTime <module-daml-finance-data-time-ledgertime-84639>`,
+:ref:`LedgerTime <module-daml-finance-data-v4-time-ledgertime-80144>`,
 but that could cause problems in some scenarios, for example:
 
 - The system is down when the coupon should be processed. Processing it the next day is difficult if
@@ -108,16 +108,16 @@ rule is exercised to process the time event:
   :start-after: -- LIFECYCLE_BOND_BEGIN
   :end-before: -- LIFECYCLE_BOND_END
 
-Both the :ref:`LedgerTime <module-daml-finance-data-time-ledgertime-84639>` and the
-:ref:`DateClock <module-daml-finance-data-time-dateclock-65212>` implement the
-:ref:`TimeObservable <module-daml-finance-interface-lifecycle-observable-timeobservable-45971>`
+Both the :ref:`LedgerTime <module-daml-finance-data-v4-time-ledgertime-80144>` and the
+:ref:`DateClock <module-daml-finance-data-v4-time-dateclock-1389>` implement the
+:ref:`TimeObservable <module-daml-finance-interface-lifecycle-v4-observable-timeobservable-64296>`
 interface, which is used by ``Evolve`` to specify the current time for the lifecycling.
 
 The result of this is an effect describing the per-unit asset movements to be executed for bond
 holders. Each holder can now present their holding to *claim* the effect and instruct settlement of
 the associated entitlements.
 
-A :ref:`Claim Rule <module-daml-finance-lifecycle-rule-claim-99318>` allows a holder of the
+A :ref:`Claim Rule <module-daml-finance-lifecycle-v4-rule-claim-11721>` allows a holder of the
 target instrument to claim the effect resulting from the time event:
 
 .. literalinclude:: ../../finance-lifecycling/daml/Scripts/FixedRateBond.daml

--- a/docs/3.1/docs/daml-finance/tutorials/lifecycling/floating-rate-bond.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/lifecycling/floating-rate-bond.rst
@@ -30,9 +30,9 @@ Instrument and Holding
 ======================
 
 For the purpose of showcasing the
-:ref:`Observation <module-daml-finance-data-numeric-observation-78761>` concept,
+:ref:`Observation <module-daml-finance-data-v4-numeric-observation-19522>` concept,
 we need a suitable sample instrument.
-:ref:`Floating rate bonds <module-daml-finance-instrument-bond-floatingrate-instrument-98586>`
+:ref:`Floating rate bonds <module-daml-finance-instrument-bond-v3-floatingrate-instrument-82370>`
 pay a coupon which is determined by a reference rate, e.g. 3M Libor. The
 :doc:`Bond Instrument packages <../../instruments/bond>` page describes this instrument
 in more detail. Here, we briefly show how to create the bond instrument using a factory:
@@ -58,7 +58,7 @@ Now, we have both an instrument definition and a holding. Let us proceed to life
 Lifecycle Events and Rule
 =========================
 
-An :ref:`Observation <module-daml-finance-data-numeric-observation-78761>` of a reference rate
+An :ref:`Observation <module-daml-finance-data-v4-numeric-observation-19522>` of a reference rate
 contains two pieces of information: the interest rate level and the date to which it applies. The
 rate level can be positive or negative. In our example, we have a negative interest rate:
 
@@ -68,8 +68,8 @@ rate level can be positive or negative. In our example, we have a negative inter
   :end-before: -- CREATE_FLOATING_RATE_OBSERVATIONS_END
 
 In our case, the bank then creates the observation on the ledger.
-The :ref:`Observation <module-daml-finance-data-numeric-observation-78761>` implements the
-:ref:`NumericObservable <module-daml-finance-interface-lifecycle-observable-numericobservable-67288>`
+The :ref:`Observation <module-daml-finance-data-v4-numeric-observation-19522>` implements the
+:ref:`NumericObservable <module-daml-finance-interface-lifecycle-v4-observable-numericobservable-50817>`
 interface, which is used during lifecycling.
 
 In order to lifecycle a coupon payment, we need a lifecycle rule that defines how to process all

--- a/docs/3.1/docs/daml-finance/tutorials/settlement/internal.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/settlement/internal.rst
@@ -21,15 +21,15 @@ Understanding Internal Settlement with Examples
 
 To start, let us briefly revisit the settlement process which was explained in the
 :doc:`Settlement <../../concepts/settlement>` section.
-A :ref:`Batch <module-daml-finance-interface-settlement-batch-39188>` consists of one or
-more :ref:`Instructions <module-daml-finance-interface-settlement-instruction-10970>`.
+A :ref:`Batch <module-daml-finance-interface-settlement-v4-batch-88127>` consists of one or
+more :ref:`Instructions <module-daml-finance-interface-settlement-v4-instruction-71097>`.
 Each instruction signifies a
-:ref:`RoutedStep <type-daml-finance-interface-settlement-types-routedstep-10086>`, delineating the
+:ref:`RoutedStep <type-daml-finance-interface-settlement-v4-types-routedstep-26293>`, delineating the
 quantity of an instrument to be transferred from a sender to a receiver at a specific custodian. For
 an instruction to be prepared for settlement (or execution), the sender-side must furnish an
-:ref:`Allocation <type-daml-finance-interface-settlement-types-allocation-46483>`, and the
+:ref:`Allocation <type-daml-finance-interface-settlement-v4-types-allocation-41200>`, and the
 receiver-side must provide an
-:ref:`Approval <type-daml-finance-interface-settlement-types-approval-84286>`.
+:ref:`Approval <type-daml-finance-interface-settlement-v4-types-approval-77821>`.
 
 This tutorial will walk you through three example scripts for settling instructions at a single
 custodian: ``runWrappedTransferSettlement``, ``runCreditDebitSettlement``, and

--- a/docs/3.1/docs/daml-finance/tutorials/settlement/transfer.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/settlement/transfer.rst
@@ -25,7 +25,7 @@ transfers (credits) and outgoing transfers (debits) of holdings to an account.
 Configuring Account Controllers
 *******************************
 
-The :ref:`Controllers <type-daml-finance-interface-account-account-controllers-36430>` data type
+The :ref:`Controllers <type-daml-finance-interface-account-v4-account-controllers-59817>` data type
 specifies the parties that need to authorize incoming and outgoing transfers to an account.
 
 For this tutorial, we provide four example scripts illustrating various incoming and outgoing

--- a/docs/3.1/docs/daml-finance/tutorials/upgrade/account.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/upgrade/account.rst
@@ -5,24 +5,24 @@ Account Upgrade
 ###############
 
 This tutorial presents a scenario where a custodian offers its clients the option to *voluntarily*
-upgrade their "old" :ref:`Account <module-daml-finance-account-account-19369>` contracts to a
+upgrade their "old" :ref:`Account <module-daml-finance-account-v4-account-5834>` contracts to a
 "new" version. The focus is on demonstrating the process of such a voluntary upgrade.
 
 We are going to:
 
 #. Introduce ``MyAccount``, a custom account implementation for the custodian. It differs from
-   the standard Daml Finance :ref:`Account <module-daml-finance-account-account-19369>`
+   the standard Daml Finance :ref:`Account <module-daml-finance-account-v4-account-5834>`
    implementation in that it does not implement the
-   :ref:`Lockable <module-daml-finance-interface-util-lockable-80915>`
+   :ref:`Lockable <module-daml-finance-interface-util-v3-lockable-20339>`
    interface, making it a non-freezable account.
 #. Prevent the custodian from creating old
-   :ref:`Account <module-daml-finance-account-account-19369>` instances, by archiving its
+   :ref:`Account <module-daml-finance-account-v4-account-5834>` instances, by archiving its
    existing
-   :ref:`AccountFactory <module-daml-finance-account-account-19369>`.
+   :ref:`AccountFactory <module-daml-finance-account-v4-account-5834>`.
 #. Instantiate a new account factory, ``MyAccountFactory``, which can create ``MyAccount``
    instances.
 #. Provide a ``MyAccountUpgradeRule`` instance for clients, permitting them to upgrade their
-   existing :ref:`Account <module-daml-finance-account-account-19369>` instances to new
+   existing :ref:`Account <module-daml-finance-account-v4-account-5834>` instances to new
    ``MyAccount`` instances.
 #. Upgrade the accounts for the clients.
 

--- a/docs/3.1/docs/daml-finance/tutorials/upgrade/holding.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/upgrade/holding.rst
@@ -11,10 +11,10 @@ manner. Specifically, the upgrade occurs seamlessly during a client's transfer a
 We are going to:
 
 #. Introduce a new holding implementation, ``MyTransferable``, which extends the Daml Finance
-   :ref:`Transferable <module-daml-finance-holding-transferable-43388>` holding
+   :ref:`Transferable <module-daml-finance-holding-v4-transferable-38649>` holding
    implementation. This new implementation differs in that it creates a
    ``MyTransferableTransferEvent`` contract instance with each transfer.
-#. Replace the existing :ref:`HoldingFactory <module-daml-finance-holding-factory-11188>`
+#. Replace the existing :ref:`HoldingFactory <module-daml-finance-holding-v4-factory-50391>`
    instance of the custodian with a new, compatible ``MyHoldingFactory`` for the ``MyTransferable``
    holding implementation.
 #. Demonstrate that an upgrade happens upon a transfer of an old holding.

--- a/docs/3.1/docs/daml-finance/tutorials/upgrade/intro.rst
+++ b/docs/3.1/docs/daml-finance/tutorials/upgrade/intro.rst
@@ -28,9 +28,9 @@ We offer the following tutorials to guide you through the upgrade process:
 
 * :doc:`Holding Upgrade Tutorial <holding>`:
   Here, we walk you through a scenario where a custodian upgrades the
-  :ref:`Transferable <module-daml-finance-holding-transferable-43388>` holding
+  :ref:`Transferable <module-daml-finance-holding-v4-transferable-38649>` holding
   implementation to a custom, enhanced version, and its
-  :ref:`HoldingFactory <module-daml-finance-holding-factory-11188>` accordingly. As a result,
+  :ref:`HoldingFactory <module-daml-finance-holding-v4-factory-50391>` accordingly. As a result,
   existing holding instances (of the :ref:`Transferable <holding-standards>` holding standard) will
   be automatically upgraded to the new version during the next transfer. This serves as a practical
   example of a mandatory upgrade carried out in a lazy manner.

--- a/docs/3.1/versions.json
+++ b/docs/3.1/versions.json
@@ -1,6 +1,6 @@
 {
   "daml": "2.8.0-snapshot.20231118.12382.0.v86cb8054",
   "canton": "2.9.0-snapshot.20240402.11920.0.v2507c677",
-  "daml_finance": "1.5.0",
+  "daml_finance": "1.6.0",
   "canton_drivers": "0.1.9"
 }


### PR DESCRIPTION
Changes related to Daml Finance. This PR:
1. Bumps assembly version (to `1.6.0`) for SDK 2.10.0 and 3.1.
2. Adds the major version `Vx` to path, package, and module names.
3. Adds a script `upgrade_tags.sh` to upgrade references in the docs.
4. Updates changelogs (including list of released and deprecated packages).
5. Adds release notes.
6. Adds links to `AutoCallable` modules (in the package folder).
