### PR TITLE
Keep docs.daml.com banner visible while scrolling

### DIFF
--- a/theme/da_theme_skeleton/layout.html
+++ b/theme/da_theme_skeleton/layout.html
@@ -181,6 +181,16 @@
         </nav>
         {% include "navbar.html" %}
 
+        <aside class="deprecation-banner" aria-label="Documentation relocation notice">
+          <div class="deprecation-banner-content">
+            <span class="deprecation-banner-message">
+              If you are looking for the Canton Network documentation then go to the
+              <a class="deprecation-banner-link" href="https://docs.canton.network/">Canton Network site</a>.
+              This documentation is for a prior version called Canton 2.
+            </span>
+          </div>
+        </aside>
+
         <div class="version {{addClass}}">
           {%- if is_index %}
           <span class="hide-tablet">Documentation&nbsp;</span><span class="hide-mobile">Version&nbsp;</span><span class="version_switcher_placeholder"></span>
@@ -198,15 +208,6 @@
 
       </div>
       <div class="wy-nav-content{{addClass}}">
-        <aside class="deprecation-banner" aria-label="Documentation relocation notice">
-          <div class="deprecation-banner-content">
-            <span class="deprecation-banner-message">
-              If you are looking for the Canton Network documentation then go to the
-              <a class="deprecation-banner-link" href="https://docs.canton.network/">Canton Network site</a>.
-              This documentation is for a prior version called Canton 2.
-            </span>
-          </div>
-        </aside>
         {%- block content %}
         {% if theme_style_external_links|tobool %}
         <div class="rst-content style-external-links"></div>

--- a/theme/sass/_theme_navbar.sass
+++ b/theme/sass/_theme_navbar.sass
@@ -6,10 +6,11 @@
         max-height: 30px
 
 .deprecation-banner
-    width: auto
+    width: 100%
     box-sizing: border-box
-    margin: -53px -47px 48px
+    margin: 0
     background: #fff3cd
+    border-top: 1px solid #ffcc66
     border-bottom: 1px solid #ffcc66
     color: #272727
     font-family: $base-font-family
@@ -109,8 +110,6 @@
 
 +media($tablet)
     .deprecation-banner
-        margin: -25px -25px 32px
-
         .deprecation-banner-content
             padding: 12px 25px
 
@@ -121,6 +120,11 @@
             max-width: 141px
 
 +media($mobile)
+    .deprecation-banner
+        .deprecation-banner-content
+            padding: 10px 16px
+            font-size: 14px
+
     .wy-nav-content-wrap
         .navbar
             .navbar-menu


### PR DESCRIPTION
## Summary
- Move the Canton Network relocation banner into the fixed topbar so it remains visible while scrolling.
- Remove the content-area negative margins that were only needed when the banner lived inside the page body.
- Keep the mobile banner compact with viewport-specific padding and font size.

## Screenshots

Desktop, scrolled down with the banner still visible in the frozen header:

![Desktop scrolled sticky banner](https://raw.githubusercontent.com/digital-asset/docs.daml.com/174fef25/.pr-screenshots/docs-daml-com-sticky-banner-20260521/desktop-scrolled-sticky-banner.png)

Mobile, scrolled down with the banner still visible in the frozen header:

![Mobile scrolled sticky banner](https://raw.githubusercontent.com/digital-asset/docs.daml.com/174fef25/.pr-screenshots/docs-daml-com-sticky-banner-20260521/mobile-scrolled-sticky-banner.png)

## Validation
- `direnv exec /Users/danielporter/control/.worktrees/docs-daml-com-sticky-banner npm install`
- `direnv exec /Users/danielporter/control/.worktrees/docs-daml-com-sticky-banner npm exec grunt build`
- `direnv exec /Users/danielporter/control/.worktrees/docs-daml-com-sticky-banner npm exec grunt sass:dev usebanner exec:build_sphinx copy:versions copy:sass`
- `git diff --check`
- Browser verification against `http://127.0.0.1:1929/index.html`: after scrolling, `.topbar` remains `position: fixed` and the banner's viewport bounds remain unchanged on desktop and mobile.