### PR TITLE
Disallow search engine indexing in `robots.txt`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,9 +143,7 @@ jobs:
              )
              make_robots() (
                  echo "User-agent: *"
-                 echo "Allow: /"
-                 echo ""
-                 echo "Sitemap: https://docs.daml.com/sitemap.xml"
+                 echo "Disallow: /"
              )
 
              root=$(cat root)


### PR DESCRIPTION
Disallow search engine robot crawling of the https://docs.daml.com site

We do not want google search to return references to these 2.x docs, and instead want to favor 3.x docs from https://docs.digitalasset.com