### PR TITLE
Improve `CODEOWNERS` to reduce PR approval notification noise

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,18 @@
 # https://help.github.com/articles/about-codeowners/
 # Note that accounts or teams mentioned must have WRITE access to the repository.
 
-* @digital-asset/daml-docs @digital-asset/re
+# @digital-asset/re is the default owner for everything in the repo.
+# Unless a later match takes precedence, @digital-asset/re will be
+# requested for review when someone opens a pull request.
+*　             @digital-asset/re
+
+# @digital-asset/daml-docs owns any file in the `/docs` directory in the root of
+# the repository and any of its subdirectories.
+/docs/          @digital-asset/daml-docs
+
+# @digital-asset/re owns any file in a `/bin` directory such as `/bin` or
+# `/docs/2.10.0/bin`. And additionally any change to `README.md` or `.gitignore`
+# files require approval from @digital-asset/re independent of their file location.
+**/bin          @digital-asset/re
+**/README.md    @digital-asset/re
+**/.gitignore   @digital-asset/re


### PR DESCRIPTION
This reduces PR review notifications for the docs.daml.com maintainer team `re` who are only interested in reviewing non-documentation content.

On the other hand, any change to a file located in the `/docs` directory and its subdirectories requires an approval from the docs team.