### PR TITLE
Add 2.10.3 to broken snapshot release to prevent the CI cron job from constantly failing

### DIFF
--- a/bin/publish-snapshots
+++ b/bin/publish-snapshots
@@ -70,6 +70,7 @@ broken() (
 2.10.0-snapshot.20241002.0
 2.10.0-snapshot.20241016.0
 2.10.0-snapshot.20241120.0
+2.10.3
 EOF
   echo "$known_broken" | grep $version >/dev/null
 )


### PR DESCRIPTION
If we're not going to publish 2.10.3. – But it looks like we're going to publish it.