### PR TITLE
Remove Explicit Template Versions from upgrading docs

### DIFF
--- a/docs/2.10.0/docs/single-domain/extend-model.rst
+++ b/docs/2.10.0/docs/single-domain/extend-model.rst
@@ -32,7 +32,7 @@ Templates specify:
 
 - fields and data types that define the contract payload information upon creation
 - `signatory <https://docs.daml.com/concepts/ledger-model/ledger-integrity.html#signatories-agreements-and-maintainers>`_, whose authorization is required for the creation of the contract
-- choices, which are actions that a :doc:`controller </daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Account-Account>` can take on a contract
+- choices, which are actions that a :doc:`controller </daml-finance/reference/code-documentation/daml-finance-rst/Daml-Finance-Account-V4-Account>` can take on a contract
 
 **Create a RejectedTransferOffer Template**
 

--- a/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
+++ b/docs/2.10.0/docs/upgrade/smart-contract-upgrades.rst
@@ -2058,17 +2058,6 @@ project that uses retroactive instances, you must move the instances to their re
 during the migration.
 See `Limitations <#limitations>`__ for more information.
 
-Explicit Template Versions
---------------------------
-
-If you need package version-specific behavior that does not depend on
-the presence or absence of new fields, you can
-tag your contracts in their payload with an explicit version field.
-This makes
-"partial upgrades" (where a user may only upgrade part of the payload of
-a package, intentionally) less fragile, and allows you to model rollbacks as upgrades
-in a principled manner.
-
 Avoid Contract Metadata Changes
 -------------------------------
 


### PR DESCRIPTION
Decided together with @meiersi-da and @hrischuk-da to remove as it's not targeting general enough use cases and might lead to confusion. CC @remyhaemmerle-da 