### PR TITLE
#22681 Document `tls.enabled` for in 2.10

### DIFF
--- a/docs/2.10.0/docs/canton/usermanual/console.rst
+++ b/docs/2.10.0/docs/canton/usermanual/console.rst
@@ -85,7 +85,13 @@ TLS and Authorization
 ^^^^^^^^^^^^^^^^^^^^^
 
 For production use cases, in particular if the Admin API is not just bound to localhost, we recommend to enable
-:ref:`TLS <tls-configuration>` with mutual authentication.
+:ref:`TLS <tls-configuration>` with mutual authentication. If an API is secured using certificates that are
+singed by a system-wide trusted CA and TLS configuration is otherwise empty, TLS can be enabled
+for a remote node as following:
+
+.. code-block:: none
+
+    canton.remote-domains.mydomain.<api>.tls.enabled = true
 
 The remote console can be used in installations that utilize authorization, so long as it has a valid access token. This can be achieved by modifying the configuration or by adding
 an option to the remote console's launch command as in the following snippet:

--- a/docs/2.10.0/docs/canton/usermanual/console.rst
+++ b/docs/2.10.0/docs/canton/usermanual/console.rst
@@ -86,7 +86,7 @@ TLS and Authorization
 
 For production use cases, in particular if the Admin API is not just bound to localhost, we recommend to enable
 :ref:`TLS <tls-configuration>` with mutual authentication. If an API is secured using certificates that are
-singed by a system-wide trusted CA and TLS configuration is otherwise empty, TLS can be enabled
+signed by a system-wide trusted CA and the TLS configuration is otherwise empty, TLS can be enabled
 for a remote node as following:
 
 .. code-block:: none


### PR DESCRIPTION
Little doc update for TLS config for 2.10+, corresponds to https://github.com/DACH-NY/canton/pull/23017
