### PR TITLE
Add clarifying paragraph to One-Step Migration

### DIFF
--- a/docs/2.10.0/docs/canton/usermanual/upgrading.rst
+++ b/docs/2.10.0/docs/canton/usermanual/upgrading.rst
@@ -778,7 +778,7 @@ One-Step Migration
 ------------------
 
 The term *one-step migration* refers to upgrading the Canton binary version
-*and* the protocol version with a unified, well-tested, multi-step recipe.
+*and* the protocol version with a unified multi-step recipe.
 
 *One-step migrations* cover a :ref:`binary upgrade <upgrade_canton_binary>` from Canton version 2.3 and following minor versions
 up to a new minor release version. Additionally, it :ref:`changes the protocol version <change_pv>` supported by

--- a/docs/2.10.0/docs/canton/usermanual/upgrading.rst
+++ b/docs/2.10.0/docs/canton/usermanual/upgrading.rst
@@ -780,7 +780,7 @@ One-Step Migration
 The term *one-step migration* refers to upgrading the Canton binary version
 *and* the protocol version with a unified multi-step recipe.
 
-*One-step migrations* cover a :ref:`binary upgrade <upgrade_canton_binary>` from Canton version 2.3 and following minor versions
+*One-step migration* covers a :ref:`binary upgrade <upgrade_canton_binary>` from Canton version 2.3 and following minor versions
 up to a new minor release version. Additionally, it :ref:`changes the protocol version <change_pv>` supported by
 these prior releases to a protocol version supported by this new minor release version
 (see also the :ref:`protocol version table <release-version-to-protocol-version-table>`).

--- a/docs/2.10.0/docs/canton/usermanual/upgrading.rst
+++ b/docs/2.10.0/docs/canton/usermanual/upgrading.rst
@@ -777,9 +777,12 @@ a while for large numbers of contracts.
 One-Step Migration
 ------------------
 
-The *one-step migration* covers a :ref:`binary upgrade <upgrade_canton_binary>` from Canton version 2.3 and following minor versions
-up to this minor release version. Additionally, it :ref:`changes the protocol version <change_pv>` supported by
-these prior releases to a protocol version supported by this minor release version
+The term *one-step migration* refers to upgrading the Canton binary version
+*and* the protocol version with a unified, well-tested, multi-step recipe.
+
+*One-step migrations* cover a :ref:`binary upgrade <upgrade_canton_binary>` from Canton version 2.3 and following minor versions
+up to a new minor release version. Additionally, it :ref:`changes the protocol version <change_pv>` supported by
+these prior releases to a protocol version supported by this new minor release version
 (see also the :ref:`protocol version table <release-version-to-protocol-version-table>`).
 
 .. note::
@@ -796,8 +799,8 @@ these prior releases to a protocol version supported by this minor release versi
     tests, and its steps are known to work, additional measures and configuration may be required to
     address the peculiarities of your environment.
 
-Migration Recipe for 2.10
-~~~~~~~~~~~~~~~~~~~~~~~~~
+One-Step Migration Recipe for 2.10
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This recipe allows you to upgrade the Canton binary to release version 2.10 and migrate your sync domain to a new sync domain running protocol version 7.
 
 .. note::

--- a/docs/2.10.0/docs/canton/usermanual/upgrading.rst
+++ b/docs/2.10.0/docs/canton/usermanual/upgrading.rst
@@ -796,8 +796,8 @@ these prior releases to a protocol version supported by this minor release versi
     tests, and its steps are known to work, additional measures and configuration may be required to
     address the peculiarities of your environment.
 
-One-Step Migration Recipe for 2.10
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Migration Recipe for 2.10
+~~~~~~~~~~~~~~~~~~~~~~~~~
 This recipe allows you to upgrade the Canton binary to release version 2.10 and migrate your sync domain to a new sync domain running protocol version 7.
 
 .. note::


### PR DESCRIPTION
~This PR changes the heading "One-Step Migration Recipe for 2.10" to simply "Migration Recipe for 2.10".~ _EDIT: This PR adds a new short paragraph to more explicitly define the term "one-step migration."_

~The original intent of the heading was probably based on the idea of a single migration step from any 2.3+ directly to 2.10, instead of having to go through each intermediate major release version.~ _Edit: this is wrong, as discussed in the comments._

However, the text itself uses "steps" to enumerate the steps of the recipe. The reader may not understand what was meant by the current heading.