### PR TITLE
Request PR reviews for docs content only from the docs team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,7 @@
 # https://help.github.com/articles/about-codeowners/
 # Note that accounts or teams mentioned must have WRITE access to the repository.
 
-* @digital-asset/daml-docs @digital-asset/re
+/docs/ @digital-asset/daml-docs
+
+* @digital-asset/re
+


### PR DESCRIPTION
This reduces the PR review notifications for the docs.daml.com maintainer team `re` who are interested in reviewing non-documentation content only.