### PR TITLE
[Tri-state vetting] Package management docs updates

### DIFF
--- a/docs/2.10.0/docs/canton/includes/snippet_data/usermanual/packagemanagement.json
+++ b/docs/2.10.0/docs/canton/includes/snippet_data/usermanual/packagemanagement.json
@@ -1,58 +1,42 @@
 {
-  "202" : {
-    "command" : "participant1.topology.check_only_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
-    "output" : "res25: Boolean = true"
-  },
-  "184" : {
-    "command" : "participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
-    "output" : "res22: Boolean = true"
-  },
   "20" : {
     "command" : "participant2.dars.upload(\"dars/CantonExamples.dar\")",
     "output" : "res1: String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
   },
-  "201" : {
-    "command" : "",
-    "output" : ""
-  },
-  "28" : {
-    "command" : "participant2.dars.list()",
-    "output" : "res2: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12207f38b04c40dd9cf5bc1daa97625427665af959801fc77024dafd5898cb01f01b\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  ),\n  DarDescription(\n    hash = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\",\n    name = \"CantonExamples\"\n  )\n)"
-  },
-  "236" : {
-    "command" : "import com.digitalasset.canton.LfPackageId",
-    "output" : ""
-  },
-  "103" : {
-    "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
-  },
-  "223" : {
+  "221" : {
     "command" : "participant1.dars.vetting.enable(darHash)",
     "output" : ""
   },
-  "150" : {
+  "229" : {
+    "command" : "val txsContainingMainPackage = participant1.topology.vetted_packages.list(filterStore = \"Authorized\", filterParticipant = participant1.id.filterString).filter(_.item.packageIds.contains(mainPackageId))",
+    "output" : "txsContainingMainPackage : Seq[ListVettedPackagesResult] = Vector(\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2025-01-08T09:55:24.957199Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@71995ebb size=2450 contents=\"\\n\\217\\023\\n\\275\\020\\n\\270\\020\\n\\265\\020\\022 m3cLchRcVzRkHAXHPA1MwuXxp1EG1j3EJ...\">,\n      signedBy = 1220ffcaad4b...\n    ),\n    item = VettedPackages(\n      participant = participant1::1220ffcaad4b...,\n      packages = Seq(\n        28cf6c194d92...,\n        7e0aa3d819f2...,\n        6851f194e144...,\n.."
+  },
+  "105" : {
+    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty ), Seq(createIouCmd))",
+    "output" : "res14: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220737bbbe48ada6eb9e1b2e5e1f14aacf37a324317a5cd4524f9fb71b7d963cb75\",\n  commandId = \"0843265a-4e4f-4e69-bbd2-42bc9cd83331\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
+  },
+  "148" : {
     "command" : "participant1.dars.vetting.disable(darHash)",
     "output" : ""
   },
-  "127" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
-    "output" : "res17: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"12207d293dd4befb562b30c3d5daa1e11154d8778aa392e501a217658b204ada5a1e\",\n  commandId = \"5de0a322-032f-425e-bd55-1ac5357b0fd8\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
+  "143" : {
+    "command" : "participant1.dars.vetting.disable(examplesDependencyDarHash)",
+    "output" : ""
   },
-  "36" : {
-    "command" : "val dars = participant2.dars.list(filterName = \"CantonExamples\")",
-    "output" : "dars : Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\",\n    name = \"CantonExamples\"\n  )\n)"
+  "55" : {
+    "command" : "participant2.packages.list_contents(darContent.main)",
+    "output" : "res7: Seq[com.digitalasset.canton.participant.admin.v0.ModuleDescription] = Vector(\n  ModuleDescription(name = \"CantonExamples\"),\n  ModuleDescription(name = \"ContractKeys\"),\n  ModuleDescription(name = \"SafePaint\"),\n  ModuleDescription(name = \"LockIou\"),\n  ModuleDescription(name = \"Iou\"),\n  ModuleDescription(name = \"Divulgence\"),\n  ModuleDescription(name = \"Paint\"),\n.."
   },
-  "138" : {
+  "136" : {
     "command" : "val examplesDependencyDarHash = participant1.dars.upload(\"dars/CantonExamplesDependency.dar\")",
     "output" : "examplesDependencyDarHash : String = \"1220ee0bfbe921a7f88b376b9b35c74d9ff18a4aab9ceacf877b8e1880281518ef7a\""
   },
-  "88" : {
-    "command" : "participant2.dars.vetting.enable(hash)",
-    "output" : ""
+  "101" : {
+    "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
+    "output" : "darHash : String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
   },
-  "185" : {
-    "command" : "",
+  "234" : {
+    "command" : "import com.digitalasset.canton.LfPackageId",
     "output" : ""
   },
   "42" : {
@@ -63,68 +47,92 @@
     "command" : "val hash = dars.head.hash",
     "output" : "hash : String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
   },
-  "179" : {
-    "command" : "participant1.dars.vetting.enable(darHash)",
-    "output" : ""
-  },
-  "106" : {
-    "command" : "val createIouCmd = ledger_api_utils.create(mainPackageId,\"Iou\",\"Iou\",Map(\"payer\" -> participant1.adminParty,\"owner\" -> participant1.adminParty,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
-    "output" : ".."
-  },
-  "121" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/NO_DOMAIN_FOR_SUBMISSION(9,c869040d): No valid domain for submission found.\n  Request: SubmitAndWaitTransactionTree(\n  actAs = participant1::1220a22f7006...,\n  readAs = Seq(),\n  commandId = '',\n  workflowId = '',\n  submissionId = '',\n  deduplicationPeriod = None(),\n  applicationId = 'CantonConsole',\n  commands = ...\n)\n  CorrelationId: c869040d8beb473936360cfde8f175d2\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, domainsNotUsed -> Map(mydomain::1220edc575ff... -> The topology state for some packages does not meet the requirements on domain mydomain::1220edc575ff...: [(Participant PAR::participant1::1220a22f7006... has not vetted 7e0aa3d819f2...)]), tid -> c869040d8beb473936360cfde8f175d2, definite_answer -> false)\n  Command BaseLedgerApiAdministration$ledger_api$commands$.submit invoked from cmd10000038.sc:1"
-  },
-  "237" : {
-    "command" : "txsContainingMainPackage.foreach { tx => participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove,participant1.id,tx.item.packageIds,force = true); participant1.topology.vetted_packages.authorize(TopologyChangeOp.Add,participant1.id,tx.item.packageIds.filterNot(_ == mainPackageId),force = true)}",
-    "output" : ""
-  },
-  "105" : {
-    "command" : "participant1.domains.connect_local(mydomain)",
-    "output" : ""
-  },
-  "112" : {
+  "110" : {
     "command" : "participant1.dars.vetting.disable(darHash)",
     "output" : ""
   },
-  "145" : {
-    "command" : "participant1.dars.vetting.disable(examplesDependencyDarHash)",
-    "output" : ""
+  "125" : {
+    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
+    "output" : "res17: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"12200faa549cb6a8834f70344519bf81cbfa20264d8b158bef4a03881c79f9d1e2cb\",\n  commandId = \"211d35d1-b2ca-447d-bcba-8dcbfd448f40\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
   },
-  "231" : {
-    "command" : "val txsContainingMainPackage = participant1.topology.vetted_packages.list(filterStore = \"Authorized\", filterParticipant = participant1.id.filterString).filter(_.item.packageIds.contains(mainPackageId))",
-    "output" : "txsContainingMainPackage : Seq[ListVettedPackagesResult] = Vector(\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2025-01-07T14:55:47.976708Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@7d7437d2 size=2450 contents=\"\\n\\217\\023\\n\\275\\020\\n\\270\\020\\n\\265\\020\\022 oqOD1a9cLZGccHfE5cZWMJd21OnvyrmcJ...\">,\n      signedBy = 1220a22f7006...\n    ),\n    item = VettedPackages(\n      participant = participant1::1220a22f7006...,\n      packages = Seq(\n        28cf6c194d92...,\n        7e0aa3d819f2...,\n        6851f194e144...,\n.."
-  },
-  "203" : {
+  "201" : {
     "command" : "",
     "output" : ""
   },
-  "104" : {
+  "220" : {
+    "command" : "participant1.dars.vetting.enable(examplesDependencyDarHash)",
+    "output" : ""
+  },
+  "102" : {
     "command" : "val mainPackageId = participant1.packages.find(\"Iou\").head.packageId",
     "output" : "mainPackageId : String = \"7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84\""
   },
-  "55" : {
-    "command" : "participant2.packages.list_contents(darContent.main)",
-    "output" : "res7: Seq[com.digitalasset.canton.participant.admin.v0.ModuleDescription] = Vector(\n  ModuleDescription(name = \"CantonExamples\"),\n  ModuleDescription(name = \"ContractKeys\"),\n  ModuleDescription(name = \"SafePaint\"),\n  ModuleDescription(name = \"LockIou\"),\n  ModuleDescription(name = \"Iou\"),\n  ModuleDescription(name = \"Divulgence\"),\n  ModuleDescription(name = \"Paint\"),\n.."
+  "28" : {
+    "command" : "participant2.dars.list()",
+    "output" : "res2: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12207f38b04c40dd9cf5bc1daa97625427665af959801fc77024dafd5898cb01f01b\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  ),\n  DarDescription(\n    hash = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\",\n    name = \"CantonExamples\"\n  )\n)"
   },
-  "139" : {
+  "137" : {
     "command" : "participant1.dars.vetting.disable(darHash)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/MAIN_DAR_PACKAGE_REFERENCED_EXTERNALLY(9,b583d752): Operation DAR disabling for DAR 'CantonExamples' failed due to its main package with packageId=7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84 being vetted multiple times\n  Request: UnvetDar(12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709,true)\n  CorrelationId: b583d75280e593ba9fdce012ebea166b\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, darDescription -> CantonExamples, operationName -> DAR disabling, mainPackageId -> 7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84, tid -> b583d75280e593ba9fdce012ebea166b)\n  Command ParticipantAdministration$dars$vetting$.disable invoked from cmd10000046.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/MAIN_DAR_PACKAGE_REFERENCED_EXTERNALLY(9,7a5d6802): Operation DAR disabling for DAR 'CantonExamples' failed due to its main package with packageId=7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84 being vetted multiple times\n  Request: UnvetDar(12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709,true)\n  CorrelationId: 7a5d68026107b5b935e392712a2525a4\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, darDescription -> CantonExamples, operationName -> DAR disabling, mainPackageId -> 7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84, tid -> 7a5d68026107b5b935e392712a2525a4)\n  Command ParticipantAdministration$dars$vetting$.disable invoked from cmd10000046.sc:1"
   },
-  "107" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty ), Seq(createIouCmd))",
-    "output" : "res14: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"12203c1ec2fc1efe30fafca72d0b3267727131fb39937733bb2a58cf0ab24068d4d7\",\n  commandId = \"15fb7888-93cd-47c2-bfd6-aae1547b2970\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
-  },
-  "242" : {
-    "command" : "participant1.topology.check_only_packages.authorize(TopologyChangeOp.Add, participant1.id, Seq(LfPackageId.assertFromString(mainPackageId)), force = true)",
-    "output" : ".."
-  },
-  "126" : {
+  "124" : {
     "command" : "participant1.dars.vetting.enable(darHash)",
     "output" : ""
   },
-  "195" : {
+  "193" : {
     "command" : "participant1.dars.vetting.disable(darHash)",
+    "output" : ""
+  },
+  "103" : {
+    "command" : "participant1.domains.connect_local(mydomain)",
+    "output" : ""
+  },
+  "240" : {
+    "command" : "participant1.topology.check_only_packages.authorize(TopologyChangeOp.Add, participant1.id, Seq(LfPackageId.assertFromString(mainPackageId)), force = true)",
+    "output" : ".."
+  },
+  "198" : {
+    "command" : "participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
+    "output" : "res24: Boolean = false"
+  },
+  "199" : {
+    "command" : "",
+    "output" : ""
+  },
+  "177" : {
+    "command" : "participant1.dars.vetting.enable(darHash)",
+    "output" : ""
+  },
+  "182" : {
+    "command" : "participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
+    "output" : "res22: Boolean = true"
+  },
+  "87" : {
+    "command" : "participant2.dars.vetting.enable(hash)",
+    "output" : ""
+  },
+  "104" : {
+    "command" : "val createIouCmd = ledger_api_utils.create(mainPackageId,\"Iou\",\"Iou\",Map(\"payer\" -> participant1.adminParty,\"owner\" -> participant1.adminParty,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
+    "output" : ".."
+  },
+  "119" : {
+    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/NO_DOMAIN_FOR_SUBMISSION(9,a1fc5ba7): No valid domain for submission found.\n  Request: SubmitAndWaitTransactionTree(\n  actAs = participant1::1220ffcaad4b...,\n  readAs = Seq(),\n  commandId = '',\n  workflowId = '',\n  submissionId = '',\n  deduplicationPeriod = None(),\n  applicationId = 'CantonConsole',\n  commands = ...\n)\n  CorrelationId: a1fc5ba7425689d5d49ee4f420388cca\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, domainsNotUsed -> Map(mydomain::122031b78160... -> The topology state for some packages does not meet the requirements on domain mydomain::122031b78160...: [(Participant PAR::participant1::1220ffcaad4b... has not vetted 7e0aa3d819f2...)]), tid -> a1fc5ba7425689d5d49ee4f420388cca, definite_answer -> false)\n  Command BaseLedgerApiAdministration$ledger_api$commands$.submit invoked from cmd10000038.sc:1"
+  },
+  "235" : {
+    "command" : "txsContainingMainPackage.foreach { tx => participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove,participant1.id,tx.item.packageIds,force = true); participant1.topology.vetted_packages.authorize(TopologyChangeOp.Add,participant1.id,tx.item.packageIds.filterNot(_ == mainPackageId),force = true)}",
+    "output" : ""
+  },
+  "82" : {
+    "command" : "participant2.dars.upload(\"dars/CantonExamples.dar\", vetAllPackages = false)",
+    "output" : "res8: String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
+  },
+  "36" : {
+    "command" : "val dars = participant2.dars.list(filterName = \"CantonExamples\")",
+    "output" : "dars : Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\",\n    name = \"CantonExamples\"\n  )\n)"
+  },
+  "183" : {
+    "command" : "",
     "output" : ""
   },
   "47" : {
@@ -132,15 +140,7 @@
     "output" : "res6: Seq[com.digitalasset.canton.participant.admin.v0.PackageDescription] = Vector(\n  PackageDescription(\n    packageId = \"88cf65277201722eda8564ac04494bed23ac79673722af482c6f3fb37aec83ed\",\n    sourceDescription = \"AdminWorkflowsWithVacuuming\"\n  ),\n  PackageDescription(\n    packageId = \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n    sourceDescription = \"CantonExamples\"\n.."
   },
   "200" : {
-    "command" : "participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
-    "output" : "res24: Boolean = false"
-  },
-  "83" : {
-    "command" : "participant2.dars.upload(\"dars/CantonExamples.dar\", vetAllPackages = false)",
-    "output" : "res8: String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
-  },
-  "222" : {
-    "command" : "participant1.dars.vetting.enable(examplesDependencyDarHash)",
-    "output" : ""
+    "command" : "participant1.topology.check_only_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
+    "output" : "res25: Boolean = true"
   }
 }

--- a/docs/2.10.0/docs/canton/includes/snippet_data/usermanual/packagemanagement.json
+++ b/docs/2.10.0/docs/canton/includes/snippet_data/usermanual/packagemanagement.json
@@ -1,210 +1,126 @@
 {
-  "252" : {
-    "command" : "val createIouCmd = ledger_api_utils.create(packageId,\"Iou\",\"Iou\",Map(\"payer\" -> participant1.adminParty,\"owner\" -> participant1.adminParty,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
-    "output" : "createIouCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Create(\n    value = CreateCommand(\n      templateId = Some(\n        value = Identifier(\n.."
-  },
-  "124" : {
-    "command" : "val darHash_ = participant1.dars.list().filter(_.name == \"CantonExamples\").head.hash",
-    "output" : "darHash_ : String = \"1220948b69780faf57430a05ecf00acdfa284404d1ea3be0422cd1bab0f13b21ff69\""
-  },
-  "173" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(archiveIouCmd))",
-    "output" : "res24: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"122008bcebf8fc6e7f643ee87f961c43b8d46349f9e68246f5951063e192540a15ef\",\n  commandId = \"696aa968-4bb5-469b-9449-82f46b27deb2\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
-  },
-  "118" : {
-    "command" : "val packagesBefore = participant1.packages.list().map(_.packageId).toSet",
-    "output" : "packagesBefore : Set[String] = HashSet(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"5921708ce82f4255deb1b26d2c05358b548720938a5a325718dc69f381ba47ff\",\n  \"d79b5d4f1d34702aefd8eee2bfa7618cb45ae771d62a7bf81024ba51985e57ef\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"e22bce619ae24ca3b8e6519281cb5a33b64b3190cc763248b4c3f9ad5087a92c\",\n  \"d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97\",\n  \"6c2c0667393c5f92f1885163068cd31800d2264eb088eb6fc740e11241b2bf06\",\n  \"1a856cdaa0677615297d90baff5d9618f29796f17a312d98bde6b49094ffeb49\",\n  \"8a7806365bbd98d88b4c13832ebfa305f6abaeaf32cfa2b7dd25c4fa489b79fb\",\n.."
-  },
-  "159" : {
-    "command" : "participant1.domains.connect_local(mydomain)",
-    "output" : ""
-  },
-  "263" : {
-    "command" : "val iou = participant1.ledger_api.acs.find_generic(participant1.adminParty, _.templateId.isModuleEntity(\"Iou\", \"Iou\"))",
-    "output" : "iou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#1220a88ee8b25685397073bcde83d3c6ed11c4d7d5f5a0f60964e29207940bca2297:0\",\n    contractId = \"003a57759d210734c7391c6ee4ac692b88d673d871606ea329770c464c2188c95fca0212202e284610acae9f02c66bd17ea25fb28b824e0e653e9204280c963298c1266681\",\n    templateId = Some(\n      value = Identifier(\n        packageId = \"858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4\",\n        moduleName = \"Iou\",\n        entityName = \"Iou\"\n      )\n.."
-  },
-  "195" : {
-    "command" : "participant1.dars.remove(darHash)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,698d9e14): An error was encountered whilst trying to unvet the DAR DarDescriptor(SHA-256:948b69780faf...,CantonExamples) with main package 858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4 for DAR removal. Details: IdentityManagerParentError(Mapping(VettedPackages(\n  participant = participant1::12202c5a0641...,\n  packages = Seq(\n    858e7bb622e5...,\n    6851f194e144...,\n    cb0552debf21...,\n    3f4deaf145a1...,\n    86828b984346...,\n    f20de1e4e37b...,\n    76bf0fd12bd9...,\n    38e6274601b2...,\n    d58cf...\n  Request: RemoveDar(1220948b69780faf57430a05ecf00acdfa284404d1ea3be0422cd1bab0f13b21ff69)\n  CorrelationId: 698d9e14b29a5ba6c5691c8ad840c4d6\n  Context: Map(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, tid -> 698d9e14b29a5ba6c5691c8ad840c4d6)\n  Command ParticipantAdministration$dars$.remove invoked from cmd10000076.sc:1"
-  },
-  "276" : {
-    "command" : "participant1.packages.remove(packageId)",
-    "output" : ""
-  },
-  "247" : {
-    "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220948b69780faf57430a05ecf00acdfa284404d1ea3be0422cd1bab0f13b21ff69\""
-  },
-  "42" : {
-    "command" : "val darContent = participant2.dars.list_contents(hash)",
-    "output" : "darContent : DarMetadata = DarMetadata(\n  name = \"CantonExamples\",\n  main = \"858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4\",\n  packages = Vector(\n    \"858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4\",\n    \"6851f194e144b693e63e9034b956c76cef6b5088dd8c66a657ab652a204dba2b\",\n    \"cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a\",\n    \"3f4deaf145a15cdcfa762c058005e2edb9baa75bb7f95a4f8f6f937378e86415\",\n.."
-  },
-  "37" : {
-    "command" : "val hash = dars.head.hash",
-    "output" : "hash : String = \"1220948b69780faf57430a05ecf00acdfa284404d1ea3be0422cd1bab0f13b21ff69\""
-  },
-  "125" : {
-    "command" : "",
-    "output" : ""
-  },
-  "157" : {
-    "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220948b69780faf57430a05ecf00acdfa284404d1ea3be0422cd1bab0f13b21ff69\""
-  },
-  "189" : {
-    "command" : "val packageIds = participant1.packages.list().filter(_.sourceDescription == \"CantonExamples\").map(_.packageId).map(PackageId.assertFromString)",
-    "output" : "packageIds : Seq[PackageId] = Vector(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n.."
+  "101" : {
+    "command" : "val createIouCmd = ledger_api_utils.create(mainPackageId,\"Iou\",\"Iou\",Map(\"payer\" -> participant1.adminParty,\"owner\" -> participant1.adminParty,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
+    "output" : ".."
   },
   "20" : {
     "command" : "participant2.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "res1: String = \"1220948b69780faf57430a05ecf00acdfa284404d1ea3be0422cd1bab0f13b21ff69\""
+    "output" : "res1: String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
   },
-  "253" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
-    "output" : "res39: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220a88ee8b25685397073bcde83d3c6ed11c4d7d5f5a0f60964e29207940bca2297\",\n  commandId = \"d10ea5c3-e685-4d94-b5bd-35e642f7af9b\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1719407129L,\n      nanos = 946177000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n.."
-  },
-  "238" : {
-    "command" : "participant1.packages.remove(packageId)",
+  "132" : {
+    "command" : "participant1.dars.vetting.disable(examplesDependencyDarHash)",
     "output" : ""
   },
-  "147" : {
-    "command" : "assert(packages == packagesBefore)",
-    "output" : ""
+  "181" : {
+    "command" : "participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
+    "output" : "res23: Boolean = false"
   },
-  "221" : {
+  "98" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220948b69780faf57430a05ecf00acdfa284404d1ea3be0422cd1bab0f13b21ff69\""
+    "output" : "darHash : String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
   },
-  "265" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(archiveIouCmd))",
-    "output" : "res42: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220523c718f5ad294255f755d45762e170c5f0f9514e450a1662a6c74a117fdd02c\",\n  commandId = \"3a34583e-3ef2-4000-9fd0-e63a6818bb5e\",\n  workflowId = \"\",\n  effectiveAt = Some(\n    value = Timestamp(\n      seconds = 1719407130L,\n      nanos = 215983000,\n      unknownFields = UnknownFieldSet(fields = Map())\n    )\n  ),\n  offset = \"00000000000000000c\",\n.."
-  },
-  "292" : {
-    "command" : "participant1.packages.remove(packageId, force = true)",
+  "108" : {
+    "command" : "participant1.dars.vetting.disable(darHash)",
     "output" : ""
   },
-  "233" : {
-    "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove, participant1.id, packageIds, force = true)",
-    "output" : "res35: com.google.protobuf.ByteString = <ByteString@4e9f1af1 size=2386 contents=\"\\n\\317\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 SgQnYYMa4t4vqpaigNs0VsuBGzl2ySs...\">"
-  },
-  "270" : {
-    "command" : "val packageIds = participant1.topology.vetted_packages.list().map(_.item.packageIds).filter(_.contains(packageId)).head",
-    "output" : "packageIds : Seq[com.digitalasset.canton.package.LfPackageId] = Vector(\n  \"858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4\",\n  \"6851f194e144b693e63e9034b956c76cef6b5088dd8c66a657ab652a204dba2b\",\n.."
-  },
-  "201" : {
-    "command" : "participant1.dars.remove(darHash)",
+  "80" : {
+    "command" : "participant2.dars.vetting.enable(hash)",
     "output" : ""
+  },
+  "127" : {
+    "command" : "participant1.dars.vetting.disable(darHash)",
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/MAIN_DAR_PACKAGE_REFERENCED_EXTERNALLY(9,25d6ffd7): Operation DAR disabling for DAR 'CantonExamples' failed due to its main package with packageId=7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84 being vetted multiple times\n  Request: UnvetDar(12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709,true)\n  CorrelationId: 25d6ffd72b85fb4a13c92c2755007f52\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, darDescription -> CantonExamples, operationName -> DAR disabling, mainPackageId -> 7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84, tid -> 25d6ffd72b85fb4a13c92c2755007f52)\n  Command ParticipantAdministration$dars$vetting$.disable invoked from cmd10000044.sc:1"
+  },
+  "75" : {
+    "command" : "participant2.dars.upload(\"dars/CantonExamples.dar\", vetAllPackages = false)",
+    "output" : "res8: String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
+  },
+  "36" : {
+    "command" : "val dars = participant2.dars.list(filterName = \"CantonExamples\")",
+    "output" : "dars : Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\",\n    name = \"CantonExamples\"\n  )\n)"
+  },
+  "126" : {
+    "command" : "val examplesDependencyDarHash = participant1.dars.upload(\"dars/CantonExamplesDependency.dar\")",
+    "output" : "examplesDependencyDarHash : String = \"1220ee0bfbe921a7f88b376b9b35c74d9ff18a4aab9ceacf877b8e1880281518ef7a\""
+  },
+  "47" : {
+    "command" : "participant2.packages.list()",
+    "output" : "res6: Seq[com.digitalasset.canton.participant.admin.v0.PackageDescription] = Vector(\n  PackageDescription(\n    packageId = \"88cf65277201722eda8564ac04494bed23ac79673722af482c6f3fb37aec83ed\",\n    sourceDescription = \"AdminWorkflowsWithVacuuming\"\n  ),\n  PackageDescription(\n    packageId = \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n    sourceDescription = \"CantonExamples\"\n.."
+  },
+  "115" : {
+    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
+    "output" : "res16: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220c52d497fadffb85630554a33d76c4817c144f7c4d6a2acc81b5b192306916418\",\n  commandId = \"26e5d72c-53b8-4470-aae8-54b38c87a2b2\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
+  },
+  "217" : {
+    "command" : "import com.digitalasset.canton.LfPackageId",
+    "output" : ""
+  },
+  "42" : {
+    "command" : "val darContent = participant2.dars.list_contents(hash)",
+    "output" : "darContent : DarMetadata = DarMetadata(\n  name = \"CantonExamples\",\n  main = \"7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84\",\n  packages = Vector(\n    \"7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84\",\n    \"6851f194e144b693e63e9034b956c76cef6b5088dd8c66a657ab652a204dba2b\",\n    \"cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a\",\n    \"3f4deaf145a15cdcfa762c058005e2edb9baa75bb7f95a4f8f6f937378e86415\",\n.."
+  },
+  "37" : {
+    "command" : "val hash = dars.head.hash",
+    "output" : "hash : String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
   },
   "28" : {
     "command" : "participant2.dars.list()",
-    "output" : "res2: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220948b69780faf57430a05ecf00acdfa284404d1ea3be0422cd1bab0f13b21ff69\",\n    name = \"CantonExamples\"\n  ),\n  DarDescription(\n    hash = \"122029f5ef0de5058a7330b7577570ad1130ad64dcaffb17cfe54db5738bd92d5e65\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  )\n)"
+    "output" : "res2: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12207f38b04c40dd9cf5bc1daa97625427665af959801fc77024dafd5898cb01f01b\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  ),\n  DarDescription(\n    hash = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\",\n    name = \"CantonExamples\"\n  )\n)"
   },
-  "160" : {
-    "command" : "val createIouCmd = ledger_api_utils.create(packageId,\"Iou\",\"Iou\",Map(\"payer\" -> participant1.adminParty,\"owner\" -> participant1.adminParty,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
-    "output" : ".."
-  },
-  "188" : {
-    "command" : "import com.daml.lf.data.Ref.IdString.PackageId",
+  "137" : {
+    "command" : "participant1.dars.vetting.disable(darHash)",
     "output" : ""
   },
-  "141" : {
-    "command" : "packageIds.filter(id => ! packagesBefore.contains(id)).foreach(id => participant1.packages.remove(id))",
-    "output" : ""
+  "109" : {
+    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/NO_DOMAIN_FOR_SUBMISSION(9,b3cbc8e8): No valid domain for submission found.\n  Request: SubmitAndWaitTransactionTree(\n  actAs = participant1::12206baa196b...,\n  readAs = Seq(),\n  commandId = '',\n  workflowId = '',\n  submissionId = '',\n  deduplicationPeriod = None(),\n  applicationId = 'CantonConsole',\n  commands = ...\n)\n  CorrelationId: b3cbc8e81749166ffadf7602e1e908ad\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, domainsNotUsed -> Map(mydomain::12202fd803a2... -> The topology state for some packages does not meet the requirements on domain mydomain::12202fd803a2...: [(Participant PAR::participant1::12206baa196b... has not vetted 7e0aa3d819f2...)]), tid -> b3cbc8e81749166ffadf7602e1e908ad, definite_answer -> false)\n  Command BaseLedgerApiAdministration$ledger_api$commands$.submit invoked from cmd10000036.sc:1"
+  },
+  "212" : {
+    "command" : "val txsContainingMainPackage = participant1.topology.vetted_packages.list(filterStore = \"Authorized\", filterParticipant = participant1.id.filterString).filter(_.item.packageIds.contains(mainPackageId))",
+    "output" : "txsContainingMainPackage : Seq[ListVettedPackagesResult] = Vector(\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2025-01-06T19:55:19.094041Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@4604aa42 size=2450 contents=\"\\n\\217\\023\\n\\275\\020\\n\\270\\020\\n\\265\\020\\022 R9IDS7aR3H5zdgkJI1ClZvBYaQmHa31dJ...\">,\n      signedBy = 12206baa196b...\n    ),\n    item = VettedPackages(\n      participant = participant1::12206baa196b...,\n      packages = Seq(\n        28cf6c194d92...,\n        7e0aa3d819f2...,\n        6851f194e144...,\n        cb0552debf21...,\n        3f4deaf145a1...,\n        86828b984346...,\n        f20de1e4e37b...,\n        76bf0fd12bd9...,\n        38e6274601b2...,\n        d58cf9939847...,\n        40f452260bef...,\n        e491352788e5...,\n        6839a6d3d430...,\n        518032f41fd0...,\n        b6d4b2160a76...,\n        c0ff73164651...,\n        10e0333b52bb...,\n        bfcd37bd6b84...,\n        cc348d369011...,\n        057eed1fd48c...,\n        d14e08374fc7...,\n        c1f1f0055879...,\n        6c2c0667393c...,\n        e22bce619ae2...,\n        e4cc67c3264e...,\n        8a7806365bbd...,\n        97b883cd8a2b...,\n        5921708ce82f...,\n        733e38d36a27...,\n        99a2705ed38c...\n      )\n    )\n  ),\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2025-01-06T19:55:19.430608Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@70164894 size=2384 contents=\"\\n\\315\\022\\n\\373\\017\\n\\366\\017\\n\\363\\017\\022 igpmTaUdwWTGh96GplfrnAayzf0NkoGwJ...\">,\n      signedBy = 12206baa196b...\n    ),\n    item = VettedPackages(\n      participant = participant1::12206baa196b...,\n      packages = Seq(\n        7e0aa3d819f2...,\n        6851f194e144...,\n        cb0552debf21...,\n        3f4deaf145a1...,\n        86828b984346...,\n        f20de1e4e37b...,\n        76bf0fd12bd9...,\n        38e6274601b2...,\n        d58cf9939847...,\n        40f452260bef...,\n        e491352788e5...,\n        6839a6d3d430...,\n        518032f41fd0...,\n        b6d4b2160a76...,\n        c0ff73164651...,\n        10e0333b52bb...,\n        bfcd37bd6b84...,\n        cc348d369011...,\n        057eed1fd48c...,\n        d14e08374fc7...,\n        c1f1f0055879...,\n        6c2c0667393c...,\n        e22bce619ae2...,\n        e4cc67c3264e...,\n        8a7806365bbd...,\n        97b883cd8a2b...,\n        5921708ce82f...,\n        733e38d36a27...,\n        99a2705ed38c...\n      )\n    )\n  )\n)"
   },
   "166" : {
-    "command" : "participant1.dars.remove(darHash)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,22db37e3): The DAR DarDescriptor(SHA-256:948b69780faf...,CantonExamples) cannot be removed because its main package 858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4 is in-use by contract ContractId(00c3b774818f6d619872ad1acc7abfeffc98774031a9c5c5476e7ea5eabc468a57ca021220e7ce1c0749452bb5b3f2b863fdf6ac6bbbd40c003f93279e10fac6eddefeb83f)\non domain mydomain::122018ccc2cd....\n  Request: RemoveDar(1220948b69780faf57430a05ecf00acdfa284404d1ea3be0422cd1bab0f13b21ff69)\n  CorrelationId: 22db37e3cad35173fff1b6031508aac8\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, pkg -> 858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4, tid -> 22db37e3cad35173fff1b6031508aac8)\n  Command ParticipantAdministration$dars$.remove invoked from cmd10000056.sc:1"
-  },
-  "264" : {
-    "command" : "val archiveIouCmd = ledger_api_utils.exercise(\"Archive\", Map.empty, iou.event)",
-    "output" : "archiveIouCmd : com.daml.ledger.api.v1.commands.Command = Command(\n  command = Exercise(\n    value = ExerciseCommand(\n      templateId = Some(\n        value = Identifier(\n          packageId = \"858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4\",\n          moduleName = \"Iou\",\n          entityName = \"Iou\"\n        )\n      ),\n.."
+    "command" : "participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
+    "output" : "res21: Boolean = true"
   },
   "161" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
-    "output" : "res21: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220a5fe4bbe1a23da202a16037b3ffda8bb0d0f727792314f55dead1b966a85ab96\",\n  commandId = \"72633ec7-84d9-47ae-bcb9-83bcef402248\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
-  },
-  "187" : {
-    "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\", vetAllPackages = false)",
-    "output" : "darHash : String = \"1220948b69780faf57430a05ecf00acdfa284404d1ea3be0422cd1bab0f13b21ff69\""
-  },
-  "172" : {
-    "command" : "val archiveIouCmd = ledger_api_utils.exercise(\"Archive\", Map.empty, iou.event)",
-    "output" : ".."
-  },
-  "271" : {
-    "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove, participant1.id, packageIds, force = true)",
-    "output" : "res44: com.google.protobuf.ByteString = <ByteString@111e9159 size=2386 contents=\"\\n\\317\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 XoYL5d506CvG943lpHe4QCHJI71ydsC...\">"
-  },
-  "130" : {
-    "command" : "participant1.dars.remove(darHash)",
+    "command" : "participant1.dars.vetting.enable(darHash)",
     "output" : ""
   },
-  "135" : {
-    "command" : "val packageIds = participant1.packages.list().filter(_.sourceDescription == \"CantonExamples\").map(_.packageId)",
-    "output" : "packageIds : Seq[String] = Vector(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n  \"e491352788e56ca4603acc411ffe1a49fefd76ed8b163af86cf5ee5f4c38645b\",\n  \"cb0552debf219cc909f51cbb5c3b41e9981d39f8f645b1f35e2ef5be2e0b858a\",\n  \"38e6274601b21d7202bb995bc5ec147decda5a01b68d57dda422425038772af7\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"6851f194e144b693e63e9034b956c76cef6b5088dd8c66a657ab652a204dba2b\",\n  \"f20de1e4e37b92280264c08bf15eca0be0bc5babd7a7b5e574997f154c00cb78\",\n  \"d79b5d4f1d34702aefd8eee2bfa7618cb45ae771d62a7bf81024ba51985e57ef\",\n.."
+  "176" : {
+    "command" : "participant1.dars.vetting.disable(darHash)",
+    "output" : ""
   },
-  "258" : {
-    "command" : "participant1.packages.remove(packageId)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,153d5083): Package 858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4 is currently in-use by contract ContractId(003a57759d210734c7391c6ee4ac692b88d673d871606ea329770c464c2188c95fca0212202e284610acae9f02c66bd17ea25fb28b824e0e653e9204280c963298c1266681) on domain mydomain::122018ccc2cd.... It may also be in-use by other contracts.\n  Request: RemovePackage(858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4,false)\n  CorrelationId: 153d50836da2eed1391d71acfe226815\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, domain -> mydomain::122018ccc2cd..., pkg -> 858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4, tid -> 153d50836da2eed1391d71acfe226815, contract -> ContractId(003a57759d210734c7391c6ee4ac692b88d673d871606ea329770c464c2188c95fca0212202e284610acae9f02c66bd17ea25fb28b824e0e653e9204280c963298c1266681))\n  Command ParticipantAdministration$packages$.remove invoked from cmd10000103.sc:1"
+  "204" : {
+    "command" : "participant1.dars.vetting.enable(darHash)",
+    "output" : ""
   },
-  "158" : {
-    "command" : "val packageId = participant1.packages.find(\"Iou\").head.packageId",
-    "output" : "packageId : String = \"858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4\""
+  "99" : {
+    "command" : "val mainPackageId = participant1.packages.find(\"Iou\").head.packageId",
+    "output" : "mainPackageId : String = \"7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84\""
+  },
+  "203" : {
+    "command" : "participant1.dars.vetting.enable(examplesDependencyDarHash)",
+    "output" : ""
+  },
+  "218" : {
+    "command" : "txsContainingMainPackage.foreach { tx => participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove,participant1.id,tx.item.packageIds,force = true); participant1.topology.vetted_packages.authorize(TopologyChangeOp.Add,participant1.id,tx.item.packageIds.filterNot(_ == mainPackageId),force = true)}",
+    "output" : ""
   },
   "55" : {
     "command" : "participant2.packages.list_contents(darContent.main)",
     "output" : "res7: Seq[com.digitalasset.canton.participant.admin.v0.ModuleDescription] = Vector(\n  ModuleDescription(name = \"CantonExamples\"),\n  ModuleDescription(name = \"ContractKeys\"),\n  ModuleDescription(name = \"SafePaint\"),\n  ModuleDescription(name = \"LockIou\"),\n  ModuleDescription(name = \"Iou\"),\n  ModuleDescription(name = \"Divulgence\"),\n  ModuleDescription(name = \"Paint\"),\n.."
   },
-  "171" : {
-    "command" : "val iou = participant1.ledger_api.acs.find_generic(participant1.adminParty, _.templateId.isModuleEntity(\"Iou\", \"Iou\"))",
-    "output" : "iou : com.digitalasset.canton.admin.api.client.commands.LedgerApiTypeWrappers.WrappedCreatedEvent = WrappedCreatedEvent(\n  event = CreatedEvent(\n    eventId = \"#1220a5fe4bbe1a23da202a16037b3ffda8bb0d0f727792314f55dead1b966a85ab96:0\",\n    contractId = \"00c3b774818f6d619872ad1acc7abfeffc98774031a9c5c5476e7ea5eabc468a57ca021220e7ce1c0749452bb5b3f2b863fdf6ac6bbbd40c003f93279e10fac6eddefeb83f\",\n    templateId = Some(\n      value = Identifier(\n        packageId = \"858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4\",\n        moduleName = \"Iou\",\n        entityName = \"Iou\"\n      )\n.."
-  },
-  "75" : {
-    "command" : "participant2.topology.vetted_packages.list()",
-    "output" : "res8: Seq[ListVettedPackagesResult] = Vector(\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2024-06-26T13:05:16.427221Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@40831b3c size=2582 contents=\"\\n\\223\\024\\n\\301\\021\\n\\274\\021\\n\\271\\021\\022 G5O1RtGMdOWO3tFgvFFF9ocGTBrwPhCuJ...\">,\n.."
-  },
-  "119" : {
-    "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"1220948b69780faf57430a05ecf00acdfa284404d1ea3be0422cd1bab0f13b21ff69\""
-  },
-  "287" : {
-    "command" : "participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "res46: String = \"1220948b69780faf57430a05ecf00acdfa284404d1ea3be0422cd1bab0f13b21ff69\""
-  },
-  "36" : {
-    "command" : "val dars = participant2.dars.list(filterName = \"CantonExamples\")",
-    "output" : "dars : Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"1220948b69780faf57430a05ecf00acdfa284404d1ea3be0422cd1bab0f13b21ff69\",\n    name = \"CantonExamples\"\n  )\n)"
-  },
-  "146" : {
-    "command" : "val packages = participant1.packages.list().map(_.packageId).toSet",
-    "output" : "packages : Set[String] = HashSet(\n  \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n  \"5921708ce82f4255deb1b26d2c05358b548720938a5a325718dc69f381ba47ff\",\n  \"d79b5d4f1d34702aefd8eee2bfa7618cb45ae771d62a7bf81024ba51985e57ef\",\n  \"99a2705ed38c1c26cbb8fe7acf36bbf626668e167a33335de932599219e0a235\",\n  \"e22bce619ae24ca3b8e6519281cb5a33b64b3190cc763248b4c3f9ad5087a92c\",\n  \"d58cf9939847921b2aab78eaa7b427dc4c649d25e6bee3c749ace4c3f52f5c97\",\n  \"6c2c0667393c5f92f1885163068cd31800d2264eb088eb6fc740e11241b2bf06\",\n  \"1a856cdaa0677615297d90baff5d9618f29796f17a312d98bde6b49094ffeb49\",\n  \"8a7806365bbd98d88b4c13832ebfa305f6abaeaf32cfa2b7dd25c4fa489b79fb\",\n.."
-  },
-  "190" : {
-    "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Add, participant1.id, packageIds)",
-    "output" : "res29: com.google.protobuf.ByteString = <ByteString@1d61b2c7 size=2384 contents=\"\\n\\315\\022\\n\\373\\017\\n\\366\\017\\n\\363\\017\\022 n5vv7NBUSsVA6TKqezir9F4nP8T6GvQaJ...\">"
-  },
-  "47" : {
-    "command" : "participant2.packages.list()",
-    "output" : "res6: Seq[com.digitalasset.canton.participant.admin.v0.PackageDescription] = Vector(\n  PackageDescription(\n    packageId = \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n    sourceDescription = \"CantonExamples\"\n  ),\n  PackageDescription(\n    packageId = \"cc348d369011362a5190fe96dd1f0dfbc697fdfd10e382b9e9666f0da05961b7\",\n    sourceDescription = \"CantonExamples\"\n.."
-  },
-  "200" : {
-    "command" : "participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove, participant1.id, packageIds, force = true)",
-    "output" : "res30: com.google.protobuf.ByteString = <ByteString@4c35bbab size=2386 contents=\"\\n\\317\\022\\n\\375\\017\\n\\370\\017\\n\\365\\017\\b\\001\\022 n5vv7NBUSsVA6TKqezir9F4nP8T6GvQ...\">"
-  },
-  "178" : {
-    "command" : "participant1.dars.remove(darHash)",
+  "114" : {
+    "command" : "participant1.dars.vetting.enable(darHash)",
     "output" : ""
   },
-  "227" : {
-    "command" : "participant1.packages.remove(packageId)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/PACKAGE_OR_DAR_REMOVAL_ERROR(9,dec6e02c): Package 858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4 is currently vetted and available to use.\n  Request: RemovePackage(858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4,false)\n  CorrelationId: dec6e02c141029a18f38df069701ad33\n  Context: Map(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, tid -> dec6e02c141029a18f38df069701ad33)\n  Command ParticipantAdministration$packages$.remove invoked from cmd10000087.sc:1"
-  },
   "222" : {
-    "command" : "val packageId = participant1.packages.find(\"Iou\").head.packageId",
-    "output" : "packageId : String = \"858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4\""
+    "command" : "participant1.topology.check_only_packages.authorize(TopologyChangeOp.Add, participant1.id, Seq(LfPackageId.assertFromString(mainPackageId)), force = true)",
+    "output" : ".."
   },
-  "232" : {
-    "command" : "val packageIds = participant1.topology.vetted_packages.list().map(_.item.packageIds).filter(_.contains(packageId)).head",
-    "output" : "packageIds : Seq[com.digitalasset.canton.package.LfPackageId] = Vector(\n  \"858e7bb622e5be4df263b88af6fad9af584e272423e8dde5dab8a2f58a8feaa4\",\n  \"6851f194e144b693e63e9034b956c76cef6b5088dd8c66a657ab652a204dba2b\",\n.."
+  "100" : {
+    "command" : "participant1.domains.connect_local(mydomain)",
+    "output" : ""
   }
 }

--- a/docs/2.10.0/docs/canton/includes/snippet_data/usermanual/packagemanagement.json
+++ b/docs/2.10.0/docs/canton/includes/snippet_data/usermanual/packagemanagement.json
@@ -1,58 +1,58 @@
 {
-  "101" : {
-    "command" : "val createIouCmd = ledger_api_utils.create(mainPackageId,\"Iou\",\"Iou\",Map(\"payer\" -> participant1.adminParty,\"owner\" -> participant1.adminParty,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
-    "output" : ".."
+  "202" : {
+    "command" : "participant1.topology.check_only_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
+    "output" : "res25: Boolean = true"
+  },
+  "184" : {
+    "command" : "participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
+    "output" : "res22: Boolean = true"
   },
   "20" : {
     "command" : "participant2.dars.upload(\"dars/CantonExamples.dar\")",
     "output" : "res1: String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
   },
-  "132" : {
-    "command" : "participant1.dars.vetting.disable(examplesDependencyDarHash)",
+  "201" : {
+    "command" : "",
     "output" : ""
   },
-  "181" : {
-    "command" : "participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
-    "output" : "res23: Boolean = false"
+  "28" : {
+    "command" : "participant2.dars.list()",
+    "output" : "res2: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12207f38b04c40dd9cf5bc1daa97625427665af959801fc77024dafd5898cb01f01b\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  ),\n  DarDescription(\n    hash = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\",\n    name = \"CantonExamples\"\n  )\n)"
   },
-  "98" : {
+  "236" : {
+    "command" : "import com.digitalasset.canton.LfPackageId",
+    "output" : ""
+  },
+  "103" : {
     "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
     "output" : "darHash : String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
   },
-  "108" : {
-    "command" : "participant1.dars.vetting.disable(darHash)",
+  "223" : {
+    "command" : "participant1.dars.vetting.enable(darHash)",
     "output" : ""
   },
-  "80" : {
-    "command" : "participant2.dars.vetting.enable(hash)",
+  "150" : {
+    "command" : "participant1.dars.vetting.disable(darHash)",
     "output" : ""
   },
   "127" : {
-    "command" : "participant1.dars.vetting.disable(darHash)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/MAIN_DAR_PACKAGE_REFERENCED_EXTERNALLY(9,25d6ffd7): Operation DAR disabling for DAR 'CantonExamples' failed due to its main package with packageId=7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84 being vetted multiple times\n  Request: UnvetDar(12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709,true)\n  CorrelationId: 25d6ffd72b85fb4a13c92c2755007f52\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, darDescription -> CantonExamples, operationName -> DAR disabling, mainPackageId -> 7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84, tid -> 25d6ffd72b85fb4a13c92c2755007f52)\n  Command ParticipantAdministration$dars$vetting$.disable invoked from cmd10000044.sc:1"
-  },
-  "75" : {
-    "command" : "participant2.dars.upload(\"dars/CantonExamples.dar\", vetAllPackages = false)",
-    "output" : "res8: String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
+    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
+    "output" : "res17: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"12207d293dd4befb562b30c3d5daa1e11154d8778aa392e501a217658b204ada5a1e\",\n  commandId = \"5de0a322-032f-425e-bd55-1ac5357b0fd8\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
   },
   "36" : {
     "command" : "val dars = participant2.dars.list(filterName = \"CantonExamples\")",
     "output" : "dars : Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\",\n    name = \"CantonExamples\"\n  )\n)"
   },
-  "126" : {
+  "138" : {
     "command" : "val examplesDependencyDarHash = participant1.dars.upload(\"dars/CantonExamplesDependency.dar\")",
     "output" : "examplesDependencyDarHash : String = \"1220ee0bfbe921a7f88b376b9b35c74d9ff18a4aab9ceacf877b8e1880281518ef7a\""
   },
-  "47" : {
-    "command" : "participant2.packages.list()",
-    "output" : "res6: Seq[com.digitalasset.canton.participant.admin.v0.PackageDescription] = Vector(\n  PackageDescription(\n    packageId = \"88cf65277201722eda8564ac04494bed23ac79673722af482c6f3fb37aec83ed\",\n    sourceDescription = \"AdminWorkflowsWithVacuuming\"\n  ),\n  PackageDescription(\n    packageId = \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n    sourceDescription = \"CantonExamples\"\n.."
+  "88" : {
+    "command" : "participant2.dars.vetting.enable(hash)",
+    "output" : ""
   },
-  "115" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
-    "output" : "res16: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220c52d497fadffb85630554a33d76c4817c144f7c4d6a2acc81b5b192306916418\",\n  commandId = \"26e5d72c-53b8-4470-aae8-54b38c87a2b2\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
-  },
-  "217" : {
-    "command" : "import com.digitalasset.canton.LfPackageId",
+  "185" : {
+    "command" : "",
     "output" : ""
   },
   "42" : {
@@ -63,64 +63,84 @@
     "command" : "val hash = dars.head.hash",
     "output" : "hash : String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
   },
-  "28" : {
-    "command" : "participant2.dars.list()",
-    "output" : "res2: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12207f38b04c40dd9cf5bc1daa97625427665af959801fc77024dafd5898cb01f01b\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  ),\n  DarDescription(\n    hash = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\",\n    name = \"CantonExamples\"\n  )\n)"
-  },
-  "137" : {
-    "command" : "participant1.dars.vetting.disable(darHash)",
+  "179" : {
+    "command" : "participant1.dars.vetting.enable(darHash)",
     "output" : ""
   },
-  "109" : {
+  "106" : {
+    "command" : "val createIouCmd = ledger_api_utils.create(mainPackageId,\"Iou\",\"Iou\",Map(\"payer\" -> participant1.adminParty,\"owner\" -> participant1.adminParty,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
+    "output" : ".."
+  },
+  "121" : {
     "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/NO_DOMAIN_FOR_SUBMISSION(9,b3cbc8e8): No valid domain for submission found.\n  Request: SubmitAndWaitTransactionTree(\n  actAs = participant1::12206baa196b...,\n  readAs = Seq(),\n  commandId = '',\n  workflowId = '',\n  submissionId = '',\n  deduplicationPeriod = None(),\n  applicationId = 'CantonConsole',\n  commands = ...\n)\n  CorrelationId: b3cbc8e81749166ffadf7602e1e908ad\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, domainsNotUsed -> Map(mydomain::12202fd803a2... -> The topology state for some packages does not meet the requirements on domain mydomain::12202fd803a2...: [(Participant PAR::participant1::12206baa196b... has not vetted 7e0aa3d819f2...)]), tid -> b3cbc8e81749166ffadf7602e1e908ad, definite_answer -> false)\n  Command BaseLedgerApiAdministration$ledger_api$commands$.submit invoked from cmd10000036.sc:1"
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/NO_DOMAIN_FOR_SUBMISSION(9,c869040d): No valid domain for submission found.\n  Request: SubmitAndWaitTransactionTree(\n  actAs = participant1::1220a22f7006...,\n  readAs = Seq(),\n  commandId = '',\n  workflowId = '',\n  submissionId = '',\n  deduplicationPeriod = None(),\n  applicationId = 'CantonConsole',\n  commands = ...\n)\n  CorrelationId: c869040d8beb473936360cfde8f175d2\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, domainsNotUsed -> Map(mydomain::1220edc575ff... -> The topology state for some packages does not meet the requirements on domain mydomain::1220edc575ff...: [(Participant PAR::participant1::1220a22f7006... has not vetted 7e0aa3d819f2...)]), tid -> c869040d8beb473936360cfde8f175d2, definite_answer -> false)\n  Command BaseLedgerApiAdministration$ledger_api$commands$.submit invoked from cmd10000038.sc:1"
   },
-  "212" : {
-    "command" : "val txsContainingMainPackage = participant1.topology.vetted_packages.list(filterStore = \"Authorized\", filterParticipant = participant1.id.filterString).filter(_.item.packageIds.contains(mainPackageId))",
-    "output" : "txsContainingMainPackage : Seq[ListVettedPackagesResult] = Vector(\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2025-01-06T19:55:19.094041Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@4604aa42 size=2450 contents=\"\\n\\217\\023\\n\\275\\020\\n\\270\\020\\n\\265\\020\\022 R9IDS7aR3H5zdgkJI1ClZvBYaQmHa31dJ...\">,\n      signedBy = 12206baa196b...\n    ),\n    item = VettedPackages(\n      participant = participant1::12206baa196b...,\n      packages = Seq(\n        28cf6c194d92...,\n        7e0aa3d819f2...,\n        6851f194e144...,\n        cb0552debf21...,\n        3f4deaf145a1...,\n        86828b984346...,\n        f20de1e4e37b...,\n        76bf0fd12bd9...,\n        38e6274601b2...,\n        d58cf9939847...,\n        40f452260bef...,\n        e491352788e5...,\n        6839a6d3d430...,\n        518032f41fd0...,\n        b6d4b2160a76...,\n        c0ff73164651...,\n        10e0333b52bb...,\n        bfcd37bd6b84...,\n        cc348d369011...,\n        057eed1fd48c...,\n        d14e08374fc7...,\n        c1f1f0055879...,\n        6c2c0667393c...,\n        e22bce619ae2...,\n        e4cc67c3264e...,\n        8a7806365bbd...,\n        97b883cd8a2b...,\n        5921708ce82f...,\n        733e38d36a27...,\n        99a2705ed38c...\n      )\n    )\n  ),\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2025-01-06T19:55:19.430608Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@70164894 size=2384 contents=\"\\n\\315\\022\\n\\373\\017\\n\\366\\017\\n\\363\\017\\022 igpmTaUdwWTGh96GplfrnAayzf0NkoGwJ...\">,\n      signedBy = 12206baa196b...\n    ),\n    item = VettedPackages(\n      participant = participant1::12206baa196b...,\n      packages = Seq(\n        7e0aa3d819f2...,\n        6851f194e144...,\n        cb0552debf21...,\n        3f4deaf145a1...,\n        86828b984346...,\n        f20de1e4e37b...,\n        76bf0fd12bd9...,\n        38e6274601b2...,\n        d58cf9939847...,\n        40f452260bef...,\n        e491352788e5...,\n        6839a6d3d430...,\n        518032f41fd0...,\n        b6d4b2160a76...,\n        c0ff73164651...,\n        10e0333b52bb...,\n        bfcd37bd6b84...,\n        cc348d369011...,\n        057eed1fd48c...,\n        d14e08374fc7...,\n        c1f1f0055879...,\n        6c2c0667393c...,\n        e22bce619ae2...,\n        e4cc67c3264e...,\n        8a7806365bbd...,\n        97b883cd8a2b...,\n        5921708ce82f...,\n        733e38d36a27...,\n        99a2705ed38c...\n      )\n    )\n  )\n)"
-  },
-  "166" : {
-    "command" : "participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
-    "output" : "res21: Boolean = true"
-  },
-  "161" : {
-    "command" : "participant1.dars.vetting.enable(darHash)",
-    "output" : ""
-  },
-  "176" : {
-    "command" : "participant1.dars.vetting.disable(darHash)",
-    "output" : ""
-  },
-  "204" : {
-    "command" : "participant1.dars.vetting.enable(darHash)",
-    "output" : ""
-  },
-  "99" : {
-    "command" : "val mainPackageId = participant1.packages.find(\"Iou\").head.packageId",
-    "output" : "mainPackageId : String = \"7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84\""
-  },
-  "203" : {
-    "command" : "participant1.dars.vetting.enable(examplesDependencyDarHash)",
-    "output" : ""
-  },
-  "218" : {
+  "237" : {
     "command" : "txsContainingMainPackage.foreach { tx => participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove,participant1.id,tx.item.packageIds,force = true); participant1.topology.vetted_packages.authorize(TopologyChangeOp.Add,participant1.id,tx.item.packageIds.filterNot(_ == mainPackageId),force = true)}",
     "output" : ""
+  },
+  "105" : {
+    "command" : "participant1.domains.connect_local(mydomain)",
+    "output" : ""
+  },
+  "112" : {
+    "command" : "participant1.dars.vetting.disable(darHash)",
+    "output" : ""
+  },
+  "145" : {
+    "command" : "participant1.dars.vetting.disable(examplesDependencyDarHash)",
+    "output" : ""
+  },
+  "231" : {
+    "command" : "val txsContainingMainPackage = participant1.topology.vetted_packages.list(filterStore = \"Authorized\", filterParticipant = participant1.id.filterString).filter(_.item.packageIds.contains(mainPackageId))",
+    "output" : "txsContainingMainPackage : Seq[ListVettedPackagesResult] = Vector(\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2025-01-07T14:55:47.976708Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@7d7437d2 size=2450 contents=\"\\n\\217\\023\\n\\275\\020\\n\\270\\020\\n\\265\\020\\022 oqOD1a9cLZGccHfE5cZWMJd21OnvyrmcJ...\">,\n      signedBy = 1220a22f7006...\n    ),\n    item = VettedPackages(\n      participant = participant1::1220a22f7006...,\n      packages = Seq(\n        28cf6c194d92...,\n        7e0aa3d819f2...,\n        6851f194e144...,\n.."
+  },
+  "203" : {
+    "command" : "",
+    "output" : ""
+  },
+  "104" : {
+    "command" : "val mainPackageId = participant1.packages.find(\"Iou\").head.packageId",
+    "output" : "mainPackageId : String = \"7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84\""
   },
   "55" : {
     "command" : "participant2.packages.list_contents(darContent.main)",
     "output" : "res7: Seq[com.digitalasset.canton.participant.admin.v0.ModuleDescription] = Vector(\n  ModuleDescription(name = \"CantonExamples\"),\n  ModuleDescription(name = \"ContractKeys\"),\n  ModuleDescription(name = \"SafePaint\"),\n  ModuleDescription(name = \"LockIou\"),\n  ModuleDescription(name = \"Iou\"),\n  ModuleDescription(name = \"Divulgence\"),\n  ModuleDescription(name = \"Paint\"),\n.."
   },
-  "114" : {
-    "command" : "participant1.dars.vetting.enable(darHash)",
-    "output" : ""
+  "139" : {
+    "command" : "participant1.dars.vetting.disable(darHash)",
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/MAIN_DAR_PACKAGE_REFERENCED_EXTERNALLY(9,b583d752): Operation DAR disabling for DAR 'CantonExamples' failed due to its main package with packageId=7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84 being vetted multiple times\n  Request: UnvetDar(12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709,true)\n  CorrelationId: b583d75280e593ba9fdce012ebea166b\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, darDescription -> CantonExamples, operationName -> DAR disabling, mainPackageId -> 7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84, tid -> b583d75280e593ba9fdce012ebea166b)\n  Command ParticipantAdministration$dars$vetting$.disable invoked from cmd10000046.sc:1"
   },
-  "222" : {
+  "107" : {
+    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty ), Seq(createIouCmd))",
+    "output" : "res14: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"12203c1ec2fc1efe30fafca72d0b3267727131fb39937733bb2a58cf0ab24068d4d7\",\n  commandId = \"15fb7888-93cd-47c2-bfd6-aae1547b2970\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
+  },
+  "242" : {
     "command" : "participant1.topology.check_only_packages.authorize(TopologyChangeOp.Add, participant1.id, Seq(LfPackageId.assertFromString(mainPackageId)), force = true)",
     "output" : ".."
   },
-  "100" : {
-    "command" : "participant1.domains.connect_local(mydomain)",
+  "126" : {
+    "command" : "participant1.dars.vetting.enable(darHash)",
+    "output" : ""
+  },
+  "195" : {
+    "command" : "participant1.dars.vetting.disable(darHash)",
+    "output" : ""
+  },
+  "47" : {
+    "command" : "participant2.packages.list()",
+    "output" : "res6: Seq[com.digitalasset.canton.participant.admin.v0.PackageDescription] = Vector(\n  PackageDescription(\n    packageId = \"88cf65277201722eda8564ac04494bed23ac79673722af482c6f3fb37aec83ed\",\n    sourceDescription = \"AdminWorkflowsWithVacuuming\"\n  ),\n  PackageDescription(\n    packageId = \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n    sourceDescription = \"CantonExamples\"\n.."
+  },
+  "200" : {
+    "command" : "participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
+    "output" : "res24: Boolean = false"
+  },
+  "83" : {
+    "command" : "participant2.dars.upload(\"dars/CantonExamples.dar\", vetAllPackages = false)",
+    "output" : "res8: String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
+  },
+  "222" : {
+    "command" : "participant1.dars.vetting.enable(examplesDependencyDarHash)",
     "output" : ""
   }
 }

--- a/docs/2.10.0/docs/canton/includes/snippet_data/usermanual/packagemanagement.json
+++ b/docs/2.10.0/docs/canton/includes/snippet_data/usermanual/packagemanagement.json
@@ -1,43 +1,55 @@
 {
-  "20" : {
-    "command" : "participant2.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "res1: String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
+  "234" : {
+    "command" : "txsContainingMainPackage.foreach { tx => participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove,participant1.id,tx.item.packageIds,force = true); participant1.topology.vetted_packages.authorize(TopologyChangeOp.Add,participant1.id,tx.item.packageIds.filterNot(_ == mainPackageId),force = true)}",
+    "output" : ""
   },
-  "221" : {
+  "84" : {
+    "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\", vetAllPackages = false)",
+    "output" : "darHash : String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
+  },
+  "96" : {
+    "command" : "val createIouCmd = ledger_api_utils.create(mainPackageId,\"Iou\",\"Iou\",Map(\"payer\" -> participant1.adminParty,\"owner\" -> participant1.adminParty,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
+    "output" : ".."
+  },
+  "129" : {
+    "command" : "participant1.dars.vetting.disable(darHash)",
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/MAIN_DAR_PACKAGE_REFERENCED_EXTERNALLY(9,e170807f): Operation DAR disabling for DAR 'CantonExamples' failed due to its main package with packageId=7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84 being vetted multiple times\n  Request: UnvetDar(12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709,true)\n  CorrelationId: e170807f92749b94aa7a5c8a552a4804\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, darDescription -> CantonExamples, operationName -> DAR disabling, mainPackageId -> 7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84, tid -> e170807f92749b94aa7a5c8a552a4804)\n  Command ParticipantAdministration$dars$vetting$.disable invoked from cmd10000044.sc:1"
+  },
+  "128" : {
+    "command" : "val examplesDependencyDarHash = participant1.dars.upload(\"dars/CantonExamplesDependency.dar\")",
+    "output" : "examplesDependencyDarHash : String = \"1220ee0bfbe921a7f88b376b9b35c74d9ff18a4aab9ceacf877b8e1880281518ef7a\""
+  },
+  "176" : {
     "command" : "participant1.dars.vetting.enable(darHash)",
     "output" : ""
   },
-  "229" : {
-    "command" : "val txsContainingMainPackage = participant1.topology.vetted_packages.list(filterStore = \"Authorized\", filterParticipant = participant1.id.filterString).filter(_.item.packageIds.contains(mainPackageId))",
-    "output" : "txsContainingMainPackage : Seq[ListVettedPackagesResult] = Vector(\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2025-01-08T09:55:24.957199Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@71995ebb size=2450 contents=\"\\n\\217\\023\\n\\275\\020\\n\\270\\020\\n\\265\\020\\022 m3cLchRcVzRkHAXHPA1MwuXxp1EG1j3EJ...\">,\n      signedBy = 1220ffcaad4b...\n    ),\n    item = VettedPackages(\n      participant = participant1::1220ffcaad4b...,\n      packages = Seq(\n        28cf6c194d92...,\n        7e0aa3d819f2...,\n        6851f194e144...,\n.."
+  "181" : {
+    "command" : "participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
+    "output" : "res21: Boolean = true"
   },
-  "105" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty ), Seq(createIouCmd))",
-    "output" : "res14: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220737bbbe48ada6eb9e1b2e5e1f14aacf37a324317a5cd4524f9fb71b7d963cb75\",\n  commandId = \"0843265a-4e4f-4e69-bbd2-42bc9cd83331\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
-  },
-  "148" : {
-    "command" : "participant1.dars.vetting.disable(darHash)",
+  "219" : {
+    "command" : "participant1.dars.vetting.enable(examplesDependencyDarHash)",
     "output" : ""
   },
-  "143" : {
+  "135" : {
     "command" : "participant1.dars.vetting.disable(examplesDependencyDarHash)",
+    "output" : ""
+  },
+  "95" : {
+    "command" : "participant1.domains.connect_local(mydomain)",
     "output" : ""
   },
   "55" : {
     "command" : "participant2.packages.list_contents(darContent.main)",
     "output" : "res7: Seq[com.digitalasset.canton.participant.admin.v0.ModuleDescription] = Vector(\n  ModuleDescription(name = \"CantonExamples\"),\n  ModuleDescription(name = \"ContractKeys\"),\n  ModuleDescription(name = \"SafePaint\"),\n  ModuleDescription(name = \"LockIou\"),\n  ModuleDescription(name = \"Iou\"),\n  ModuleDescription(name = \"Divulgence\"),\n  ModuleDescription(name = \"Paint\"),\n.."
   },
-  "136" : {
-    "command" : "val examplesDependencyDarHash = participant1.dars.upload(\"dars/CantonExamplesDependency.dar\")",
-    "output" : "examplesDependencyDarHash : String = \"1220ee0bfbe921a7f88b376b9b35c74d9ff18a4aab9ceacf877b8e1880281518ef7a\""
+  "36" : {
+    "command" : "val dars = participant2.dars.list(filterName = \"CantonExamples\")",
+    "output" : "dars : Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\",\n    name = \"CantonExamples\"\n  )\n)"
   },
-  "101" : {
-    "command" : "val darHash = participant1.dars.upload(\"dars/CantonExamples.dar\")",
-    "output" : "darHash : String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
-  },
-  "234" : {
-    "command" : "import com.digitalasset.canton.LfPackageId",
-    "output" : ""
+  "111" : {
+    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
+    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/NO_DOMAIN_FOR_SUBMISSION(9,67d333be): No valid domain for submission found.\n  Request: SubmitAndWaitTransactionTree(\n  actAs = participant1::1220c1317037...,\n  readAs = Seq(),\n  commandId = '',\n  workflowId = '',\n  submissionId = '',\n  deduplicationPeriod = None(),\n  applicationId = 'CantonConsole',\n  commands = ...\n)\n  CorrelationId: 67d333bed94be4929c64661a19003178\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, domainsNotUsed -> Map(mydomain::12202c2a92d4... -> The topology state for some packages does not meet the requirements on domain mydomain::12202c2a92d4...: [(Participant PAR::participant1::1220c1317037... has not vetted 7e0aa3d819f2...)]), tid -> 67d333bed94be4929c64661a19003178, definite_answer -> false)\n  Command BaseLedgerApiAdministration$ledger_api$commands$.submit invoked from cmd10000036.sc:1"
   },
   "42" : {
     "command" : "val darContent = participant2.dars.list_contents(hash)",
@@ -47,100 +59,84 @@
     "command" : "val hash = dars.head.hash",
     "output" : "hash : String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
   },
-  "110" : {
-    "command" : "participant1.dars.vetting.disable(darHash)",
+  "20" : {
+    "command" : "participant2.dars.upload(\"dars/CantonExamples.dar\")",
+    "output" : "res1: String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
+  },
+  "228" : {
+    "command" : "val txsContainingMainPackage = participant1.topology.vetted_packages.list(filterStore = \"Authorized\", filterParticipant = participant1.id.filterString).filter(_.item.packageIds.contains(mainPackageId))",
+    "output" : "txsContainingMainPackage : Seq[ListVettedPackagesResult] = Vector(\n  ListVettedPackagesResult(\n    context = BaseResult(\n      domain = \"Authorized\",\n      validFrom = 2025-01-09T12:49:35.660209Z,\n      validUntil = None,\n      operation = Add,\n      serialized = <ByteString@74635c96 size=2450 contents=\"\\n\\217\\023\\n\\275\\020\\n\\270\\020\\n\\265\\020\\022 pq2G2mKLZMB05jYDi6GljSDXTmuQ8FUfJ...\">,\n      signedBy = 1220c1317037...\n    ),\n    item = VettedPackages(\n      participant = participant1::1220c1317037...,\n      packages = Seq(\n        28cf6c194d92...,\n        7e0aa3d819f2...,\n        6851f194e144...,\n.."
+  },
+  "89" : {
+    "command" : "participant1.dars.vetting.enable(darHash)",
     "output" : ""
   },
-  "125" : {
+  "116" : {
+    "command" : "participant1.dars.vetting.enable(darHash)",
+    "output" : ""
+  },
+  "233" : {
+    "command" : "import com.digitalasset.canton.LfPackageId",
+    "output" : ""
+  },
+  "117" : {
     "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
-    "output" : "res17: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"12200faa549cb6a8834f70344519bf81cbfa20264d8b158bef4a03881c79f9d1e2cb\",\n  commandId = \"211d35d1-b2ca-447d-bcba-8dcbfd448f40\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
-  },
-  "201" : {
-    "command" : "",
-    "output" : ""
+    "output" : "res16: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220f808522edffc3410e69d2aa48eb299f3a345995b0951a1a522251bc205efec6a\",\n  commandId = \"ff9298e6-b78c-4ba6-8f18-c65779a58457\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
   },
   "220" : {
-    "command" : "participant1.dars.vetting.enable(examplesDependencyDarHash)",
+    "command" : "participant1.dars.vetting.enable(darHash)",
     "output" : ""
   },
   "102" : {
-    "command" : "val mainPackageId = participant1.packages.find(\"Iou\").head.packageId",
-    "output" : "mainPackageId : String = \"7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84\""
+    "command" : "participant1.dars.vetting.disable(darHash)",
+    "output" : ""
   },
   "28" : {
     "command" : "participant2.dars.list()",
     "output" : "res2: Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12207f38b04c40dd9cf5bc1daa97625427665af959801fc77024dafd5898cb01f01b\",\n    name = \"AdminWorkflowsWithVacuuming\"\n  ),\n  DarDescription(\n    hash = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\",\n    name = \"CantonExamples\"\n  )\n)"
   },
-  "137" : {
-    "command" : "participant1.dars.vetting.disable(darHash)",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/MAIN_DAR_PACKAGE_REFERENCED_EXTERNALLY(9,7a5d6802): Operation DAR disabling for DAR 'CantonExamples' failed due to its main package with packageId=7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84 being vetted multiple times\n  Request: UnvetDar(12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709,true)\n  CorrelationId: 7a5d68026107b5b935e392712a2525a4\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, darDescription -> CantonExamples, operationName -> DAR disabling, mainPackageId -> 7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84, tid -> 7a5d68026107b5b935e392712a2525a4)\n  Command ParticipantAdministration$dars$vetting$.disable invoked from cmd10000046.sc:1"
-  },
-  "124" : {
-    "command" : "participant1.dars.vetting.enable(darHash)",
-    "output" : ""
-  },
-  "193" : {
+  "192" : {
     "command" : "participant1.dars.vetting.disable(darHash)",
     "output" : ""
   },
-  "103" : {
-    "command" : "participant1.domains.connect_local(mydomain)",
+  "197" : {
+    "command" : "participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
+    "output" : "res23: Boolean = false"
+  },
+  "97" : {
+    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty ), Seq(createIouCmd))",
+    "output" : "res13: com.daml.ledger.api.v1.transaction.TransactionTree = TransactionTree(\n  transactionId = \"1220659388dfd31751452e0af913535d8c26e9176e0caf23185fd7b7f825276bb1e6\",\n  commandId = \"bb2732c7-64d4-4fec-8696-d491b1574206\",\n  workflowId = \"\",\n  effectiveAt = Some(\n.."
+  },
+  "140" : {
+    "command" : "participant1.dars.vetting.disable(darHash)",
     "output" : ""
   },
-  "240" : {
+  "198" : {
+    "command" : "",
+    "output" : ""
+  },
+  "199" : {
+    "command" : "participant1.topology.check_only_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
+    "output" : "res24: Boolean = true"
+  },
+  "182" : {
+    "command" : "",
+    "output" : ""
+  },
+  "239" : {
     "command" : "participant1.topology.check_only_packages.authorize(TopologyChangeOp.Add, participant1.id, Seq(LfPackageId.assertFromString(mainPackageId)), force = true)",
     "output" : ".."
   },
-  "198" : {
-    "command" : "participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
-    "output" : "res24: Boolean = false"
-  },
-  "199" : {
-    "command" : "",
-    "output" : ""
-  },
-  "177" : {
-    "command" : "participant1.dars.vetting.enable(darHash)",
-    "output" : ""
-  },
-  "182" : {
-    "command" : "participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
-    "output" : "res22: Boolean = true"
-  },
-  "87" : {
-    "command" : "participant2.dars.vetting.enable(hash)",
-    "output" : ""
-  },
-  "104" : {
-    "command" : "val createIouCmd = ledger_api_utils.create(mainPackageId,\"Iou\",\"Iou\",Map(\"payer\" -> participant1.adminParty,\"owner\" -> participant1.adminParty,\"amount\" -> Map(\"value\" -> 100.0, \"currency\" -> \"EUR\"),\"viewers\" -> List()))",
-    "output" : ".."
-  },
-  "119" : {
-    "command" : "participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))",
-    "output" : "ERROR com.digitalasset.canton.integration.EnterpriseEnvironmentDefinition$$anon$3 - Request failed for participant1.\n  GrpcRequestRefusedByServer: FAILED_PRECONDITION/NO_DOMAIN_FOR_SUBMISSION(9,a1fc5ba7): No valid domain for submission found.\n  Request: SubmitAndWaitTransactionTree(\n  actAs = participant1::1220ffcaad4b...,\n  readAs = Seq(),\n  commandId = '',\n  workflowId = '',\n  submissionId = '',\n  deduplicationPeriod = None(),\n  applicationId = 'CantonConsole',\n  commands = ...\n)\n  CorrelationId: a1fc5ba7425689d5d49ee4f420388cca\n  Context: HashMap(participant -> participant1, test -> PackageDarManagementDocumentationIntegrationTest, domainsNotUsed -> Map(mydomain::122031b78160... -> The topology state for some packages does not meet the requirements on domain mydomain::122031b78160...: [(Participant PAR::participant1::1220ffcaad4b... has not vetted 7e0aa3d819f2...)]), tid -> a1fc5ba7425689d5d49ee4f420388cca, definite_answer -> false)\n  Command BaseLedgerApiAdministration$ledger_api$commands$.submit invoked from cmd10000038.sc:1"
-  },
-  "235" : {
-    "command" : "txsContainingMainPackage.foreach { tx => participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove,participant1.id,tx.item.packageIds,force = true); participant1.topology.vetted_packages.authorize(TopologyChangeOp.Add,participant1.id,tx.item.packageIds.filterNot(_ == mainPackageId),force = true)}",
-    "output" : ""
-  },
-  "82" : {
-    "command" : "participant2.dars.upload(\"dars/CantonExamples.dar\", vetAllPackages = false)",
-    "output" : "res8: String = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\""
-  },
-  "36" : {
-    "command" : "val dars = participant2.dars.list(filterName = \"CantonExamples\")",
-    "output" : "dars : Seq[com.digitalasset.canton.participant.admin.v0.DarDescription] = Vector(\n  DarDescription(\n    hash = \"12202102be83f3489f0f3df0d42d54280e6769eb173a8fee8eb02b20f82e1ef5d709\",\n    name = \"CantonExamples\"\n  )\n)"
-  },
-  "183" : {
-    "command" : "",
-    "output" : ""
+  "94" : {
+    "command" : "val mainPackageId = participant1.packages.find(\"Iou\").head.packageId",
+    "output" : "mainPackageId : String = \"7e0aa3d819f2dfd20c1ba08ac133130e1f135172e5c0f4cf0c8a70d79d7b5a84\""
   },
   "47" : {
     "command" : "participant2.packages.list()",
     "output" : "res6: Seq[com.digitalasset.canton.participant.admin.v0.PackageDescription] = Vector(\n  PackageDescription(\n    packageId = \"88cf65277201722eda8564ac04494bed23ac79673722af482c6f3fb37aec83ed\",\n    sourceDescription = \"AdminWorkflowsWithVacuuming\"\n  ),\n  PackageDescription(\n    packageId = \"86828b9843465f419db1ef8a8ee741d1eef645df02375ebf509cdc8c3ddd16cb\",\n    sourceDescription = \"CantonExamples\"\n.."
   },
   "200" : {
-    "command" : "participant1.topology.check_only_packages.list().exists(_.item.packageIds.contains(mainPackageId))",
-    "output" : "res25: Boolean = true"
+    "command" : "",
+    "output" : ""
   }
 }

--- a/docs/2.10.0/docs/canton/usermanual/packagemanagement.rst
+++ b/docs/2.10.0/docs/canton/usermanual/packagemanagement.rst
@@ -17,7 +17,7 @@ comes packaged as one or more DARs that need to be uploaded in the order of thei
 upload DARs to a Canton node: either via the `Ledger Api <https://docs.daml.com/app-dev/grpc/proto-docs.html#com-daml-ledger-api-v1-packageservice>`__,
 or through Canton :ref:`console command <dars.upload>`:
 
-.. snippet:: package_dar_removal
+.. snippet:: package_dar_vetting
     .. success:: participant2.dars.upload("dars/CantonExamples.dar")
 
 Inspecting DARs and Packages
@@ -25,7 +25,7 @@ Inspecting DARs and Packages
 
 You can get a list of uploaded DARs using:
 
-.. snippet:: package_dar_removal
+.. snippet:: package_dar_vetting
     .. success:: participant2.dars.list()
 
 Please note that the package "AdminWorkflows" is a package that ships with Canton. It contains the Daml templates
@@ -33,18 +33,18 @@ used by the ``participant.health.ping`` command.
 
 In order to inspect the contents of the DAR, you need to grab the hash identifying it:
 
-.. snippet:: package_dar_removal
+.. snippet:: package_dar_vetting
     .. success:: val dars = participant2.dars.list(filterName = "CantonExamples")
     .. success:: val hash = dars.head.hash
 
 Using that hash, you can inspect the contents of the DAR using:
 
-.. snippet:: package_dar_removal
+.. snippet:: package_dar_vetting
     .. success(output=8):: val darContent = participant2.dars.list_contents(hash)
 
 You can also directly look at the packages, using:
 
-.. snippet:: package_dar_removal
+.. snippet:: package_dar_vetting
     .. success(output=8):: participant2.packages.list()
 
 Please note that a DAR can include packages that are already included in other DARs. In particular the Daml standard library
@@ -52,7 +52,7 @@ are shipped with every DAR. Therefore, the ``sourceDescription`` will always con
 
 You can also inspect the content of a package, using:
 
-.. snippet:: package_dar_removal
+.. snippet:: package_dar_vetting
     .. success(output=8):: participant2.packages.list_contents(darContent.main)
 
 .. _package_vetting:
@@ -61,235 +61,163 @@ Understanding Package Vetting
 -----------------------------
 
 Every participant operator uploads DARs individually to their participant node. There is no global DAR repository
-anywhere and participants do not have access to each others DAR repositories. Therefore, for two participants to
-synchronise on a transaction that uses packages contained in a certain DAR, we need both participant operators to
-have uploaded the same DAR before the transaction was submitted.
+anywhere and participants do not have access to each others DAR repositories. Instead, participants publicly declare towards their peers
+that they are ready to receive transactions referring to certain packages. This is done by vetting topology transactions which can be seen
+by all the participants connected to a specific domain.
+Therefore, for two participants to synchronise on a transaction that uses packages contained in a certain DAR, both participant operators
+must upload and enable vetting for the same DAR and its contained packages before the transaction is submitted.
 
 If one of the involved participants doesn't know about a certain DAR, then the transaction will bounce with an error
 ``NO_DOMAIN_FOR_SUBMISSION`` (with additional metadata listing which package has not been vetted on which participant).
+This can happen if the DAR has not been uploaded to the participant node or it has not been vetted. Vetting happens
+automatically when you upload a DAR, although it can be disabled by a request flag.
 
-This error goes back to the fact that both participants not only upload the DAR, but also publicly declare towards
-their peers that they are ready to receive transactions referring to certain packages. This declaration happens
-automatically when you upload a DAR. The package vettings can be inspected using (preview):
+.. snippet:: package_dar_vetting
+    .. success:: participant2.dars.upload("dars/CantonExamples.dar", vetAllPackages = false)
 
-.. snippet:: package_dar_removal
-    .. success(output=8):: participant2.topology.vetted_packages.list()
+Vetting can also be enabled explicitly for a DAR's packages (e.g. if the DAR upload operation was triggerred without vetting)
+
+.. snippet:: package_dar_vetting
+    .. success:: participant2.dars.vetting.enable(hash)
 
 Vetting is necessary, as otherwise, a malicious participant might send a transaction referring to package a receiver
 does not have, which would make it impossible for the receiver to process the transaction, leading to a ledger fork.
 As transactions are valid only if all involved participants have vetted the used packages, this attack cannot happen.
 
-Removing Packages and DARs
---------------------------
+The unit of vettable Daml code is a Daml package. In practice, for ensuring consistency,
+the high-level Canton APIs act on vetting at the DAR level (i.e. for all of a DAR's packages).
 
-.. note::
+DAR vetting lifecycle
+~~~~~~~~~~~~~~~~~~~~~
 
-    Note that package and DAR removal is under active development. The behaviour described in this documentation may
-    change in the future. Package and DAR removal is a preview feature and should not be used in production.
+As mentioned above, a participant can start accepting transactions that reference a DAR's packages after the DAR has been uploaded
+and its vetting enabled.
 
-Canton supports removal of both packages and DARs that are no longer in use. Removing unused packages and DARs has the following advantages:
+Let's upload a DAR and create a contract that references the main package from the DAR:
 
-- Freeing up storage
-
-- Preventing accidental use of the old package / DAR
-
-- Reducing the number of packages / DARs that are trusted and may potentially have to be audited
-
-
-
-Certain conditions must to be met in order to remove packages or DARs. These conditions are designed to prevent removal of packages or DARs that are currently in use.
-The rest of this page describes the requirements.
-
-Removing DARs
-~~~~~~~~~~~~~
-
-The following checks are performed before a DAR can be removed:
-
-- The main package of the DAR must be unused -- there should be no active contract from this package
-
-- All package dependencies of the DAR should either be unused or contained in another of the participant node's uploaded DARs. Canton uses this restriction to ensure that the package dependencies of the DAR don't become "stranded" if they're in use.
-
-- The main package of the dar should not be vetted. If it is vetted, Canton will try to automatically revoke the vetting for the main package of the DAR, but this automatic vetting revocation will only succeed if the main package vetting originates from a standard ``dars.upload``. Even if the automatic revocation fails, you can always manually revoke the package vetting.
-
-The following tutorial shows how to remove a DAR with the Canton console. The first step is to upload a DAR so that
-we have one to remove. Additionally, store the packages that are present before the DAR is uploaded, as these can be
-used to double-check that DAR removal reverts to a clean state.
-
-.. snippet:: package_dar_removal
-    .. success(output=10):: val packagesBefore = participant1.packages.list().map(_.packageId).toSet
+.. snippet:: package_dar_vetting
     .. success:: val darHash = participant1.dars.upload("dars/CantonExamples.dar")
-
-If the DAR hash is unknown, it can be found using ``dars.list``:
-
-.. snippet:: package_dar_removal
-    .. success:: val darHash_ = participant1.dars.list().filter(_.name == "CantonExamples").head.hash
-    .. assert:: darHash == darHash_
-
-The DAR can then be removed with the following command:
-
-.. snippet:: package_dar_removal
-    .. success:: participant1.dars.remove(darHash)
-
-Note that, right now, DAR removal will only remove the main packages associated with the DAR:
-
-.. snippet:: package_dar_removal
-    .. success(output=10):: val packageIds = participant1.packages.list().filter(_.sourceDescription == "CantonExamples").map(_.packageId)
-
-It's possible to remove each of these manually, using package removal. There is a complication here that packages needed
-for admin workflows (e.g. the Ping command) cannot be removed, so these are skipped.
-
-.. snippet:: package_dar_removal
-    .. success(output=5):: packageIds.filter(id => ! packagesBefore.contains(id)).foreach(id => participant1.packages.remove(id))
-
-The following command verifies that all the packages have been removed.
-
-.. snippet:: package_dar_removal
-    .. success(output=10):: val packages = participant1.packages.list().map(_.packageId).toSet
-    .. success:: assert(packages == packagesBefore)
-
-The following sections explain what happens when the DAR removal operation goes wrong, for various reasons.
-
-Main package of the DAR is in use
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The first step to illustrate this is to upload a DAR and create a contract using the main package of the DAR:
-
-.. snippet:: package_dar_removal
-    .. success:: val darHash = participant1.dars.upload("dars/CantonExamples.dar")
-    .. success:: val packageId = participant1.packages.find("Iou").head.packageId
+    .. success:: val mainPackageId = participant1.packages.find("Iou").head.packageId
     .. success:: participant1.domains.connect_local(mydomain)
-    .. success(output=0):: val createIouCmd = ledger_api_utils.create(packageId,"Iou","Iou",Map("payer" -> participant1.adminParty,"owner" -> participant1.adminParty,"amount" -> Map("value" -> 100.0, "currency" -> "EUR"),"viewers" -> List()))
+    .. success(output=0):: val createIouCmd = ledger_api_utils.create(mainPackageId,"Iou","Iou",Map("payer" -> participant1.adminParty,"owner" -> participant1.adminParty,"amount" -> Map("value" -> 100.0, "currency" -> "EUR"),"viewers" -> List()))
+.. success(output=5):: participant1.ledger_api.commands.submit(Seq(participant1.adminParty ), Seq(createIouCmd))
+
+The vetting of a DAR can be disabled, effectively preventing its use in Daml transactions.
+Any subsequent commands attempting to create or exercise choices on contracts for the referenced package IDs will now be rejected.
+
+.. snippet:: package_dar_vetting
+    .. success:: participant1.dars.vetting.disable(darHash)
+    .. failure:: participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))
+
+If the decision to support the DAR changes, its vetting can be re-enabled:
+
+.. snippet:: package_dar_vetting
+    .. success:: participant1.dars.vetting.enable(darHash)
     .. success(output=5):: participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))
 
-Now that a contract exists using the main package of the DAR, a subsequent DAR removal operation will fail:
+.. _multi_vetted_package:
 
-.. snippet:: package_dar_removal
-    .. failure:: participant1.dars.remove(darHash)
+What if a package is vetted multiple times?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In order to remove the DAR, we must archive this contract. Note that the contract ID for this contract can also be found in the error message above.
+We can't disable the vetting for a DAR whose main package is referenced as part of a distinct vetted DAR.
+For example, let's upload a DAR that depends on the "CantonExamples" DAR and try to disable vetting for the latter:
 
-.. snippet:: package_dar_removal
-    .. success(output=10):: val iou = participant1.ledger_api.acs.find_generic(participant1.adminParty, _.templateId.isModuleEntity("Iou", "Iou"))
-    .. success(output=0):: val archiveIouCmd = ledger_api_utils.exercise("Archive", Map.empty, iou.event)
-    .. success(output=5):: participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(archiveIouCmd))
+.. snippet:: package_dar_vetting
+    .. success:: val examplesDependencyDarHash = participant1.dars.upload("dars/CantonExamplesDependency.dar")
+    .. failure:: participant1.dars.vetting.disable(darHash)
 
-The DAR removal operation will now succeed.
+Now, if we disable the vetting for the "CantonExamplesDependency" DAR,
 
-.. snippet:: package_dar_removal
-    .. success:: participant1.dars.remove(darHash)
+.. snippet:: package_dar_vetting
+    .. success:: participant1.dars.vetting.disable(examplesDependencyDarHash)
 
-Main package of the DAR can't be automatically removed
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+then we can continue by disabling the vetting for the "CantonExamples" DAR as well.
 
-Similarly, DAR removal may fail because the DAR can't be automatically removed. To illustrate this, upload the DAR
-without automatic vetting and subsequently vet all the packages manually.
+.. snippet:: package_dar_vetting
+    .. success:: participant1.dars.vetting.disable(darHash)
 
-.. snippet:: package_dar_removal
-    .. success:: val darHash = participant1.dars.upload("dars/CantonExamples.dar", vetAllPackages = false)
-    .. success:: import com.daml.lf.data.Ref.IdString.PackageId
-    .. success(output=3):: val packageIds = participant1.packages.list().filter(_.sourceDescription == "CantonExamples").map(_.packageId).map(PackageId.assertFromString)
-    .. success:: participant1.topology.vetted_packages.authorize(TopologyChangeOp.Add, participant1.id, packageIds)
+Advanced vetting concepts
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The DAR removal operation will now fail:
-
-.. snippet:: package_dar_removal
-    .. failure:: participant1.dars.remove(darHash)
-
-The DAR can be successfully removed after manually revoking the vetting for the main package:
-
-.. snippet:: package_dar_removal
-    .. success(output=5):: participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove, participant1.id, packageIds, force = true)
-    .. success:: participant1.dars.remove(darHash)
-
-Note that a ``force`` flag is needed used to revoke the package vetting; throughout this tutorial ``force`` will be used whenever a package vetting is being removed.
-See :ref:`topology.vetted_packages.authorize <topology.vetted_packages.authorize>` for more detail.
-
-
-Removing Packages
-~~~~~~~~~~~~~~~~~
-
-Canton also supports removing individual packages, giving the user more fine-grained control over the system.
-Packages can be removed if the package satisfies the following two requirements:
-
-- The package must be unused. This means that there shouldn't be an active contract corresponding to the package.
-
-- The package must not be vetted. This means there shouldn't be an active vetting transaction corresponding to the package.
-
-The following tutorial shows how to remove a package using the Canton console. The first step is to upload and identify the
-package ID for the package to be removed.
-
-.. snippet:: package_dar_removal
-    .. success:: val darHash = participant1.dars.upload("dars/CantonExamples.dar")
-    .. success:: val packageId = participant1.packages.find("Iou").head.packageId
-
-Package removal will initially fail as, by default, uploading the DAR will add a vetting transaction for the package:
-
-.. snippet:: package_dar_removal
-    .. failure:: participant1.packages.remove(packageId)
-
-The vetting transaction must be manually revoked:
-
-.. snippet:: package_dar_removal
-    .. success(output=3):: val packageIds = participant1.topology.vetted_packages.list().map(_.item.packageIds).filter(_.contains(packageId)).head
-    .. success(output=5):: participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove, participant1.id, packageIds, force = true)
-
-And then the package can be removed:
-
-.. snippet:: package_dar_removal
-    .. success:: participant1.packages.remove(packageId)
-
-
-Package is in use
-^^^^^^^^^^^^^^^^^
-
-The operations above will fail if the package is in use. To illustrate this, first re-upload the package (uploading the associated DAR will work):
-
-.. snippet:: package_dar_removal
-    .. success:: val darHash = participant1.dars.upload("dars/CantonExamples.dar")
-
-Then create a contract using the package:
-
-.. snippet:: package_dar_removal
-    .. success(output=5):: val createIouCmd = ledger_api_utils.create(packageId,"Iou","Iou",Map("payer" -> participant1.adminParty,"owner" -> participant1.adminParty,"amount" -> Map("value" -> 100.0, "currency" -> "EUR"),"viewers" -> List()))
-    .. success(output=10):: participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(createIouCmd))
-
-In this situation, the package cannot be removed:
-
-.. snippet:: package_dar_removal
-    .. failure:: participant1.packages.remove(packageId)
-
-To remove the package, first archive the contract:
-
-.. snippet:: package_dar_removal
-    .. success(output=10):: val iou = participant1.ledger_api.acs.find_generic(participant1.adminParty, _.templateId.isModuleEntity("Iou", "Iou"))
-    .. success(output=10):: val archiveIouCmd = ledger_api_utils.exercise("Archive", Map.empty, iou.event)
-    .. success(output=12):: participant1.ledger_api.commands.submit(Seq(participant1.adminParty), Seq(archiveIouCmd))
-
-Then revoke the package vetting transaction:
-
-.. snippet:: package_dar_removal
-    .. success(output=3):: val packageIds = participant1.topology.vetted_packages.list().map(_.item.packageIds).filter(_.contains(packageId)).head
-    .. success:: participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove, participant1.id, packageIds, force = true)
-
-The package removal operation should now succeed.
-
-.. snippet:: package_dar_removal
-    .. success:: participant1.packages.remove(packageId)
-
-Force-removing packages
+Package topology states
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Packages can also be forcibly removed, even if the conditions above are not satisfied. This is done by setting the
-``force`` flag to ``true``.
+With respect to a participant, a package can be in one of the following states:
 
-To experiment with this, first re-upload the DAR so the package becomes available again:
+- **Not found** on the participant: The package does not exist in the local participant stores and it can't be referenced in any request to the participant node.
 
-.. snippet:: package_dar_removal
-    .. success:: participant1.dars.upload("dars/CantonExamples.dar")
+- **Unknown**: The package may exist in the local participant stores, but it has no associated topology transaction issued by the participant node (i.e. it is unknown topology-wise). A package pertaining to a DAR that was uploaded with the vetting flag disabled is unknown.
 
-Then force-remove the package:
+- **Check-only**: This concept has been introduced in protocol version 7 for supporting :ref:`Smart contract upgrades <smart-contract-upgrades>` and it allows a participant to announce via a `CheckOnlyPackages` topology transaction that a collection of Daml packages are known but can only be used for validating pre-existing contracts on the ledger and not for executing new Daml transactions.
 
-.. snippet:: package_dar_removal
-    .. success:: participant1.packages.remove(packageId, force = true)
+- **Vetted**: This state is unchanged from the previous protocol versions. A package in this state appears at least in a `VettedPackages` topology transaction and allows the participant to accept new transactions that reference it in Daml action nodes.
 
-Please note, this is a dangerous operation. Forced removal of packages should be avoided whenever possible.
+For a package that is unknown (topology-wise), the vetting operation issues a `VettedPackages` topology transaction for the
+submitting participant node referencing all the packages in the DAR.
+
+To exemplify, let's vet the examples DAR again:
+
+.. snippet:: package_dar_vetting
+    .. success:: participant1.dars.vetting.enable(darHash)
+
+Now, we can check that the DAR's main package-id appears in a `VettedPackages` topology transaction:
+
+.. snippet:: package_dar_vetting
+    .. success(output=1):: participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))
+.. assert:: RES
+
+.. note::
+    On enabling the vetting for a DAR, if it exists, the `CheckOnlyPackages` topology transaction is eventually removed.
+    However, this operation is done asynchronously and does not block the vetting API call.
+
+Once we disable the package's DAR vetting,
+
+.. snippet:: package_dar_vetting
+    .. success:: participant1.dars.vetting.disable(darHash)
+
+the package-id will appear only in a `CheckOnlyPackages` topology transaction:
+
+.. snippet:: package_dar_vetting
+    .. success(output=1):: participant1.topology.vetted_packages.list().exists(_.item.packageIds.contains(mainPackageId))
+.. assert:: RES == false
+.. success(output=1):: participant1.topology.check_only_packages.list().exists(_.item.packageIds.contains(mainPackageId))
+.. assert:: RES
+
+Toggling between the two states effectively always issues two topology operations:
+
+- **On vetting enable**: A `VettedPackages` topology transaction addition and the removal of the `CheckOnlyPackages` topology transaction
+
+- **On vetting disable**: A `CheckOnlyPackages` topology transaction addition and the removal of the `VettedPackages` topology transaction
+
+Forcefully unvetting a package
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In some cases, you might want to circumvent the high-level vetting APIs
+and directly issue or revoke package topology transactions.
+One such example is when a package is referenced in multiple topology transactions (e.g. the package is contained in multiple vetted DARs uploaded on the participant)
+and it can't be automatically unvetted (as exemplified in the :ref:`multi_vetted_package`).
+
+To build the example, let's re-enable vetting for both the `CantonExamples` the `CantonExamplesDependency` DARs.
+
+.. snippet:: package_dar_vetting
+    .. success:: participant1.dars.vetting.enable(examplesDependencyDarHash)
+    .. success:: participant1.dars.vetting.enable(darHash)
+
+In order to mark a the main package of the `CantonExamples` DAR as check-only, we need to remove it from all the
+`VettedPackages` topology transactions it appears in. We'll do so by using the low-level topology management API.
+
+First, we need to identify the topology transactions containing the package that we need to disable:
+
+.. snippet:: package_dar_vetting
+    .. success:: val txsContainingMainPackage = participant1.topology.vetted_packages.list(filterStore = "Authorized", filterParticipant = participant1.id.filterString).filter(_.item.packageIds.contains(mainPackageId))
+
+Then, we replace the `VettedPackages` transactions with ones not referring to the main package.
+
+.. snippet:: package_dar_vetting
+    .. success:: import com.digitalasset.canton.LfPackageId
+    .. success:: txsContainingMainPackage.foreach { tx => participant1.topology.vetted_packages.authorize(TopologyChangeOp.Remove,participant1.id,tx.item.packageIds,force = true); participant1.topology.vetted_packages.authorize(TopologyChangeOp.Add,participant1.id,tx.item.packageIds.filterNot(_ == mainPackageId),force = true)}
+
+Additionally, we make sure the package becomes check-only by issuing a dedicated `CheckOnlyPackages` topology transaction.
+.. snippet:: package_dar_vetting
+    .. success(output=0):: participant1.topology.check_only_packages.authorize(TopologyChangeOp.Add, participant1.id, Seq(LfPackageId.assertFromString(mainPackageId)), force = true)

--- a/docs/2.10.0/docs/canton/usermanual/packagemanagement.rst
+++ b/docs/2.10.0/docs/canton/usermanual/packagemanagement.rst
@@ -48,7 +48,7 @@ You can also directly look at the packages, using:
     .. success(output=8):: participant2.packages.list()
 
 Please note that a DAR can include packages that are already included in other DARs. In particular the Daml standard library
-are shipped with every DAR. Therefore, the ``sourceDescription`` will always contain only one textual reference to a DAR.
+is shipped with every DAR. Therefore, the ``sourceDescription`` will always contain only one textual reference to a DAR.
 
 You can also inspect the content of a package, using:
 


### PR DESCRIPTION
@mziolekda @rgugliel-da @simonmaxen-da The main purpose of this PR is:
- document the package topology state and UX after the introduction of tri-state vetting
- prepare this section for an LTS Canton version. More specifically, I thought of cleaning up references to unsupported operations such as DAR and package removal. We will still have endpoints supporting these but we don't advertise them

Hint for reviewing: Since it also has code snippets, `live-preview` is not enough for reviewing this PR. I advise reviewers to use `docs/2.10.0/bin/build`