### PR TITLE
Document for UPD-12, UPD-30, UPD-33, and improve docs for deps upgrade checks

### DIFF
--- a/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
+++ b/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
@@ -2192,13 +2192,62 @@ Upgrades feature.
 Testing
 =======
 
-Upgrade Validity Checking
--------------------------
+Standalone Upgradeability Checks
+--------------------------------
 
-We recommend that as a further check for the validity of your upgraded
-package, you perform a dry-run upload of your package to a testing environment,
-using the ``--dry-run`` flag of the ``daml ledger upload-dar`` command.
-This runs the upgrade type-checking, but does not persist your package to the ledger.
+We recommend that as a further check for the validity of your upgraded packages,
+you perform a standalone check that all of the DARs typecheck against one
+another correctly via the ``upgrade-check`` tool.
+
+This tool takes a list of DARs and runs Canton's participant-side upgrade
+typechecking, without spinning up an instance of Canton. You should pass the
+tool the list of DARs constituting your previous model and the list of DARs for
+your new model.
+
+For example, assume you have a helper package ``helper`` that does not change,
+and two packages ``main`` and ``dep``.
+
+.. code:: text
+
+  main-1.0.0.dar
+  dep-1.0.0.dar
+  helper-1.0.0.dar
+
+After upgrading your model, you would a new DAR ``main-2.0.0.dar`` for ``main``
+and a new DAR ``dep-2.0.0.dar`` for ``dep``. We would then recommend running the
+upgrade-check tool as follows:
+
+.. code:: bash
+
+  > daml upgrade-check --participant helper-1.0.0.dar dep-1.0.0.dar main-1.0.0.dar dep-2.0.0.dar main-2.0.0.dar
+  ...
+
+This will run the same upload validation over these DARs that would be run in
+the event of an upload to the ledger, and will print out the same messages and
+errors. Because it will not require a ledger to be spun up, the command runs
+much more quickly.
+
+We can also check that all of the DARs pass compiler-side checks, but this is
+much less likely to indicate an issue because the DARs are typechecked during
+compilation anyways.
+
+.. code:: bash
+
+  > daml upgrade-check --compiler helper-1.0.0.dar dep-1.0.0.dar main-1.0.0.dar dep-2.0.0.dar main-2.0.0.dar
+  ...
+
+Dry Run Uploading to a Test Environment
+---------------------------------------
+
+If you have a test environment with DARs that are not available to you, you may
+not be able to supply a complete list of DARs for your previous model to the
+standalone ``upgrade-check`` tool.
+
+In this case, we recommend that as a further check for the validity of your
+upgraded package, you perform a dry-run upload of your package to a testing
+environment, using the ``--dry-run`` flag of the ``daml ledger upload-dar``
+command. This also runs the upgrade type-checking, but does not persist your
+package to the ledger.
 
 For workflows involving multiple DARs, we recommend more robust testing by
 running a Canton sandbox with the same version and environment as your

--- a/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
+++ b/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
@@ -1524,7 +1524,7 @@ module ``my-iface/daml/MyIface.daml``:
 
 .. code:: yaml
 
-  sdk-version: 0.0.0
+  sdk-version: 2.10.0
   name: my-iface
   version: 1.0.0
   source: daml/MyIface.daml

--- a/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
+++ b/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
@@ -1740,7 +1740,7 @@ upgrade, leaving the template ``T`` non-upgradeable.
   - daml-prim
   - daml-stdlib
   build-options:
-  - --target=1.dev
+  - --target=1.17
 
 The SCU type checker will emit an error and refuse to compile this module:
 
@@ -1778,7 +1778,7 @@ it as two packages, ``helper`` and ``main``:
   - daml-prim
   - daml-stdlib
   build-options:
-  - --target=1.dev
+  - --target=1.17
 
 .. code:: daml
 
@@ -1801,7 +1801,7 @@ it as two packages, ``helper`` and ``main``:
   data-dependencies:
   - <path to helper DAR>
   build-options:
-  - --target=1.dev
+  - --target=1.17
 
 Remove Retroactive Instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1865,8 +1865,8 @@ When you want to make a breaking change, you would publish a new version of the
 package with package name ``main-v2``. Because this package would have a
 different package name from those with ``main-v1``, it would not be typechecked
 against those packages and its datatypes would not automatically be converted.
-You would need to manually convert values from ``main-v1`` packages to be
-consumed by ``main-v2``, and vice versa.
+You would need to manually migrate values from ``main-v1`` packages to
+``main-v2`` -- existing downtime upgrade techniques are listed :ref:`here <upgrades-index>`.
 
 Migration
 ---------
@@ -2229,7 +2229,7 @@ much more quickly.
 
 We can also check that all of the DARs pass compiler-side checks, but this is
 much less likely to indicate an issue because the DARs are typechecked during
-compilation anyways.
+compilation.
 
 .. code:: bash
 

--- a/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
+++ b/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
@@ -1433,11 +1433,11 @@ Dependencies
 Package authors may upgrade the dependencies of a package as well as the
 package itself. A new version of a package may add new dependencies, and
 must have all the (non-:ref:`utility-package <upgrades-utility-package>`)
-dependencies of the old version. When using these dependencies in ways that are
-checked for upgrades, each of these existing dependencies must either be
-unchanged from the old dar, or an upgrade of its previous version.
+dependencies of the old version. If these dependencies are used in ways that are
+checked for upgrades, each existing dependency must be either
+unchanged from the old DAR or an upgrade of its previous version.
 
-For example, given a dependencies folder, containing v1, v2, and v3
+For example, given a dependencies folder containing v1, v2, and v3
 of a dependency package ``dep``:
 
 .. code:: bash
@@ -1487,8 +1487,7 @@ package may keep its dependencies the same, or it may upgrade ``dep`` to
   - dependencies/dep-3.0.0.dar # Can upgrade dep-2.0.0 to dep-3.0.0, or leave it unchanged
   ...
 
-Downgrading a dependency when using that dependency's datatypes is not
-permitted. For example, ``main`` may not downgrade ``dep`` to version ``1.0.0``.
+You cannot downgrade a dependency when using that dependency's datatypes. For example, ``main`` may not downgrade ``dep`` to version ``1.0.0``.
 The following ``daml.yaml`` would be invalid:
 
 .. code:: yaml
@@ -1502,7 +1501,7 @@ The following ``daml.yaml`` would be invalid:
   - dependencies/dep-1.0.0.dar # Cannot downgrade dep-2.0.0 to dep-1.0.0
   ...
 
-If you try to build this package, the typechecker will error on a package ID
+If you try to build this package, the typechecker returns an error on a package ID
 mismatch for the Dep:AdditionalData field, because the Dep:AdditionalData
 reference in this case has changed to a package that is not a legitimate upgrade
 of the original.
@@ -1712,10 +1711,8 @@ version 2 package also causes issues, especially if the interface has
 choices.
 
 This means that template definitions that exist in the same package as
-interfaces and exception definitions will not be upgradeable. To avoid this
-issue, move interface and exception definitions out into a separate package in
-your model, such that subsequent versions of your package with templates all
-depend on the same version of the package with interfaces/exceptions.
+interfaces and exception definitions are not upgradeable. To avoid this
+issue, move interface and exception definitions into a separate package such that subsequent versions of your template package all depend on the same version of the package with interfaces/exceptions.
 
 For example, a single package ``main`` defined as follows would not be able to
 upgrade, leaving the template ``T`` non-upgradeable.
@@ -1742,7 +1739,7 @@ upgrade, leaving the template ``T`` non-upgradeable.
   build-options:
   - --target=1.17
 
-The SCU type checker will emit an error and refuse to compile this module:
+The SCU type checker emits an error and refuses to compile this module:
 
 .. code:: text
 
@@ -1839,10 +1836,10 @@ the contract in your transaction.
 Breaking Changes via Explicit Package Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In the event that you would like to make a breaking change to your package that
+To make a breaking change to your package that
 is not upgrade compatible, you can change the name of your package to indicate a
-breaking version bump. In order to enable this, we recommend that your package
-name contains a version marker for when a breaking change does happen.
+breaking version bump. To enable this, we recommend that your package
+name contains a version marker for when a breaking change occurs.
 
 For example, for your first iteration of a package, you would name it
 ``main-v1``, starting with package version ``1.0.0``. In this case, the ``v1``
@@ -2195,12 +2192,10 @@ Testing
 Standalone Upgradeability Checks
 --------------------------------
 
-We recommend that as a further check for the validity of your upgraded packages,
-you perform a standalone check that all of the DARs typecheck against one
-another correctly via the ``upgrade-check`` tool.
+We recommend using the ``upgrade-check`` tool to perform a standalone check that all of the DARs typecheck against one another correctly as further validation of your upgraded packages.
 
 This tool takes a list of DARs and runs Canton's participant-side upgrade
-typechecking, without spinning up an instance of Canton. You should pass the
+typechecking without spinning up an instance of Canton. You should pass the
 tool the list of DARs constituting your previous model and the list of DARs for
 your new model.
 
@@ -2213,7 +2208,7 @@ and two packages ``main`` and ``dep``.
   dep-1.0.0.dar
   helper-1.0.0.dar
 
-After upgrading your model, you would a new DAR ``main-2.0.0.dar`` for ``main``
+After upgrading your model, you would publish a new DAR ``main-2.0.0.dar`` for ``main``
 and a new DAR ``dep-2.0.0.dar`` for ``dep``. We would then recommend running the
 upgrade-check tool as follows:
 
@@ -2222,9 +2217,9 @@ upgrade-check tool as follows:
   > daml upgrade-check --participant helper-1.0.0.dar dep-1.0.0.dar main-1.0.0.dar dep-2.0.0.dar main-2.0.0.dar
   ...
 
-This will run the same upload validation over these DARs that would be run in
-the event of an upload to the ledger, and will print out the same messages and
-errors. Because it will not require a ledger to be spun up, the command runs
+This runs the same upload validation over these DARs that would be run in
+the event of an upload to the ledger, and prints out the same messages and
+errors. Because it does not require a ledger to be spun up, the command runs
 much more quickly.
 
 We can also check that all of the DARs pass compiler-side checks, but this is
@@ -2246,7 +2241,7 @@ standalone ``upgrade-check`` tool.
 In this case, we recommend that as a further check for the validity of your
 upgraded package, you perform a dry-run upload of your package to a testing
 environment, using the ``--dry-run`` flag of the ``daml ledger upload-dar``
-command. This also runs the upgrade type-checking, but does not persist your
+command. This also runs the upgrade typechecking, but does not persist your
 package to the ledger.
 
 For workflows involving multiple DARs, we recommend more robust testing by

--- a/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
+++ b/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
@@ -404,7 +404,9 @@ Add ``daml-script-lts`` to the list of dependencies in ``v1/my-pkg/daml.yaml``,
 as well as ``--target=1.17`` to the ``build-options``:
 
 .. code:: yaml
-  
+
+  ...
+  name: my-pkg
   ...
   dependencies:
   - daml-prim
@@ -412,6 +414,11 @@ as well as ``--target=1.17`` to the ``build-options``:
   - daml-script-lts
   build-options:
   - --target=1.17
+
+**Note:** Normally a package undergoing SCU should contain a version identifier
+in its name as well, but we leave this out for simplicity's sake - consult the
+section on :ref:`package naming best practices <upgrade_package_naming>` to
+learn more about this.
 
 Then create ``v1/my-pkg/daml/Main.daml``:
 
@@ -1832,6 +1839,8 @@ values, be aware that if their runtime value changes in any way, the
 upgrade, and thus the full transaction, fails. Contracts in this
 state can then only be used by explicitly choosing the older version of
 the contract in your transaction.
+
+.. _upgrade_package_naming:
 
 Breaking Changes via Explicit Package Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
+++ b/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
@@ -1836,6 +1836,38 @@ upgrade, and thus the full transaction, fails. Contracts in this
 state can then only be used by explicitly choosing the older version of
 the contract in your transaction.
 
+Breaking Changes via Explicit Package Version
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the event that you would like to make a breaking change to your package that
+is not upgrade compatible, you can change the name of your package to indicate a
+breaking version bump. In order to enable this, we recommend that your package
+name contains a version marker for when a breaking change does happen.
+
+For example, for your first iteration of a package, you would name it
+``main-v1``, starting with package version ``1.0.0``. In this case, the ``v1``
+is part of the *package name*, not the package version. You could publish
+upgrade-compatible versions by changing the ``version:`` field from ``1.0.0`` to
+``2.0.0`` to ``3.0.0``. These versions would all be upgrade-compatible with
+one another:
+
+.. code:: text
+
+  main-v1-1.0.0
+  main-v1-2.0.0
+  main-v1-3.0.0
+
+Note how the ``v1`` in all three packages remains stable - this means the
+package name has not changed, and ensures that these three packages and their
+datatypes are considered by the runtime and the type checker to be upgradeable.
+
+When you want to make a breaking change, you would publish a new version of the
+package with package name ``main-v2``. Because this package would have a
+different package name from those with ``main-v1``, it would not be typechecked
+against those packages and its datatypes would not automatically be converted.
+You would need to manually convert values from ``main-v1`` packages to be
+consumed by ``main-v2``, and vice versa.
+
 Migration
 ---------
 


### PR DESCRIPTION
From fields in: https://docs.google.com/spreadsheets/d/1_0ER--x-YJzoYSoy7VFs6emzn4ZYjBc0kte4MLosuxs/edit

Each commit addresses something different:
- 03ca9c58fcdffd3da212b2d726f29793bc787c97 updated the docs that used to state that deps are only checked on the participant - they are now checked on the compiler as well, so I've updated the docs there and made them easier to understand.
- e11bbd330e458e737d156e903ffb7d93e525deaf is a trivial fix to `sdk-version: 0.0.0` -> `sdk-version: 2.10.0`
- 81700d6057238b4c79e6c96e3c78ae6cbdbd2b43 addresses UPD-12 by improving the section on best practice for interface/template splitting, and documenting the flags that affect this. There are still some other flags for upgrade warnings/errors, so there will be more to come.
- 772203992bd6d83bb6e2d56cf909b85d44721a39 addresses UPD-30 "Explain how package should be versioned"
- b220f4707a06543f408ab93c296234358fca1dbf addresses UPD-33 "Using upgrade-check, takes precedence over --dry-run flag"