### PR TITLE
add link to 3.x docs from main view

### DIFF
--- a/theme/da_theme_skeleton/boxes.html
+++ b/theme/da_theme_skeleton/boxes.html
@@ -11,6 +11,12 @@
 {%- endmacro %}
 
 <div class="boxes">
+        <p class="first">
+                This documentation covers Daml 2.x applications. If you are developing
+                applications for the Canton Network, please refer to
+                <a class="reference internal" href="https://docs.digitalasset.com">Daml 3.x documentation</a>.
+
+        </p>
         <a class="box box1 da-btn" href="{{ safe_pathto('getting-started/installation') }}" >
                 <h3>Getting started</h3>
                 <span class="da-btn-label">Go</span>
@@ -35,5 +41,5 @@
                 <h3>Examples</h3>
                 <span class="da-btn-label">Go</span>
         </a>
-        <p>If you are developing applications for the Canton Network, please refer to <a href="https://docs.digitalasset.com">Daml 3.x documentation</a>.  This documentation covers Daml 2.x applications.</p>
+
 </div>


### PR DESCRIPTION
Add link to 3.x docs site from 2.x site for easy of discovering if you stumble on this site inadvertently, but are actually doing CN development

<img width="965" alt="image" src="https://github.com/user-attachments/assets/9e138ef1-1c76-4571-8b47-5602bcae0de9" />
