### PR TITLE
Add docs.daml.com relocation banner

### DIFF
--- a/theme/da_theme_skeleton/layout.html
+++ b/theme/da_theme_skeleton/layout.html
@@ -201,9 +201,9 @@
         <aside class="deprecation-banner" aria-label="Documentation relocation notice">
           <div class="deprecation-banner-content">
             <span class="deprecation-banner-message">
-              We've moved this documentation to a new home. This page will be retired soon - please refer to the new consolidated docs on the
-              <a class="deprecation-banner-link" href="https://docs.canton.network/">Canton Network site</a>
-              for the latest developer guidance.
+              If you are looking for the Canton Network documentation then go to the
+              <a class="deprecation-banner-link" href="https://docs.canton.network/">Canton Network site</a>.
+              This documentation is for a prior version called Canton 2.
             </span>
           </div>
         </aside>

--- a/theme/da_theme_skeleton/layout.html
+++ b/theme/da_theme_skeleton/layout.html
@@ -198,6 +198,15 @@
 
       </div>
       <div class="wy-nav-content{{addClass}}">
+        <aside class="deprecation-banner" aria-label="Documentation relocation notice">
+          <div class="deprecation-banner-content">
+            <span class="deprecation-banner-message">
+              We've moved this documentation to a new home. This page will be retired soon - please refer to the new consolidated docs on the
+              <a class="deprecation-banner-link" href="https://docs.canton.network/">Canton Network site</a>
+              for the latest developer guidance.
+            </span>
+          </div>
+        </aside>
         {%- block content %}
         {% if theme_style_external_links|tobool %}
         <div class="rst-content style-external-links"></div>

--- a/theme/sass/_theme_navbar.sass
+++ b/theme/sass/_theme_navbar.sass
@@ -5,6 +5,41 @@
     img
         max-height: 30px
 
+.deprecation-banner
+    width: auto
+    box-sizing: border-box
+    margin: -53px -47px 48px
+    background: #fff3cd
+    border-bottom: 1px solid #ffcc66
+    color: #272727
+    font-family: $base-font-family
+
+    .deprecation-banner-content
+        width: 100%
+        box-sizing: border-box
+        padding: 12px 47px
+        display: flex
+        align-items: center
+        justify-content: center
+        gap: 8px 12px
+        flex-wrap: wrap
+        text-align: center
+        font-size: 15px
+        line-height: 1.4
+
+    .deprecation-banner-message
+        font-weight: $weight-body
+
+    .deprecation-banner-link
+        color: #272727
+        font-weight: $weight-bold
+        text-decoration: underline
+        text-underline-offset: 0.2em
+
+        &:hover,
+        &:focus
+            color: #0d33a0
+
 .navbar
     display: flex
     height: 65px
@@ -73,6 +108,12 @@
                     transition-duration: 10ms
 
 +media($tablet)
+    .deprecation-banner
+        margin: -25px -25px 32px
+
+        .deprecation-banner-content
+            padding: 12px 25px
+
     .navbar
         padding-left: 65px
         h1


### PR DESCRIPTION
## Summary

- Updates the site-wide docs.daml.com banner to Curtis's Canton 2-specific wording.
- Keeps the banner link pointed at `https://docs.canton.network/` for Canton Network documentation.
- Styles the banner in the editable Sphinx theme source so generated docs pages inherit it consistently.

Addresses `canton-network/cf-docs#362` for the docs.daml.com site.

## Screenshots

| Page | Screenshot |
| --- | --- |
| Landing page | ![docs.daml.com landing page banner](https://raw.githubusercontent.com/digital-asset/docs.daml.com/0d8c648a7c061cc4e355a2e2adcb407edd433892/.github/pr-screenshots/docs-daml-com-header/docs-daml-com-banner-home.png) |
| Content page | ![docs.daml.com content page banner](https://raw.githubusercontent.com/digital-asset/docs.daml.com/0d8c648a7c061cc4e355a2e2adcb407edd433892/.github/pr-screenshots/docs-daml-com-header/docs-daml-com-banner-doc-page.png) |
| Mobile content page | ![docs.daml.com mobile banner](https://raw.githubusercontent.com/digital-asset/docs.daml.com/0d8c648a7c061cc4e355a2e2adcb407edd433892/.github/pr-screenshots/docs-daml-com-header/docs-daml-com-banner-mobile.png) |

## Validation

- `direnv exec . bash theme/build.sh`
- `direnv exec . sphinx-build -b html theme/docs /Users/danielporter/control/previews/docs-daml-com-header`
  - Succeeds with the existing demo fixture warnings for missing sample snippets/labels.
- `git diff --check`
- Local Chromium screenshot check against `http://127.0.0.1:3073/` and `/templates.html` confirmed the updated banner text and `https://docs.canton.network/` link render.
