### PR TITLE
[8946] update contract key uniqueness caveats

### DIFF
--- a/docs/2.10.0/docs/canton/usermanual/contract_keys.rst
+++ b/docs/2.10.0/docs/canton/usermanual/contract_keys.rst
@@ -323,6 +323,7 @@ Caveats:
   Instead, delegate appropriate adaptations of ``Deallocate`` on the corresponding ``KeyState`` contract.
   This ensures the above restriction that ``Keyed`` contracts are created and archived only through the ``KeyState`` contract choices.
   Non-consuming choices on ``Keyed`` contracts can be delegated without restrictions.
+  And so can all the choices on ``KeyState``.
   
 A usage example script is below.
 

--- a/docs/2.10.0/docs/canton/usermanual/contract_keys.rst
+++ b/docs/2.10.0/docs/canton/usermanual/contract_keys.rst
@@ -278,7 +278,7 @@ Caveats to keep in mind are:
   However, this is easy to change.
 - This approach relies on a particular internal behavior of Canton (as discussed below).
   While we don't expect the behavior to change, we do not currently make strong guarantees that it will not change.
-- If the participant is connected to multiple sync domains in future versions of Canton, the ``Generator`` contract will not guarantee uniqueness, as explained below.
+- If the participant is connected to multiple sync domains in future versions of Canton, the ``Generator`` contract cannot guarantee uniqueness, as explained below.
   To be future-proof, you should only use the ``Generator`` approach in settings when your participant is connected to a single sync domain.
 
 A usage example script is below.
@@ -295,7 +295,7 @@ As the server writes the results of accepted commands to its database atomically
 
 If the participant is connected to multiple sync domains, the ``Generator`` contract can be reassigned between those sync domains.
 Around such reassignments, it can happen that the Ledger API server already starts processing a command on the target sync domain before it has completely processed everything prior to the reassignment on the source sync domain.
-So the processing on the target sync domain does not necessarily see all key ``Keyed`` contracts created by predecessors of the current ``Generator`` contract and therefore may create contracts with the same key multiple times.
+The processing on the target sync domain does not necessarily see all key ``Keyed`` contracts created by predecessors of the current ``Generator`` contract, and therefore may create contracts with the same key multiple times.
 
 
 Setting: Single Maintainer, Multiple Participants

--- a/docs/2.10.0/docs/canton/usermanual/contract_keys.rst
+++ b/docs/2.10.0/docs/canton/usermanual/contract_keys.rst
@@ -299,21 +299,24 @@ Setting: Single Maintainer, Multiple Participants
 Ensuring uniqueness with multiple participants is more complicated, and adds more restrictions on how you operate on the contract.
 
 When there is a single maintainer hosted on multiple participant nodes,
-the ``Generator`` approach works only under the following additional restrictions:
+the ``Generator`` approach works only under the following additional restriction:
 
 - The ``Generator`` contract is never used with explicit disclosure.
 
-The correctness argument is more complicated than in the single-participant setting:
+The correctness argument is now more complicated than in the single-participant setting:
 Since the ``Generate`` choice is consuming and there is at most one ``Generator`` contract at any time,
 the ``Generator`` contract evolves sequentially, where the order is determined by the single sync domain that orders the ``Generate`` commands.
-However, the ``lookupByKey`` operation is evaluated locally on the participant nodes in a possibly different order.
-Without explicit disclosure, the command can successfully exercise a choice on a ``Generator`` contract only after the submitting participant has processed the transaction that created the ``Generator`` contract.
+However, the ``lookupByKey`` operation is evaluated locally on the participant nodes possibly in a different order.
+Without explicit disclosure, a command can successfully exercise a choice on a ``Generator`` contract only after the submitting participant has processed the transaction that created the ``Generator`` contract, because the partipant must fetch the ``Generator`` contract from its database.
 So if the ``Generator`` contract is still active when the command is ordered on the sync domain,
-this means that no other ``Keyed`` contract was created in the meantime.
-Together with atomic database updates for transaction processing, uniqueness is guaranteed.
-Note how this argument breaks when the ``Generator`` contract is explicitly disclosed: then the partipant node can exercise a choice on a ``Generator`` contract before it has processed the transaction that creates it.
+no other ``Keyed`` contract was created in the meantime and a negative ``lookupByKey`` is correct.
+Together with atomic database updates for transaction processing, uniqueness is therefore guaranteed.
+This argument breaks when the ``Generator`` contract is explicitly disclosed:
+then the partipant node can exercise a choice on a ``Generator`` contract before it has processed the transaction that creates it.
 
-In the single-participant setting, explicit disclosure is not a problem because the explicit disclosure can only be obtained via the Ledger API of the single participant that also submits the next command. The participant thus has processed the creating transaction already and sees the created ``Keyed`` contracts.
+In the single-participant setting, explicit disclosure is not a problem
+because the explicit disclosure can only be obtained via the Ledger API of the single participant that also submits the next command.
+The participant thus has processed the creating transaction already and sees the created ``Keyed`` contracts.
 
 Another approach is to track all "allocations" and "deallocations" of a key through a helper contract.
 

--- a/docs/2.10.0/docs/canton/usermanual/contract_keys.rst
+++ b/docs/2.10.0/docs/canton/usermanual/contract_keys.rst
@@ -309,13 +309,21 @@ Caveats:
 
 - Before creating a contract with the key ``k`` for the first time, your application must create the matching ``KeyState`` contract with ``allocated`` set to ``False``.
   Such a contract must be created at most once.
-  Most likely, you will want to choose a "master" participant on which you create such contracts.
-- Do not delegate choices on the ``Keyed`` contract to parties other than the maintainers.
-- You must never send a command that creates or archives the ``Keyed`` contract directly.
+  Most likely, you will want to choose a "primary" participant on which you create such contracts.
+- ``Keyed`` contracts must never be created or archived directly,
+  as this would break the synchronization with the corresponding ``KeyState`` contract.
   Instead, you must use the ``Allocate`` and ``Deallocate`` choices on the ``KeyState`` contract.
-  The only exception are consuming choices on the ``Keyed`` contract that immediately recreate a ``Keyed`` contract with the same key.
-  These choices may also be delegated.
-
+  The only exception are the following:
+  
+  * A consuming choices on the ``Keyed`` contract that immediately recreate a ``Keyed`` contract with the same key.
+    
+  * Ledger API commands that archive a ``Keyed`` contract and recreate a ``Keyed`` contract with the same key.
+    
+- Do not delegate consuming choices on the ``Keyed`` contract other than those that immediately recreate a ``Keyed`` contract with the same key.
+  Instead, delegate appropriate adaptations of ``Deallocate`` on the corresponding ``KeyState`` contract.
+  This ensures the above restriction that ``Keyed`` contracts are created and archived only through the ``KeyState`` contract choices.
+  Non-consuming choices on ``Keyed`` contracts can be delegated without restrictions.
+  
 A usage example script is below.
 
 .. literalinclude:: /canton/includes/mirrored/community/common/src/main/daml/CantonExamples/ContractKeys.daml


### PR DESCRIPTION
In response to support request https://support.digitalasset.com/s/case/500Pq00000Yt5d1IAB/question-about-the-docs-on-workarounds-for-recovering-uniqueness

* The `Generator` approach also works in the multiple participant settings.
* The `KeyState` approach works under delegation of `Keyed` non-consuming choices 

I do believe that the `Generator` approach would even work for multiple maintainers under certain trust assumptions in a single-domain setting. I don't want to flesh this out right now though.