### PR TITLE
Remove '--target=1.15' requirement.

### DIFF
--- a/docs/2.10.0/docs/daml/reference/interfaces.rst
+++ b/docs/2.10.0/docs/daml/reference/interfaces.rst
@@ -17,14 +17,8 @@ interface instead of the concrete template.
 Configuration
 *************
 
-In order to use this new feature, your Daml project needs to
-explicitly target Daml-LF version ``1.15`` or higher which is
-specified by adding the following line to the project's ``daml.yaml``
-file:
-
-.. code-block:: yaml
-
-  build-options: [--target=1.15]
+In order to use this feature, your Daml project needs to target
+Daml-LF version ``1.15`` or higher which is the current default.
 
 If using Canton, the protocol version of the sync domain should be `4` or
 higher, see :ref:`Canton protocol version <protocol_version>` for more

--- a/docs/2.10.0/docs/daml/reference/interfaces.rst
+++ b/docs/2.10.0/docs/daml/reference/interfaces.rst
@@ -17,8 +17,8 @@ interface instead of the concrete template.
 Configuration
 *************
 
-In order to use this feature, your Daml project needs to target
-Daml-LF version ``1.15`` or higher which is the current default.
+To use this feature your Daml project must target
+Daml-LF version ``1.15`` or higher, which is the current default.
 
 If using Canton, the protocol version of the sync domain should be `4` or
 higher, see :ref:`Canton protocol version <protocol_version>` for more

--- a/docs/2.7.9/docs/daml/reference/interfaces.rst
+++ b/docs/2.7.9/docs/daml/reference/interfaces.rst
@@ -17,14 +17,8 @@ interface instead of the concrete template.
 Configuration
 *************
 
-In order to use this new feature, your Daml project needs to
-explicitly target Daml-LF version ``1.15`` or higher which is
-specified by adding the following line to the project's ``daml.yaml``
-file:
-
-.. code-block:: yaml
-
-  build-options: [--target=1.15]
+In order to use this feature, your Daml project needs to target
+Daml-LF version ``1.15`` or higher which is the current default.
 
 If using Canton, the protocol version of the domain should be `4` or
 higher, see :ref:`Canton protocol version <protocol_version>` for more

--- a/docs/2.7.9/docs/daml/reference/interfaces.rst
+++ b/docs/2.7.9/docs/daml/reference/interfaces.rst
@@ -17,8 +17,8 @@ interface instead of the concrete template.
 Configuration
 *************
 
-In order to use this feature, your Daml project needs to target
-Daml-LF version ``1.15`` or higher which is the current default.
+To use this feature your Daml project must target
+Daml-LF version ``1.15`` or higher, which is the current default.
 
 If using Canton, the protocol version of the domain should be `4` or
 higher, see :ref:`Canton protocol version <protocol_version>` for more

--- a/docs/2.8.12/docs/daml/reference/interfaces.rst
+++ b/docs/2.8.12/docs/daml/reference/interfaces.rst
@@ -17,14 +17,8 @@ interface instead of the concrete template.
 Configuration
 *************
 
-In order to use this new feature, your Daml project needs to
-explicitly target Daml-LF version ``1.15`` or higher which is
-specified by adding the following line to the project's ``daml.yaml``
-file:
-
-.. code-block:: yaml
-
-  build-options: [--target=1.15]
+In order to use this feature, your Daml project needs to target
+Daml-LF version ``1.15`` or higher which is the current default.
 
 If using Canton, the protocol version of the domain should be `4` or
 higher, see :ref:`Canton protocol version <protocol_version>` for more

--- a/docs/2.8.12/docs/daml/reference/interfaces.rst
+++ b/docs/2.8.12/docs/daml/reference/interfaces.rst
@@ -17,8 +17,8 @@ interface instead of the concrete template.
 Configuration
 *************
 
-In order to use this feature, your Daml project needs to target
-Daml-LF version ``1.15`` or higher which is the current default.
+To use this feature your Daml project must target
+Daml-LF version ``1.15`` or higher, which is the current default.
 
 If using Canton, the protocol version of the domain should be `4` or
 higher, see :ref:`Canton protocol version <protocol_version>` for more

--- a/docs/2.9.6/docs/daml/reference/interfaces.rst
+++ b/docs/2.9.6/docs/daml/reference/interfaces.rst
@@ -17,14 +17,8 @@ interface instead of the concrete template.
 Configuration
 *************
 
-In order to use this new feature, your Daml project needs to
-explicitly target Daml-LF version ``1.15`` or higher which is
-specified by adding the following line to the project's ``daml.yaml``
-file:
-
-.. code-block:: yaml
-
-  build-options: [--target=1.15]
+In order to use this feature, your Daml project needs to target
+Daml-LF version ``1.15`` or higher which is the current default.
 
 If using Canton, the protocol version of the sync domain should be `4` or
 higher, see :ref:`Canton protocol version <protocol_version>` for more

--- a/docs/2.9.6/docs/daml/reference/interfaces.rst
+++ b/docs/2.9.6/docs/daml/reference/interfaces.rst
@@ -17,8 +17,8 @@ interface instead of the concrete template.
 Configuration
 *************
 
-In order to use this feature, your Daml project needs to target
-Daml-LF version ``1.15`` or higher which is the current default.
+To use this feature your Daml project must target
+Daml-LF version ``1.15`` or higher, which is the current default.
 
 If using Canton, the protocol version of the sync domain should be `4` or
 higher, see :ref:`Canton protocol version <protocol_version>` for more

--- a/docs/3.1/docs/daml/reference/interfaces.rst
+++ b/docs/3.1/docs/daml/reference/interfaces.rst
@@ -17,14 +17,8 @@ interface instead of the concrete template.
 Configuration
 *************
 
-In order to use this new feature, your Daml project needs to
-explicitly target Daml-LF version ``1.15`` or higher which is
-specified by adding the following line to the project's ``daml.yaml``
-file:
-
-.. code-block:: yaml
-
-  build-options: [--target=1.15]
+In order to use this feature, your Daml project needs to target
+Daml-LF version ``1.15`` or higher which is the current default.
 
 If using Canton, the protocol version of the sync domain should be `4` or
 higher, see Canton protocol version for more details.

--- a/docs/3.1/docs/daml/reference/interfaces.rst
+++ b/docs/3.1/docs/daml/reference/interfaces.rst
@@ -17,8 +17,8 @@ interface instead of the concrete template.
 Configuration
 *************
 
-In order to use this feature, your Daml project needs to target
-Daml-LF version ``1.15`` or higher which is the current default.
+To use this feature your Daml project must target
+Daml-LF version ``1.15`` or higher, which is the current default.
 
 If using Canton, the protocol version of the sync domain should be `4` or
 higher, see Canton protocol version for more details.


### PR DESCRIPTION
Update config requirement for interfaces since DAML LF 1.15 is already the default from version 2.6.0.